### PR TITLE
Refuse adding empty string queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update Elasticsearch logo.  https://github.com/o19s/quepid/pull/38 by @moshebla
 * Remove sqlite from gem, no longer used.  https://github.com/o19s/quepid/pull/41 by @epugh fixes https://github.com/o19s/quepid/issues/40
 * Better look and UI experience for the dev panel.  https://github.com/o19s/quepid/pull/39 by @moshebla
+* Add Query button activates in response to query text entered.  https://github.com/o19s/quepid/pull/43 by @moshebla
 
 ## 6.0.2 - 11/26/2019
 * Deprecate www.quepid.com/support in favor of linking to wiki.  https://github.com/o19s/quepid/pull/18 by @epugh fixes https://github.com/o19s/quepid/issues/17

--- a/app/assets/javascripts/components/add_query/add_query.html
+++ b/app/assets/javascripts/components/add_query/add_query.html
@@ -11,7 +11,7 @@
   <input
     class="btn btn-success"
     ng-click="ctrl.submit()"
-    ng-disabled="ctrl.inputIsEmpty() || user.hasReachedQueryLimit()"
+    ng-disabled="ctrl.textInputIsEmpty() || user.hasReachedQueryLimit()"
     type="submit"
     value="{{ ctrl.text.indexOf(';') === -1 ? 'Add query' : 'Add queries' }}"
    />

--- a/app/assets/javascripts/components/add_query/add_query.html
+++ b/app/assets/javascripts/components/add_query/add_query.html
@@ -11,7 +11,7 @@
   <input
     class="btn btn-success"
     ng-click="ctrl.submit()"
-    ng-disabled="user.hasReachedQueryLimit()"
+    ng-disabled="ctrl.inputIsEmpty() || user.hasReachedQueryLimit()"
     type="submit"
     value="{{ ctrl.text.indexOf(';') === -1 ? 'Add query' : 'Add queries' }}"
    />

--- a/app/assets/javascripts/components/add_query/add_query_controller.js
+++ b/app/assets/javascripts/components/add_query/add_query_controller.js
@@ -24,7 +24,7 @@ angular.module('QuepidApp')
       ctrl.handlePaste  = handlePaste;
       ctrl.message      = message;
       ctrl.submit       = submit;
-      ctrl.inputIsEmpty = inputIsEmpty;
+      ctrl.textInputIsEmpty = textInputIsEmpty;
 
       var addOne = function(queryText, user) {
         var q = queriesSvc.createQuery(queryText);
@@ -66,8 +66,8 @@ angular.module('QuepidApp')
           });
       };
 
-      var userQueries = function(searchStrings) { 
-        return searchStrings; 
+      var userQueries = function(searchStrings) {
+        return searchStrings;
       };
 
       var parseAddQuery = function(formInput) {
@@ -83,12 +83,12 @@ angular.module('QuepidApp')
         return newQueries;
       };
 
-      function inputIsEmpty() {
-          return (!ctrl.text || /^\s*$/.test(ctrl.text));
+      function textInputIsEmpty() {
+        return (!ctrl.text || /^\s*$/.test(ctrl.text));
       }
 
       function submit () {
-        if (inputIsEmpty) { return; }
+        if (textInputIsEmpty()) { return; }
 
         ctrl.loading = true;
         var initialSearchStrings  = parseAddQuery(ctrl.text);

--- a/app/assets/javascripts/components/add_query/add_query_controller.js
+++ b/app/assets/javascripts/components/add_query/add_query_controller.js
@@ -24,6 +24,7 @@ angular.module('QuepidApp')
       ctrl.handlePaste  = handlePaste;
       ctrl.message      = message;
       ctrl.submit       = submit;
+      ctrl.inputIsEmpty = inputIsEmpty;
 
       var addOne = function(queryText, user) {
         var q = queriesSvc.createQuery(queryText);
@@ -82,7 +83,13 @@ angular.module('QuepidApp')
         return newQueries;
       };
 
+      function inputIsEmpty() {
+          return (!ctrl.text || /^\s*$/.test(ctrl.text));
+      }
+
       function submit () {
+        if (inputIsEmpty) { return; }
+
         ctrl.loading = true;
         var initialSearchStrings  = parseAddQuery(ctrl.text);
         var searchStrings         = userQueries(initialSearchStrings, $rootScope.currentUser);

--- a/spec/javascripts/angular/controllers/add_query_controller_spec.js
+++ b/spec/javascripts/angular/controllers/add_query_controller_spec.js
@@ -94,6 +94,20 @@ describe('Controller: AddQueryCtrl', function () {
     $rootScope.currentUser = angular.copy(mockUser);
   });
 
+  it('rejects empty or blank text', function() {
+    var newText;
+    ctrl.text   = newText;
+
+    expect(mockQueriesSvc.lastCreatedQ()).toBe(undefined);
+    ctrl.submit();
+    expect(mockQueriesSvc.lastCreatedQ()).toBe(undefined);
+
+    newText = '';
+    ctrl.text   = newText;
+
+    ctrl.submit();
+    expect(mockQueriesSvc.lastCreatedQ()).toBe(undefined);
+  });
 
   it('adds queries', function() {
     var newText = 'foo';


### PR DESCRIPTION
Currently the Add Query button is always enabled and results in
confusion and also allows to add empty-string queries. This PR fixes
this.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
