### PR TITLE
Convert snippets that start with http into anchor links in search result pane

### DIFF
--- a/app/assets/javascripts/controllers/searchResult.js
+++ b/app/assets/javascripts/controllers/searchResult.js
@@ -86,5 +86,8 @@ angular.module('QuepidApp')
       $scope.isJSONObject = function(value) {
         return typeof value === 'object' &&  value instanceof Array !== true;
       };
+      $scope.isUrl = function(value) {
+        return ( /http/.test(value));
+      };
     }
   ]);

--- a/app/assets/templates/views/searchResult.html
+++ b/app/assets/templates/views/searchResult.html
@@ -45,6 +45,7 @@
             <span
               ng-if="isJSONObject(fieldValue)"
             >
+              <!-- output JSON blob -->
               <json-explorer
                 json-data="fieldValue"
                 collapsed="false">
@@ -52,33 +53,16 @@
             </span>
 
             <span
-              ng-bind-html="fieldValue"
-              ng-if="!isJSONObject(fieldValue) && !isUrl(fieldValue)"
-            >
+              ng-if="isUrl(fieldValue)">
+              <!-- Format a HREF link.  Use the original value, not the html escaped snippet. -->
+              <a ng-href="{{ doc.doc[fieldName] }}" target="_blank">{{ doc.doc[fieldName] }}</a>
             </span>
 
             <span
               ng-bind-html="fieldValue"
+              ng-if="!isJSONObject(fieldValue) && !isUrl(fieldValue)"
             >
-            </span>
-            <span
-              ng-if="isUrl(fieldValue)">
-              <br/>
-              A:<a href="{{ fieldValue }}" target="_blank" ng-bind-html="fieldValue"></a>
-              <br/>
-              B:
-              <a ng-href="{{ fieldValue }}">{{ fieldValue }}</a>
-              <br/>
-              C:
-              <a ng-href="{{ fieldValue }}" ng-bind-html="fieldValue"></a>
-              <br/>
-              D:
-              <a ng-href="{{ fieldValue }}">
-                <span ng-bind-html="fieldValue"/>
-              </a>
-              E:
-              <a ng-href="{{ fieldValue }}">Some Link</a>              
-              <br/>
+              <!-- Normal display of a snippet -->
             </span>
           </li>
 

--- a/app/assets/templates/views/searchResult.html
+++ b/app/assets/templates/views/searchResult.html
@@ -58,8 +58,27 @@
             </span>
 
             <span
+              ng-bind-html="fieldValue"
+            >
+            </span>
+            <span
               ng-if="isUrl(fieldValue)">
-              <a href="{{ fieldValue }}" target="_blank">{{ fieldValue }}</a>
+              <br/>
+              A:<a href="{{ fieldValue }}" target="_blank" ng-bind-html="fieldValue"></a>
+              <br/>
+              B:
+              <a ng-href="{{ fieldValue }}">{{ fieldValue }}</a>
+              <br/>
+              C:
+              <a ng-href="{{ fieldValue }}" ng-bind-html="fieldValue"></a>
+              <br/>
+              D:
+              <a ng-href="{{ fieldValue }}">
+                <span ng-bind-html="fieldValue"/>
+              </a>
+              E:
+              <a ng-href="{{ fieldValue }}">Some Link</a>              
+              <br/>
             </span>
           </li>
 

--- a/app/assets/templates/views/searchResult.html
+++ b/app/assets/templates/views/searchResult.html
@@ -53,7 +53,7 @@
 
             <span
               ng-bind-html="fieldValue"
-              ng-if="!isJSONObject(fieldValue) and !isUrl(fieldValue)"
+              ng-if="!isJSONObject(fieldValue) && !isUrl(fieldValue)"
             >
             </span>
 

--- a/app/assets/templates/views/searchResult.html
+++ b/app/assets/templates/views/searchResult.html
@@ -53,8 +53,13 @@
 
             <span
               ng-bind-html="fieldValue"
-              ng-if="!isJSONObject(fieldValue)"
+              ng-if="!isJSONObject(fieldValue) and !isUrl(fieldValue)"
             >
+            </span>
+
+            <span
+              ng-if="isUrl(fieldValue)">
+              <a href="{{ fieldValue }}" target="_blank">{{ fieldValue }}</a>
             </span>
           </li>
 


### PR DESCRIPTION
## Description
Instead of adding another key word like `url` or `link` which I discovered requires custom changes in splainer-search library, and is really built aorund the concept of just one id or title or thumb, instead we look to see if this is a URL because it starts with `http`.  In that case, instead of using the snippet, we just grab the original value and use that to construct a clickable link.

If your snippet starts with `http`, like in the sentence _http is the protocol of the future_, then you might get a bad link....



## Motivation and Context
Fixes #26 

## How Has This Been Tested?
Manually tested.   There don't seem to be specs around this.

## Screenshots or GIFs (if appropriate):
<img width="690" alt="Screenshot at Nov 24 17-23-23" src="https://user-images.githubusercontent.com/22395/69502668-c4c59380-0edf-11ea-8361-bb8ad58f35cd.png">

See the link is now clickable?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
