### PR TITLE
Remove SQLlite Gem 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,19 +10,10 @@
 # Ignore bundler config.
 /.bundle
 
-# Ignore the default SQLite database.
-/db/*.sqlite3
-/db/*.sqlite
-/db/*.sqlite3-journal
-
 # Ignore all logfiles and tempfiles.
 /log/*
 !/log/.keep
 /tmp
-
-# Ignore vagrant artifacts
-.vagrant
-vagrant.rb
 
 # Ignore bower artifacts
 /vendor/assets/bower_components

--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,3 @@ end
 group :production, :staging do
   gem 'rails_12factor'
 end
-
-group :container do
-  gem 'sqlite3'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,7 +350,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.0)
     stackprof (0.2.12)
     temple (0.8.0)
     thin (1.7.2)
@@ -442,7 +441,6 @@ DEPENDENCIES
   sinatra
   slim
   spring (= 1.6.4)
-  sqlite3
   stackprof
   thin
   timecop

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,3 +1,5 @@
+# For more information consult https://guides.rubyonrails.org/configuring.html#configuring-a-database
+
 default: &default
   adapter:    <%= ENV["DB_ADAPTER"] %>
   encoding:   utf8mb4

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -1,3 +1,5 @@
+# For more information consult https://guides.rubyonrails.org/configuring.html#configuring-a-database
+
 default: &default
   adapter:    <%= ENV["DB_ADAPTER"] %>
   encoding:   utf8mb4
@@ -21,4 +23,4 @@ test:
 
 production:
   <<: *default
-  database: <%= ENV["DATABASE_URL"] %>
+  url: <%= ENV["DATABASE_URL"] %>


### PR DESCRIPTION
We no longer use SQLLite anywhere.   This removes it from Gemfile, .gitignore, and lets us reduce our Bundler groups by one!