### PR TITLE
Enable Google Analytics Only when Environment Variable Set

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,10 +23,10 @@
       "required": true
     },
     "INTERCOM_API_KEY": {
-      "required": false
+      "required": true
     },
     "INTERCOM_APP_ID": {
-      "required": false
+      "required": true
     },
     "LANG": {
       "required": true
@@ -41,7 +41,7 @@
       "required": true
     },
     "QUEPID_GA": {
-      "required": false
+      "required": true
     },
     "RACK_ENV": {
       "required": true

--- a/app.json
+++ b/app.json
@@ -23,10 +23,10 @@
       "required": true
     },
     "INTERCOM_API_KEY": {
-      "required": true
+      "required": false
     },
     "INTERCOM_APP_ID": {
-      "required": true
+      "required": false
     },
     "LANG": {
       "required": true
@@ -41,7 +41,7 @@
       "required": true
     },
     "QUEPID_GA": {
-      "required": true
+      "required": false
     },
     "RACK_ENV": {
       "required": true

--- a/app/jobs/google_analytics_event_job.rb
+++ b/app/jobs/google_analytics_event_job.rb
@@ -5,6 +5,7 @@ class GoogleAnalyticsEventJob < ActiveJob::Base
 
   def perform data
     return unless Analytics::GA.enabled?
+    
     Analytics::GA.ga.event(
       data[:category],
       data[:action],

--- a/app/jobs/google_analytics_event_job.rb
+++ b/app/jobs/google_analytics_event_job.rb
@@ -4,6 +4,7 @@ class GoogleAnalyticsEventJob < ActiveJob::Base
   queue_as :default
 
   def perform data
+    return unless Analytics::GA.enabled?
     Analytics::GA.ga.event(
       data[:category],
       data[:action],

--- a/app/jobs/google_analytics_event_job.rb
+++ b/app/jobs/google_analytics_event_job.rb
@@ -5,7 +5,7 @@ class GoogleAnalyticsEventJob < ActiveJob::Base
 
   def perform data
     return unless Analytics::GA.enabled?
-    
+
     Analytics::GA.ga.event(
       data[:category],
       data[:action],

--- a/app/views/layouts/_common_js.html.erb
+++ b/app/views/layouts/_common_js.html.erb
@@ -1,3 +1,4 @@
+<% if Analytics::GA.enabled? %>
 <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -14,3 +15,4 @@
 
   ga('send', 'pageview');
 </script>
+<% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -49,4 +49,6 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.action_mailer.default_url_options = { host: ENV['QUEPID_DOMAIN'], port: ENV['PORT'] }
+
+  ENV['QUEPID_GA'] = "UA-FAKE-GA-CODE-FOR-TESTING"
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,5 +50,5 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: ENV['QUEPID_DOMAIN'], port: ENV['PORT'] }
 
-  ENV['QUEPID_GA'] = "UA-FAKE-GA-CODE-FOR-TESTING"
+  ENV['QUEPID_GA'] = 'UA-FAKE-GA-CODE-FOR-TESTING'
 end

--- a/config/initializers/intercom.rb
+++ b/config/initializers/intercom.rb
@@ -17,7 +17,7 @@ IntercomRails.config do |config|
   # == Enabled Environments
   # Which environments is auto inclusion of the Javascript enabled for
   #
-  config.enabled_environments = %w[development production staging]
+  config.enabled_environments = config.app_id.present? ? %w[development production staging] : []
 
   # == Current user method/variable
   # The method/variable that contains the logged in user in your controllers.

--- a/lib/analytics/google_analytics/base.rb
+++ b/lib/analytics/google_analytics/base.rb
@@ -3,7 +3,14 @@
 module Analytics
   module GA
     module Base
+      def enabled?
+        # Unset values, empty strings, and "UA-" should all be treated as
+        # disabled.
+        ENV.fetch('QUEPID_GA', '').length > 3
+      end
+
       def ga
+        return unless self.enabled?
         @ga ||= Gabba::Gabba.new(ENV['QUEPID_GA'], ENV['QUEPID_DOMAIN'])
       end
     end

--- a/lib/analytics/google_analytics/base.rb
+++ b/lib/analytics/google_analytics/base.rb
@@ -10,7 +10,8 @@ module Analytics
       end
 
       def ga
-        return unless self.enabled?
+        return unless enabled?
+
         @ga ||= Gabba::Gabba.new(ENV['QUEPID_GA'], ENV['QUEPID_DOMAIN'])
       end
     end

--- a/lib/analytics/google_analytics/events.rb
+++ b/lib/analytics/google_analytics/events.rb
@@ -686,6 +686,7 @@ module Analytics
       # https://developers.google.com/analytics/devguides/collection/analyticsjs/events
       #
       def create_event data
+        return unless Analytics::GA.enabled?
         GoogleAnalyticsEventJob.perform_later data
       end
     end

--- a/lib/analytics/google_analytics/events.rb
+++ b/lib/analytics/google_analytics/events.rb
@@ -687,7 +687,7 @@ module Analytics
       #
       def create_event data
         return unless Analytics::GA.enabled?
-        
+
         GoogleAnalyticsEventJob.perform_later data
       end
     end

--- a/lib/analytics/google_analytics/events.rb
+++ b/lib/analytics/google_analytics/events.rb
@@ -687,6 +687,7 @@ module Analytics
       #
       def create_event data
         return unless Analytics::GA.enabled?
+        
         GoogleAnalyticsEventJob.perform_later data
       end
     end


### PR DESCRIPTION
This was originally from @CgamesPlay at https://github.com/o19s/quepid/pull/30

however, in messing with it, I created a new branch somehow.  Thanks @CGamesPlay!

## Description
This makes the google analytics and intercom components of Quepid optional. If the environment variables are not configured, the functionality will simply be disabled.

## Motivation and Context
In doing a private installation of Quepid, we have no need for these features, but in the current implementation, these third-party libraries are loaded even when they API keys are not configured.

## How Has This Been Tested?
Running the application and verifying that the JavaScript snippets are removed from the resulting HTML, and no server or client errors are logged.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
