### PR TITLE
Bugfix 32 broken agreement link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,8 @@ QUEPID_DOMAIN=localhost
 
 INTERCOM_APP_ID=
 INTERCOM_API_KEY=
+
+# Used to insert web links if populated.
+TC_URL=
+PRIVACY_URL=
+COOKIES_URL=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update Elasticsearch logo.  https://github.com/o19s/quepid/pull/38 by @moshebla
 * Remove sqlite from gem, no longer used.  https://github.com/o19s/quepid/pull/41 by @epugh fixes https://github.com/o19s/quepid/issues/40
 * Better look and UI experience for the dev panel.  https://github.com/o19s/quepid/pull/39 by @moshebla
+* Show or don't show the T&C's link based on the Quepid configuration.  https://github.com/o19s/quepid/pull/42 by @epugh fixes https://github.com/o19s/quepid/issues/44 by @flaxsearch.
 
 ## 6.0.2 - 11/26/2019
 * Deprecate www.quepid.com/support in favor of linking to wiki.  https://github.com/o19s/quepid/pull/18 by @epugh fixes https://github.com/o19s/quepid/issues/17

--- a/README.md
+++ b/README.md
@@ -410,7 +410,8 @@ Check out the [App Structure](docs/app_structure.md) file for more info on how Q
 
 # Legal Pages
 
