### PR TITLE
Specify stretch ruby image to resolve PhantomJS issues in docker

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:2.5.7
+FROM ruby:2.5.7-stretch
 
 MAINTAINER OpenSource Connections <quepid_admin@opensourceconnections.com>
 


### PR DESCRIPTION
## Description
Specifies the stretch image of ruby which resolves issue with PhantomJS in the latest Rub 2.5.7 image.

## Motivation and Context
PhantomJS was erroring out using the ruby:2.5.7 image.  By specifying the stretch image PhantomJS runs as expected.

## How Has This Been Tested?
Ran a fresh docker setup and confirmed tests passed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
