### PR TITLE
Only treat content that begins with "http" as a link

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.5-node-browsers
+      - image: circleci/ruby:2.5-node-browsers-legacy
         environment: # environment variables for primary container
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3

--- a/app/assets/javascripts/controllers/searchResult.js
+++ b/app/assets/javascripts/controllers/searchResult.js
@@ -87,7 +87,7 @@ angular.module('QuepidApp')
         return typeof value === 'object' &&  value instanceof Array !== true;
       };
       $scope.isUrl = function(value) {
-        return ( /http/.test(value));
+        return ( /^\s+http/.test(value));
       };
     }
   ]);


### PR DESCRIPTION
Change the regex to detect urls if the first part of the string value is http (ignoring preceding whitespace).

## Motivation and Context

Fixes this issue https://github.com/o19s/quepid/issues/34


