### PR TITLE
Support auto-complete also for fields used with thumb: prefix

### DIFF
--- a/app/assets/javascripts/controllers/wizardModal.js
+++ b/app/assets/javascripts/controllers/wizardModal.js
@@ -155,15 +155,28 @@ angular.module('QuepidApp')
       function loadFields (query) {
         var autocompleteList = [];
         var _query = query.trim().toLowerCase();
-        var thumb = false;
-        if (_query.startsWith('thumb:')) {
-            _query = _query.substr(6);
-            thumb = true;
+        var modified = false;
+        var modifierText = '';
+
+        var allowedModifiers = [
+            'media:',
+            'thumb:'
+        ];
+
+        for (var i = 0; i < allowedModifiers.length; i++) {
+          var modifier = allowedModifiers[i];
+
+          if (_query.startsWith(modifier)) {
+            _query = _query.substr(modifier.length);
+            modifierText = modifier;
+            modified = true;
+            break;
+          }
         }
 
         angular.forEach($scope.searchFields, function(field) {
           if ( field.toLowerCase().indexOf(_query) !== -1 ) {
-            autocompleteList.push({ text: thumb ? 'thumb:' + field : field });
+            autocompleteList.push({ text: modified ? modifierText + field : field });
           }
         });
 

--- a/app/assets/javascripts/controllers/wizardModal.js
+++ b/app/assets/javascripts/controllers/wizardModal.js
@@ -154,10 +154,16 @@ angular.module('QuepidApp')
       $scope.loadFields = loadFields;
       function loadFields (query) {
         var autocompleteList = [];
+        var _query = query.trim().toLowerCase();
+        var thumb = false;
+        if (_query.startsWith('thumb:')) {
+            _query = _query.substr(6);
+            thumb = true;
+        }
 
         angular.forEach($scope.searchFields, function(field) {
-          if ( field.indexOf(query) !== -1 ) {
-            autocompleteList.push({ text: field });
+          if ( field.toLowerCase().indexOf(_query) !== -1 ) {
+            autocompleteList.push({ text: thumb ? 'thumb:' + field : field });
           }
         });
 

--- a/spec/javascripts/angular/controllers/wizardModal_spec.js
+++ b/spec/javascripts/angular/controllers/wizardModal_spec.js
@@ -140,6 +140,40 @@ describe('Controller: WizardModalCtrl', function () {
       ]
     };
 
+
+    it ('gets title field for autocomplete', function() {
+      scope.searchFields = ['title', 'body', 'image'];
+      var autocompleteList = scope.loadFields('ti');
+      expect(autocompleteList.length).toBe(1);
+    });
+
+    it ('gets all fields for media: autocomplete', function() {
+      scope.searchFields = ['title', 'body', 'image'];
+      var autocompleteList = scope.loadFields('media:');
+      expect(autocompleteList.length).toBe(3);
+    });
+
+    it ('gets all fields for thumb: autocomplete', function() {
+      scope.searchFields = ['title', 'body', 'image'];
+      var autocompleteList = scope.loadFields('thumb:');
+      expect(autocompleteList.length).toBe(3);
+    });
+
+    it ('gets subset without modifier prefix', function() {
+      scope.searchFields = ['title', 'body', 'image', 'imageAlt'];
+      var autocompleteList = scope.loadFields('im');
+      expect(autocompleteList.length).toBe(2);
+      expect(autocompleteList).toEqual([{'text': 'image'}, {'text': 'imageAlt'}]);
+    });
+
+    it ('gets subset with modifier prefix', function() {
+      scope.searchFields = ['title', 'body', 'image', 'imageAlt'];
+      var autocompleteList = scope.loadFields('thumb:im');
+      expect(autocompleteList.length).toBe(2);
+      expect(autocompleteList).toEqual([{'text': 'thumb:image'}, {'text': 'thumb:imageAlt'}]);
+    });
+
+
     // it('adds queries', function() {
     //   $httpBackend.expectPOST('/api/cases/0/tries').respond(200, mockTry);
     //   $httpBackend.expectGET('/api/cases/0/scorers').respond(200, {});


### PR DESCRIPTION
Also make the fields lookup case and whitespace insensitive

I also wanted to make it to select the full field name on enter (currently adds the typed string, and not the full auto-completed field). Might look into that later unless you have an idea.