### PR TITLE
Revert "bump splainer search, allow source to be a field name"

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "karma-phantomjs-launcher": ">= 0.1.4",
     "ng-json-explorer": "https://github.com/odra/ng-json-explorer",
     "ng-tags-input": "~3.0.0",
-    "splainer-search": "2.5.0",
+    "splainer-search": "2.4.3",
     "tether-shepherd": "latest"
   },
   "devDependencies": {


### PR DESCRIPTION
Apparently this update was seamless, so rolling it back.