### PR TITLE
bump splainer search, allow source to be a field name

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "karma-phantomjs-launcher": ">= 0.1.4",
     "ng-json-explorer": "https://github.com/odra/ng-json-explorer",
     "ng-tags-input": "~3.0.0",
-    "splainer-search": "2.4.3",
+    "splainer-search": "2.5.0",
     "tether-shepherd": "latest"
   },
   "devDependencies": {


### PR DESCRIPTION
Splainer-Search library was updated to allow `source` to be a field name.

## Description
Bump splainer-search version.

## Motivation and Context
Now you can have a field called `source`

## How Has This Been Tested?
Tested on splainer.io, and added new `source` to our test Solr configs.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
