### PR TITLE
clean up some slightly annoying text by pluaralizing

### DIFF
--- a/app/assets/templates/views/searchResults.html
+++ b/app/assets/templates/views/searchResults.html
@@ -25,7 +25,13 @@
       ng-class="query.isNotAllRated() ? 'unrated-results' : ''"
     >
       {{query.numFound}}
-      <small class="text-muted">Results</small>
+      <small class="text-muted">
+        <ng-pluralize count="query.numFound"
+            when="{'0': 'Results',
+                   'one': 'Result',
+                   'other': 'Results'}">
+        </ng-pluralize>
+      </small>
 
       <small
         class="unrated-results-text text-muted"
@@ -120,7 +126,12 @@
         </span>
 
         <span ng-if="selectedTry.searchEngine == 'solr'">
-          <a ng-show="query.state() !== 'error'" class="btn btn-primary" href="{{query.browseUrl()}}" target="_blank">  Browse {{query.numFound}} Results on Solr
+          <a ng-show="query.state() !== 'error'" class="btn btn-primary" href="{{query.browseUrl()}}" target="_blank">
+            <ng-pluralize count="query.numFound"
+                when="{'0': 'Browse {} Results on Solr',
+                       'one': 'Browse {} Result on Solr',
+                       'other': 'Browse {} Results on Solr'}">
+            </ng-pluralize>
           </a>
         </span>
 


### PR DESCRIPTION

## Description
Always bugs me when it says  *1 results* or *Browse 1 results*, so fix those messages.  

## Motivation and Context
Annoying reading pattern!  Oddly enough, I struggled with 0 results..  I guess it is plural!

## How Has This Been Tested?
Manual testing.

## Screenshots or GIFs (if appropriate):
<img width="699" alt="plurals" src="https://user-images.githubusercontent.com/22395/69504991-1cbac500-0ef5-11ea-87d2-a90e7e494247.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
