### PR TITLE
Smarter handling of JSON and http links in Search REsult

### DIFF
--- a/app/assets/javascripts/controllers/searchResult.js
+++ b/app/assets/javascripts/controllers/searchResult.js
@@ -86,14 +86,14 @@ angular.module('QuepidApp')
       $scope.isJSONObject = function(value) {
         //return typeof value === 'object' &&  value instanceof Array !== true;
         if (typeof value === 'object' && value instanceof Array === true) {
-          return typeof value[0] === 'object'
+          return typeof value[0] === 'object';
         }
         else if (typeof value === 'object' &&  value instanceof Array !== true) {
           return true;
         }
         return false;
       };
-      
+
       $scope.isUrl = function(value) {
         return (/^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/.test(value));
       };

--- a/app/assets/javascripts/controllers/searchResult.js
+++ b/app/assets/javascripts/controllers/searchResult.js
@@ -84,10 +84,18 @@ angular.module('QuepidApp')
       };
 
       $scope.isJSONObject = function(value) {
-        return typeof value === 'object' &&  value instanceof Array !== true;
+        //return typeof value === 'object' &&  value instanceof Array !== true;
+        if (typeof value === 'object' && value instanceof Array === true) {
+          return typeof value[0] === 'object'
+        }
+        else if (typeof value === 'object' &&  value instanceof Array !== true) {
+          return true;
+        }
+        return false;
       };
+      
       $scope.isUrl = function(value) {
-        return (/^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/.test(value.trim()));
+        return (/^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/.test(value));
       };
     }
   ]);

--- a/app/assets/javascripts/controllers/searchResult.js
+++ b/app/assets/javascripts/controllers/searchResult.js
@@ -87,7 +87,7 @@ angular.module('QuepidApp')
         return typeof value === 'object' &&  value instanceof Array !== true;
       };
       $scope.isUrl = function(value) {
-        return ( /^\s+http/.test(value));
+        return (/^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/.test(value.trim()));
       };
     }
   ]);

--- a/app/assets/templates/views/searchResult.html
+++ b/app/assets/templates/views/searchResult.html
@@ -43,11 +43,11 @@
             <span class="subLabel">{{fieldName}}:</span>
 
             <span
-              ng-if="isJSONObject(fieldValue)"
+              ng-if="isJSONObject(doc.doc[fieldName])"
             >
               <!-- output JSON blob -->
               <json-explorer
-                json-data="fieldValue"
+                json-data="doc.doc[fieldName]"
                 collapsed="false">
               </json-explorer>
             </span>
@@ -60,7 +60,7 @@
 
             <span
               ng-bind-html="fieldValue"
-              ng-if="!isJSONObject(fieldValue) && !isUrl(fieldValue)"
+              ng-if="!isJSONObject(doc.doc[fieldName]) && !isUrl(fieldValue)"
             >
               <!-- Normal display of a snippet -->
             </span>

--- a/app/assets/templates/views/searchResult.html
+++ b/app/assets/templates/views/searchResult.html
@@ -53,14 +53,14 @@
             </span>
 
             <span
-              ng-if="isUrl(fieldValue)">
+              ng-if="isUrl(doc.doc[fieldName])">
               <!-- Format a HREF link.  Use the original value, not the html escaped snippet. -->
               <a ng-href="{{ doc.doc[fieldName] }}" target="_blank">{{ doc.doc[fieldName] }}</a>
             </span>
 
             <span
               ng-bind-html="fieldValue"
-              ng-if="!isJSONObject(doc.doc[fieldName]) && !isUrl(fieldValue)"
+              ng-if="!isJSONObject(doc.doc[fieldName]) && !isUrl(doc.doc[fieldName])"
             >
               <!-- Normal display of a snippet -->
             </span>