-If you would like to have legal pages linked in the footer of the app, add the following `ENV` vars:
+If you would like to have legal pages linked in the footer of the app, similar to behavior on http://app.quepid.com, 
+add the following `ENV` vars:
 
 ```
 TC_URL      # terms and condition

--- a/app.json
+++ b/app.json
@@ -58,10 +58,13 @@
     "SIDEKIQ_CONCURRENCY": {
       "required": true
     },
-    "STRIPE_PUBLISHABLE_KEY": {
+    "TC_URL": {
       "required": true
     },
-    "STRIPE_SECRET_KEY": {
+    "PRIVACY_URL": {
+      "required": true
+    },
+    "COOKIES_URL": {
       "required": true
     }
   },

--- a/app/assets/javascripts/controllers/signup.js
+++ b/app/assets/javascripts/controllers/signup.js
@@ -4,7 +4,13 @@ angular.module('QuepidSecureApp')
   .controller('SignupCtrl', [
     '$scope', '$location',
     'signupSvc',
-    function ($scope, $location, signupSvc) {
+    'configurationSvc',
+    function ($scope, $location, signupSvc, configurationSvc) {
+      $scope.hasTermsAndConditions = configurationSvc.hasTermsAndConditions();
+      if (configurationSvc.hasTermsAndConditions()){
+        $scope.termsAndConditionsUrl = configurationSvc.getTermsAndConditionsUrl();
+      }
+
       $scope.submit = function (agree, name, username, pass, confirm) {
         $scope.warnAgree    = false;
         $scope.warnEmail    = false;
@@ -13,12 +19,13 @@ angular.module('QuepidSecureApp')
         $scope.warnErr      = false;
         $scope.warnName     = false;
 
+
         if ( !name ) {
           $scope.warnName = true;
           return;
         }
 
-        if( !agree ) {
+        if( $scope.hasTermsAndConditions && !agree ) {
           $scope.warnAgree = true;
           return;
         }

--- a/app/assets/javascripts/secure.js
+++ b/app/assets/javascripts/secure.js
@@ -27,6 +27,7 @@
 //= require utilitiesModule
 //= require secureApp
 //= require app
+//= require services/configurationSvc
 //= require services/secureRedirectSvc
 //= require services/loginSvc
 //= require services/userSvc

--- a/app/assets/javascripts/services/configurationSvc.js
+++ b/app/assets/javascripts/services/configurationSvc.js
@@ -3,7 +3,7 @@
 angular.module('UtilitiesModule')
   .service('configurationSvc', [
     '$window', '$log',
-    function ConfigurationSvc($window, $log) {
+    function ConfigurationSvc() {
       var termsAndConditionsUrl;
 
       this.setTermsAndConditionsUrl = function (url) {

--- a/app/assets/javascripts/services/configurationSvc.js
+++ b/app/assets/javascripts/services/configurationSvc.js
@@ -1,0 +1,26 @@
+'use strict';
+
+angular.module('UtilitiesModule')
+  .service('configurationSvc', [
+    '$window', '$log',
+    function ConfigurationSvc($window, $log) {
+      var termsAndConditionsUrl;
+
+      this.setTermsAndConditionsUrl = function (url) {
+        termsAndConditionsUrl = url;
+      };
+      this.hasTermsAndConditions = function () {
+        if (angular.isUndefined(termsAndConditionsUrl) || termsAndConditionsUrl === ''){
+          return false;
+        }
+        else {
+          return true;
+        }
+
+      };
+
+      this.getTermsAndConditionsUrl = function () {
+        return termsAndConditionsUrl;
+      };
+    }
+  ]);

--- a/app/assets/templates/views/signup.html
+++ b/app/assets/templates/views/signup.html
@@ -98,11 +98,11 @@
              />
           </div>
 
-          <div class="checkbox">
+          <div class="checkbox" ng-show="hasTermsAndConditions">
             <label>
-              <input type="checkbox" ng-model="agree" required />
+              <input type="checkbox" ng-model="agree" required ng-if="hasTermsAndConditions"/>
               Agree to
-              <a href="/agreement">terms &amp; conditions</a>?
+              <a ng-href="{{ termsAndConditionsUrl }}" target="_blank">terms &amp; conditions</a>?
             </label>
           </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 <title>Quepid -- Relevant Search Solved</title>
-<meta name="description" content="Tired of irrelevant search results? Use Quepid products & services to help improve the quality and relevancy of your search results.">
+<meta name="description" content="Tired of irrelevant search results? Use Quepid to help improve the quality and relevancy of your search results.">
 <meta name="viewport" content="width=device-width">
 
 <%= stylesheet_link_tag 'application', media: 'all' %>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -7,7 +7,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 <title>Quepid -- Relevant Search Solved</title>
-<meta name="description" content="Tired of irrelevant search results? Use Quepid products & services to help improve the quality and relevancy of your search results.">
+<meta name="description" content="Tired of irrelevant search results? Use Quepid to help improve the quality and relevancy of your search results.">
 <meta name="viewport" content="width=device-width">
 
 <%= stylesheet_link_tag 'application', media: 'all' %>

--- a/app/views/layouts/secure.html.erb
+++ b/app/views/layouts/secure.html.erb
@@ -7,7 +7,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 <title>Quepid -- Relevant Search Solved</title>
-<meta name="description" content="Tired of irrelevant search results? Use Quepid products & services to help improve the quality and relevancy of your search results.">
+<meta name="description" content="Tired of irrelevant search results? Use Quepid to help improve the quality and relevancy of your search results.">
 <meta name="viewport" content="width=device-width">
 
 <%= stylesheet_link_tag 'secure', media: 'all' %>
@@ -28,7 +28,7 @@
 
   <script>
     angular.module('QuepidSecureApp')
-      .run(function($log, userSvc, secureRedirectSvc) {
+      .run(function($log, userSvc, secureRedirectSvc, configurationSvc) {
         var appDebug  = '<%= Rails.env == 'development' ? 'true' : 'false' %>';
         var debugPort = '<%= request.port %>';
 
@@ -36,8 +36,10 @@
           $log.debug("Activate debug mode");
           secureRedirectSvc.debugServer(debugPort);
         }
+        configurationSvc.setTermsAndConditionsUrl('<%= ENV['TC_URL'] %>');
       });
   </script>
+
 
   <%= render 'layouts/common_js' %>
 </body>

--- a/spec/javascripts/angular/services/configurationSvc_spec.js
+++ b/spec/javascripts/angular/services/configurationSvc_spec.js
@@ -1,0 +1,34 @@
+'use strict';
+
+describe('Service: ConfigurationSvc', function () {
+
+  // load the service's module
+  beforeEach(module('UtilitiesModule'));
+
+  // instantiate service
+  var configurationSvc, windowMocker;
+  beforeEach(function(){
+    inject(function (_configurationSvc_) {
+      configurationSvc = _configurationSvc_;
+    });
+  });
+
+  it('exists', function () {
+    expect(!!configurationSvc).toBe(true);
+  });
+
+  it('reports if terms and conditions url was set', function () {
+    configurationSvc.setTermsAndConditionsUrl('https://quepid.com/agreement');
+    expect(configurationSvc.hasTermsAndConditions()).toBe(true);
+    expect(configurationSvc.getTermsAndConditionsUrl()).toEqual('https://quepid.com/agreement');
+  });
+
+  it('reports it doesnt have terms and conditions if not set, or blank', function () {
+
+    expect(configurationSvc.hasTermsAndConditions()).toBe(false);
+    configurationSvc.setTermsAndConditionsUrl('');
+    expect(configurationSvc.hasTermsAndConditions()).toBe(false);
+
+  });
+
+});


### PR DESCRIPTION

## Description
Introduce a `configurationSvc` that gets values from the server side rendered site into a Javascirpt var and into the fornt end app.  Consult the `configurationSvc.hasTermsAndConditions()` to decide if we show the checkbox, and if so provide the URL.

## Motivation and Context
We only fixed server side rendered URLS.   Also, this is our first example of a configuration driven change to the behavior of quepid, the checkbox on T&Cs showing up or not.

## How Has This Been Tested?
Wrote a spec for the service, and then tested by hand with `TC_URL=` and `TC_URL=http://example.com/agreement` to confirm checkbox behavior.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