--- a/spec/javascripts/angular/controllers/searchResult_spec.js
+++ b/spec/javascripts/angular/controllers/searchResult_spec.js
@@ -17,22 +17,49 @@ describe('Controller: SearchResultCtrl', function () {
   //  });
   //}));
 
-  it('rejects empty or blank text', function() {
+  it('properly detects a field with leading http or www text', function() {
 
     // This method should actually be on the SearchResultCtrl (searchResult.js), however
     // we don't know how to make this test work.  So leaving this way for now.
-    }
+
     var isUrl = function(value) {
-      return (/^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/.test(value.trim()));
+      return (/^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/gm.test(value));
     };
 
     expect(isUrl("http://www.example.com")).toBe(true);
     expect(isUrl("https://www.example.com/blah")).toBe(true);
     expect(isUrl("some text with nested https://www.example.com/blah shouldnt be true")).toBe(false);
-    expect(isUrl("  https://www.example.com/blah")).toBe(true);
-    expect(isUrl("  https://www.example.com/blah")).toBe(true);
+    expect(isUrl("  https://www.example.com/blah")).toBe(false);
+    expect(isUrl("  https://www.example.com/blah")).toBe(false);
     expect(isUrl("www.example.com/blah")).toBe(true);
 
+  });
+
+  it('properly detects if we have a JSON object', function() {
+
+    // This method should actually be on the SearchResultCtrl (searchResult.js), however
+    // we don't know how to make this test work.  So leaving this way for now.
+
+    var isJSONObject = function(value) {
+      //return typeof value === 'object' &&  value instanceof Array !== true;
+      if (typeof value === 'object' && value instanceof Array === true) {
+        return typeof value[0] === 'object'
+      }
+      else if (typeof value === 'object' &&  value instanceof Array !== true) {
+        return true;
+      }
+      return false;
+    };
+
+
+    var json_obj = { name: "Drama", id: 18};
+    var string_array = [ "some array" ];
+    var json_array = [ { name: "Drama", id: 18}, { name: "Horror", id: 3} ]
+
+    expect(isJSONObject("hello world")).toBe(false);
+    expect(isJSONObject(json_obj)).toBe(true);
+    expect(isJSONObject(string_array)).toBe(false);
+    expect(isJSONObject(json_array)).toBe(true);
   });
 
 });

--- a/spec/javascripts/angular/controllers/searchResult_spec.js
+++ b/spec/javascripts/angular/controllers/searchResult_spec.js
@@ -1,0 +1,38 @@
+'use strict';
+
+describe('Controller: SearchResultCtrl', function () {
+
+  // load the controller's module
+  beforeEach(module('QuepidTest'));
+
+  var SearchResultCtrl,
+    scope;
+
+  // Initialize the controller and a mock scope
+
+  //beforeEach(inject(function ($controller, $rootScope) {
+  //  scope = $rootScope.$new();
+  //  SearchResultCtrl = $controller('SearchResultCtrl', {
+  //    $scope: scope
+  //  });
+  //}));
+
+  it('rejects empty or blank text', function() {
+
+    // This method should actually be on the SearchResultCtrl (searchResult.js), however
+    // we don't know how to make this test work.  So leaving this way for now.
+    }
+    var isUrl = function(value) {
+      return (/^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/.test(value.trim()));
+    };
+
+    expect(isUrl("http://www.example.com")).toBe(true);
+    expect(isUrl("https://www.example.com/blah")).toBe(true);
+    expect(isUrl("some text with nested https://www.example.com/blah shouldnt be true")).toBe(false);
+    expect(isUrl("  https://www.example.com/blah")).toBe(true);
+    expect(isUrl("  https://www.example.com/blah")).toBe(true);
+    expect(isUrl("www.example.com/blah")).toBe(true);
+
+  });
+
+});

--- a/spec/javascripts/angular/controllers/searchResult_spec.js
+++ b/spec/javascripts/angular/controllers/searchResult_spec.js
@@ -32,6 +32,7 @@ describe('Controller: SearchResultCtrl', function () {
     expect(isUrl("  https://www.example.com/blah")).toBe(false);
     expect(isUrl("  https://www.example.com/blah")).toBe(false);
     expect(isUrl("www.example.com/blah")).toBe(true);
+    expect(isUrl("https://image.tmdb.org/t/p/w185/6mtUJKyedvQwEKXfWzJt3vtWx1M.jpg"))
 
   });
 


### PR DESCRIPTION
We've had reports of JSON not always rendering nicely in the search results page.   This should fix #52 

## Description
We have two methods, `isJSONObject` and `isUrl` and neither had unit tests.  I *copied* the method to `searchResults_spec.js` since I couldn't figure out how to instantiate the `searchResults.js` Controller in my spec...   Then copied the code over to `searchResults.js`.   

Would love some help on getting the structure of the controller to work.



## Motivation and Context
This fixes #52 .

Having said that, I havent figured out what to do with a big nested JSON, see how it renders in screenshots below.

Also, I haven't yet tested what if you have a field setting that looks like `genres.name`, if you have a JSON hash, then it plucks out and shows just the `name`.  But with a JSON array, nothing happens.   Wondering if `genres[0].name` should be made to work, or, if you have an array, then we do `genre.name` on each item in the array, and then maybe go back and do higighlighitng on that whole thing???

## How Has This Been Tested?
See the new searchResults_spec.js.

## Screenshots or GIFs (if appropriate):
<img width="424" alt="Screenshot at Jan 09 06-57-35" src="https://user-images.githubusercontent.com/22395/72065933-5c731b80-32ad-11ea-9a79-d54693c0b873.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
