### PR TITLE
Railsifying tries and cases table structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ These tests run the tests from the Rails side (mainly API controllers, and model
 bin/docker r bin/rake test
 ```
 
+** Make sure you don't run `bin/docker r bundle exec rake test`, you will get `uninitialized constant DatabaseCleaner` errors **
+
 Run a single test via:
 
 ```

--- a/app/assets/javascripts/controllers/queryParams.js
+++ b/app/assets/javascripts/controllers/queryParams.js
@@ -26,7 +26,7 @@ angular.module('QuepidApp')
           query_params:   $scope.settings.selectedTry.queryParams,
           search_engine:  $scope.settings.selectedTry.searchEngine,
           search_url:     $scope.settings.selectedTry.searchUrl,
-          tryNo:         $scope.settings.selectedTry.tryNo,
+          try_number:     $scope.settings.selectedTry.tryNo,
         });
         tmp.updateVars();
         $scope.settings.selectedTry = tmp;

--- a/app/assets/javascripts/controllers/queryParams.js
+++ b/app/assets/javascripts/controllers/queryParams.js
@@ -15,16 +15,17 @@ angular.module('QuepidApp')
         // try the `queryParams` attribute does not maintain its new value
         // and reverts to the old value.
         // So instead we are creating a tmp variable to use.
+        // UGH, this temp requires mapping back to API format of the data!
         var tmp = new TryFactory({
           args:          $scope.settings.selectedTry.args,
           curatorVars:   $scope.settings.selectedTry.curatorVarsDict(),
-          escapeQuery:   $scope.settings.selectedTry.escapeQuery,
-          fieldSpec:     $scope.settings.selectedTry.fieldSpec,
+          escape_query:   $scope.settings.selectedTry.escapeQuery,
+          field_spec:     $scope.settings.selectedTry.fieldSpec,
           name:          $scope.settings.selectedTry.name,
           numberOfRows:  $scope.settings.selectedTry.numberOfRows,
-          queryParams:   $scope.settings.selectedTry.queryParams,
-          searchEngine:  $scope.settings.selectedTry.searchEngine,
-          searchUrl:     $scope.settings.selectedTry.searchUrl,
+          query_params:   $scope.settings.selectedTry.queryParams,
+          search_engine:  $scope.settings.selectedTry.searchEngine,
+          search_url:     $scope.settings.selectedTry.searchUrl,
           tryNo:         $scope.settings.selectedTry.tryNo,
         });
         tmp.updateVars();

--- a/app/assets/javascripts/factories/TryFactory.js
+++ b/app/assets/javascripts/factories/TryFactory.js
@@ -33,7 +33,7 @@
       self.args          = data.args;
       self.deleted       = false;
       self.escapeQuery   = data.escape_query;
-      self.fieldSpec     = data.fieldSpec;
+      self.fieldSpec     = data.field_spec;
       self.name          = data.name;
       self.numberOfRows  = data.numberOfRows;
       self.queryParams   = data.queryParams;

--- a/app/assets/javascripts/factories/TryFactory.js
+++ b/app/assets/javascripts/factories/TryFactory.js
@@ -35,7 +35,7 @@
       self.escapeQuery   = data.escape_query;
       self.fieldSpec     = data.field_spec;
       self.name          = data.name;
-      self.numberOfRows  = data.numberOfRows;
+      self.numberOfRows  = data.number_of_rows;
       self.queryParams   = data.query_params;
       self.searchEngine  = data.search_engine;
       self.searchUrl     = data.search_url;

--- a/app/assets/javascripts/factories/TryFactory.js
+++ b/app/assets/javascripts/factories/TryFactory.js
@@ -36,7 +36,7 @@
       self.fieldSpec     = data.field_spec;
       self.name          = data.name;
       self.numberOfRows  = data.numberOfRows;
-      self.queryParams   = data.queryParams;
+      self.queryParams   = data.query_params;
       self.searchEngine  = data.search_engine;
       self.searchUrl     = data.search_url;
       self.tryNo         = data.tryNo;

--- a/app/assets/javascripts/factories/TryFactory.js
+++ b/app/assets/javascripts/factories/TryFactory.js
@@ -17,15 +17,14 @@
     var Try = function(data) {
       // This method converts the response from the API to angular objects.
       var self  = this;
-      console.log('TryFactory: Creating a try from the data:');
-      console.log(data);
       if ( data.searchEngine !== undefined ) {
         console.log('Data object creating Try has a searchEngine!');
         console.log(data);
       }
 
       if ( angular.isUndefined(data.search_engine) ) {
-        console.log('We have an undefined data.search_engine so setting to Solr');
+        console.log('We have an undefined data.search_engine so setting to Solr, should this ever happen?');
+        console.log(data);
         data.search_engine = 'solr';
       }
 

--- a/app/assets/javascripts/factories/TryFactory.js
+++ b/app/assets/javascripts/factories/TryFactory.js
@@ -15,9 +15,15 @@
     fieldSpecSvc, caseTryNavSvc, varExtractorSvc
   ) {
     var Try = function(data) {
+      // This method converts the response from the API to angular objects.
       var self  = this;
       console.log("TryFactory: Creating a try from the data:");
       console.log(data);
+      if ( data.searchEngine !== undefined ) {
+        console.log("Data object creating Try has a searchEngine!");
+        console.log(data);
+      }
+
       if ( angular.isUndefined(data.search_engine) ) {
         console.log("We have an undefined data.search_engine so setting to Solr");
         data.search_engine = 'solr';

--- a/app/assets/javascripts/factories/TryFactory.js
+++ b/app/assets/javascripts/factories/TryFactory.js
@@ -30,6 +30,8 @@
       }
 
       // Attributes
+      // Note, if you are changing these, then you probably to fix the
+      // var tmp = new TryFactory method in queryParams.js as well.
       self.args          = data.args;
       self.deleted       = false;
       self.escapeQuery   = data.escape_query;
@@ -39,7 +41,7 @@
       self.queryParams   = data.query_params;
       self.searchEngine  = data.search_engine;
       self.searchUrl     = data.search_url;
-      self.tryNo         = data.tryNo;
+      self.tryNo         = data.try_number;
 
       // transform curator vars to be more angular friendly
       var ngFriendlyCuratorVars = [];

--- a/app/assets/javascripts/factories/TryFactory.js
+++ b/app/assets/javascripts/factories/TryFactory.js
@@ -17,15 +17,15 @@
     var Try = function(data) {
       // This method converts the response from the API to angular objects.
       var self  = this;
-      console.log("TryFactory: Creating a try from the data:");
+      console.log('TryFactory: Creating a try from the data:');
       console.log(data);
       if ( data.searchEngine !== undefined ) {
-        console.log("Data object creating Try has a searchEngine!");
+        console.log('Data object creating Try has a searchEngine!');
         console.log(data);
       }
 
       if ( angular.isUndefined(data.search_engine) ) {
-        console.log("We have an undefined data.search_engine so setting to Solr");
+        console.log('We have an undefined data.search_engine so setting to Solr');
         data.search_engine = 'solr';
       }
 

--- a/app/assets/javascripts/factories/TryFactory.js
+++ b/app/assets/javascripts/factories/TryFactory.js
@@ -16,21 +16,23 @@
   ) {
     var Try = function(data) {
       var self  = this;
-
-      if ( angular.isUndefined(data.searchEngine) ) {
-        data.searchEngine = 'solr';
+      console.log("TryFactory: Creating a try from the data:");
+      console.log(data);
+      if ( angular.isUndefined(data.search_engine) ) {
+        console.log("We have an undefined data.search_engine so setting to Solr");
+        data.search_engine = 'solr';
       }
 
       // Attributes
       self.args          = data.args;
       self.deleted       = false;
-      self.escapeQuery   = data.escapeQuery;
+      self.escapeQuery   = data.escape_query;
       self.fieldSpec     = data.fieldSpec;
       self.name          = data.name;
       self.numberOfRows  = data.numberOfRows;
       self.queryParams   = data.queryParams;
-      self.searchEngine  = data.searchEngine;
-      self.searchUrl     = data.searchUrl;
+      self.searchEngine  = data.search_engine;
+      self.searchUrl     = data.search_url;
       self.tryNo         = data.tryNo;
 
       // transform curator vars to be more angular friendly

--- a/app/assets/javascripts/services/caseSvc.js
+++ b/app/assets/javascripts/services/caseSvc.js
@@ -3,11 +3,11 @@
 angular.module('QuepidApp')
   .service('caseSvc', [
     '$http', '$filter', '$q', '$rootScope',
-    'caseTryNavSvc', 'teamSvc', 'settingsSvc',
+    'caseTryNavSvc', 'settingsSvc',
     'broadcastSvc',
     function caseSvc(
       $http, $filter, $q, $rootScope,
-      caseTryNavSvc, teamSvc, settingsSvc,
+      caseTryNavSvc, settingsSvc,
       broadcastSvc
     ) {
 
@@ -39,7 +39,7 @@ angular.module('QuepidApp')
 
         theCase.caseNo            = data.caseNo;
         theCase.lastTry           = data.lastTry;
-        theCase.caseName          = data.caseName;
+        theCase.caseName          = data.case_name;
         theCase.lastScore         = data.lastScore;
         theCase.scorerId          = data.scorerId;
         theCase.scorerType        = data.scorerType;
@@ -66,7 +66,7 @@ angular.module('QuepidApp')
             var url  = '/api/cases/' + theCase.caseNo;
             var data = {
               caseNo:   theCase.caseNo,
-              caseName: newName
+              case_name: newName
             };
 
             return $http.put(url, data)
@@ -178,7 +178,7 @@ angular.module('QuepidApp')
         // on success, sets current case number to case number
         var data = {'caseName': 'Case: ' + this.casesCount};
         if (caseName) {
-          data.caseName = caseName;
+          data.case_name = caseName;
         }
         if (queries) {
           data.queries = queries;
@@ -444,7 +444,7 @@ angular.module('QuepidApp')
           clone_ratings:    options.ratings,
           preserve_history: options.history,
           tryNo:            options.tryId,
-          caseName:         options.caseName
+          case_name:         options.caseName
         };
         var defaultOptions  = {
           case_id:          theCase.caseNo,

--- a/app/assets/javascripts/services/caseSvc.js
+++ b/app/assets/javascripts/services/caseSvc.js
@@ -38,7 +38,7 @@ angular.module('QuepidApp')
         var theCase               = this;
 
         theCase.caseNo            = data.caseNo;
-        theCase.lastTry           = data.lastTry;
+        theCase.lastTry           = data.last_try_number;
         theCase.caseName          = data.case_name;
         theCase.lastScore         = data.lastScore;
         theCase.scorerId          = data.scorerId;

--- a/app/assets/javascripts/services/caseSvc.js
+++ b/app/assets/javascripts/services/caseSvc.js
@@ -176,7 +176,7 @@ angular.module('QuepidApp')
         // http post /cases/
         // returns as if we did http get /cases/<caseNo>
         // on success, sets current case number to case number
-        var data = {'caseName': 'Case: ' + this.casesCount};
+        var data = {'case_name': 'Case: ' + this.casesCount};
         if (caseName) {
           data.case_name = caseName;
         }

--- a/app/assets/javascripts/services/settingsSvc.js
+++ b/app/assets/javascripts/services/settingsSvc.js
@@ -109,7 +109,7 @@ angular.module('QuepidApp')
             tryToUse = settings.selectedTry;
             settings.selectTry(tryToUse.tryNo);
           }
-          console.log("settingsSvc: editableSettings setting up tryToUse");
+          console.log('settingsSvc: editableSettings setting up tryToUse');
           console.log(tryToUse);
           settings.escapeQuery   = tryToUse.escapeQuery;
           settings.fieldSpec     = tryToUse.fieldSpec;

--- a/app/assets/javascripts/services/settingsSvc.js
+++ b/app/assets/javascripts/services/settingsSvc.js
@@ -166,7 +166,7 @@ angular.module('QuepidApp')
         sentData.curatorVars     = settingsToSave.selectedTry.curatorVarsDict();
         sentData.escape_query    = settingsToSave.escapeQuery;
         sentData.fields          = settingsToSave.createFieldSpec().fields;
-        sentData.fieldSpec       = settingsToSave.fieldSpec;
+        sentData.field_spec      = settingsToSave.fieldSpec;
         sentData.number_of_rows  = settingsToSave.numberOfRows;
         sentData.queryParams     = settingsToSave.selectedTry.queryParams;
         sentData.search_engine   = settingsToSave.searchEngine;

--- a/app/assets/javascripts/services/settingsSvc.js
+++ b/app/assets/javascripts/services/settingsSvc.js
@@ -109,8 +109,7 @@ angular.module('QuepidApp')
             tryToUse = settings.selectedTry;
             settings.selectTry(tryToUse.tryNo);
           }
-          console.log('settingsSvc: editableSettings setting up tryToUse');
-          console.log(tryToUse);
+          
           settings.escapeQuery   = tryToUse.escapeQuery;
           settings.fieldSpec     = tryToUse.fieldSpec;
           settings.numberOfRows  = tryToUse.numberOfRows;

--- a/app/assets/javascripts/services/settingsSvc.js
+++ b/app/assets/javascripts/services/settingsSvc.js
@@ -167,7 +167,7 @@ angular.module('QuepidApp')
         sentData.fieldSpec       = settingsToSave.fieldSpec;
         sentData.number_of_rows  = settingsToSave.numberOfRows;
         sentData.queryParams     = settingsToSave.selectedTry.queryParams;
-        sentData.searchEngine    = settingsToSave.searchEngine;
+        sentData.search_engine   = settingsToSave.searchEngine;
         sentData.searchUrl       = settingsToSave.searchUrl;
 
         return $http.post('/api/cases/' + currCaseNo + '/tries', sentData)

--- a/app/assets/javascripts/services/settingsSvc.js
+++ b/app/assets/javascripts/services/settingsSvc.js
@@ -168,7 +168,7 @@ angular.module('QuepidApp')
         sentData.fields          = settingsToSave.createFieldSpec().fields;
         sentData.field_spec      = settingsToSave.fieldSpec;
         sentData.number_of_rows  = settingsToSave.numberOfRows;
-        sentData.queryParams     = settingsToSave.selectedTry.queryParams;
+        sentData.query_params    = settingsToSave.selectedTry.queryParams;
         sentData.search_engine   = settingsToSave.searchEngine;
         sentData.searchUrl       = settingsToSave.searchUrl;
 

--- a/app/assets/javascripts/services/settingsSvc.js
+++ b/app/assets/javascripts/services/settingsSvc.js
@@ -109,13 +109,14 @@ angular.module('QuepidApp')
             tryToUse = settings.selectedTry;
             settings.selectTry(tryToUse.tryNo);
           }
-
-          settings.escapeQuery   = tryToUse.escapeQuery;
+          console.log("settingsSvc: editableSettings setting up tryToUse");
+          console.log(tryToUse);
+          settings.escapeQuery   = (tryToUse.escape_query === undefined) ? tryToUse.escapeQuery : tryToUse.escape_query;
           settings.fieldSpec     = tryToUse.fieldSpec;
           settings.numberOfRows  = tryToUse.numberOfRows;
           settings.queryParams   = tryToUse.queryParams;
-          settings.searchEngine  = tryToUse.searchEngine;
-          settings.searchUrl     = tryToUse.searchUrl;
+          settings.searchEngine  = (tryToUse.search_engine === undefined) ? tryToUse.searchEngine : tryToUse.search_engine;
+          settings.searchUrl     = (tryToUse.search_url === undefined) ? tryToUse.searchUrl : tryToUse.search_url;
 
           return settings;
   			} else {

--- a/app/assets/javascripts/services/settingsSvc.js
+++ b/app/assets/javascripts/services/settingsSvc.js
@@ -111,12 +111,12 @@ angular.module('QuepidApp')
           }
           console.log("settingsSvc: editableSettings setting up tryToUse");
           console.log(tryToUse);
-          settings.escapeQuery   = (tryToUse.escape_query === undefined) ? tryToUse.escapeQuery : tryToUse.escape_query;
+          settings.escapeQuery   = tryToUse.escapeQuery;
           settings.fieldSpec     = tryToUse.fieldSpec;
           settings.numberOfRows  = tryToUse.numberOfRows;
           settings.queryParams   = tryToUse.queryParams;
-          settings.searchEngine  = (tryToUse.search_engine === undefined) ? tryToUse.searchEngine : tryToUse.search_engine;
-          settings.searchUrl     = (tryToUse.search_url === undefined) ? tryToUse.searchUrl : tryToUse.search_url;
+          settings.searchEngine  = tryToUse.searchEngine;
+          settings.searchUrl     = tryToUse.searchUrl;
 
           return settings;
   			} else {

--- a/app/assets/javascripts/services/settingsSvc.js
+++ b/app/assets/javascripts/services/settingsSvc.js
@@ -158,11 +158,12 @@ angular.module('QuepidApp')
         // (3) possibly edited query params
         // (4) possibly modified curator vars
         // probably could be a bit more restful
+        // Note that we map between camelCase in JS and snake_case in API here.
         var sentData = {};
         var currCaseNo = caseTryNavSvc.getCaseNo();
 
         sentData.curatorVars     = settingsToSave.selectedTry.curatorVarsDict();
-        sentData.escapeQuery     = settingsToSave.escapeQuery;
+        sentData.escape_query    = settingsToSave.escapeQuery;
         sentData.fields          = settingsToSave.createFieldSpec().fields;
         sentData.fieldSpec       = settingsToSave.fieldSpec;
         sentData.number_of_rows  = settingsToSave.numberOfRows;

--- a/app/assets/javascripts/services/teamSvc.js
+++ b/app/assets/javascripts/services/teamSvc.js
@@ -19,6 +19,14 @@ angular.module('QuepidApp')
         this.members      = members;
         this.scorers      = scorers;
         this.owned        = owned;
+
+
+        angular.forEach(this.cases, function(c) {
+          // This is really ugly.
+          c.caseName = c.case_name;
+        });
+
+
       };
 
       this.constructFromData = function(data) {

--- a/app/controllers/api/v1/cases_controller.rb
+++ b/app/controllers/api/v1/cases_controller.rb
@@ -81,7 +81,7 @@ module Api
       private
 
       def case_params
-        params.permit(:caseName, :scorer_id, :archived)
+        params.permit(:case_name, :scorer_id, :archived)
       end
 
       def default_scorer_removed? params = {}

--- a/app/controllers/api/v1/cases_controller.rb
+++ b/app/controllers/api/v1/cases_controller.rb
@@ -81,7 +81,7 @@ module Api
       private
 
       def case_params
-        params.permit(:caseName, :displayPosition, :scorer_id, :archived)
+        params.permit(:caseName, :scorer_id, :archived)
       end
 
       def default_scorer_removed? params = {}

--- a/app/controllers/api/v1/clone/cases_controller.rb
+++ b/app/controllers/api/v1/clone/cases_controller.rb
@@ -14,7 +14,7 @@ module Api
           preserve_history  = params[:preserve_history]
           clone_queries     = params[:clone_queries]
           clone_ratings     = params[:clone_ratings]
-          the_try           = @case.tries.where(tryNo: params[:tryNo]).first
+          the_try           = @case.tries.where(try_number: params[:try_number]).first
           @new_case.caseName = params[:caseName].presence || "Cloned: #{@case.caseName}"
 
           transaction = @new_case.clone_case(

--- a/app/controllers/api/v1/clone/cases_controller.rb
+++ b/app/controllers/api/v1/clone/cases_controller.rb
@@ -11,11 +11,11 @@ module Api
         def create
           @new_case = Case.new
 
-          preserve_history  = params[:preserve_history]
-          clone_queries     = params[:clone_queries]
-          clone_ratings     = params[:clone_ratings]
-          the_try           = @case.tries.where(try_number: params[:try_number]).first
-          @new_case.caseName = params[:caseName].presence || "Cloned: #{@case.caseName}"
+          preserve_history    = params[:preserve_history]
+          clone_queries       = params[:clone_queries]
+          clone_ratings       = params[:clone_ratings]
+          the_try             = @case.tries.where(try_number: params[:try_number]).first
+          @new_case.case_name = params[:case_name].presence || "Cloned: #{@case.case_name}"
 
           transaction = @new_case.clone_case(
             @case,

--- a/app/controllers/api/v1/clone/tries_controller.rb
+++ b/app/controllers/api/v1/clone/tries_controller.rb
@@ -21,10 +21,10 @@ module Api
 
           @new_try = @case.tries.build new_try_params
 
-          try_number = @case.lastTry + 1
+          try_number = @case.last_try_number + 1
 
-          @new_try.try_number = try_number
-          @case.lastTry       = try_number
+          @new_try.try_number   = try_number
+          @case.last_try_number = try_number
 
           if @new_try.save && @case.save
             @try.add_curator_vars @try.curator_vars_map

--- a/app/controllers/api/v1/clone/tries_controller.rb
+++ b/app/controllers/api/v1/clone/tries_controller.rb
@@ -15,7 +15,7 @@ module Api
             fieldSpec:      @try.fieldSpec,
             number_of_rows: @try.number_of_rows,
             queryParams:    @try.queryParams,
-            searchEngine:   @try.searchEngine,
+            search_engine:  @try.search_engine,
             searchUrl:      @try.searchUrl,
           }
 
@@ -54,7 +54,7 @@ module Api
             :searchUrl,
             :fieldSpec,
             :queryParams,
-            :searchEngine,
+            :search_engine,
             :escapeQuery,
             :number_of_rows
           )

--- a/app/controllers/api/v1/clone/tries_controller.rb
+++ b/app/controllers/api/v1/clone/tries_controller.rb
@@ -14,7 +14,7 @@ module Api
             escape_query:   @try.escape_query,
             field_spec:     @try.field_spec,
             number_of_rows: @try.number_of_rows,
-            queryParams:    @try.queryParams,
+            query_params:   @try.query_params,
             search_engine:  @try.search_engine,
             search_url:     @try.search_url,
           }
@@ -53,7 +53,7 @@ module Api
             :name,
             :search_url,
             :field_spec,
-            :queryParams,
+            :query_params,
             :search_engine,
             :escape_query,
             :number_of_rows

--- a/app/controllers/api/v1/clone/tries_controller.rb
+++ b/app/controllers/api/v1/clone/tries_controller.rb
@@ -12,7 +12,7 @@ module Api
         def create
           new_try_params = {
             escape_query:   @try.escape_query,
-            fieldSpec:      @try.fieldSpec,
+            field_spec:     @try.field_spec,
             number_of_rows: @try.number_of_rows,
             queryParams:    @try.queryParams,
             search_engine:  @try.search_engine,
@@ -52,7 +52,7 @@ module Api
           params.permit(
             :name,
             :search_url,
-            :fieldSpec,
+            :field_spec,
             :queryParams,
             :search_engine,
             :escape_query,

--- a/app/controllers/api/v1/clone/tries_controller.rb
+++ b/app/controllers/api/v1/clone/tries_controller.rb
@@ -21,9 +21,10 @@ module Api
 
           @new_try = @case.tries.build new_try_params
 
-          try_number     = @case.lastTry + 1
+          try_number = @case.lastTry + 1
+
           @new_try.try_number = try_number
-          @case.lastTry  = try_number
+          @case.lastTry       = try_number
 
           if @new_try.save && @case.save
             @try.add_curator_vars @try.curator_vars_map

--- a/app/controllers/api/v1/clone/tries_controller.rb
+++ b/app/controllers/api/v1/clone/tries_controller.rb
@@ -22,7 +22,7 @@ module Api
           @new_try = @case.tries.build new_try_params
 
           try_number     = @case.lastTry + 1
-          @new_try.tryNo = try_number
+          @new_try.try_number = try_number
           @case.lastTry  = try_number
 
           if @new_try.save && @case.save
@@ -39,7 +39,7 @@ module Api
         private
 
         def set_try
-          @try = @case.tries.where(tryNo: params[:tryNo]).first
+          @try = @case.tries.where(try_number: params[:try_number]).first
 
           render json: { message: 'Try not found!' }, status: :not_found unless @try
         end

--- a/app/controllers/api/v1/clone/tries_controller.rb
+++ b/app/controllers/api/v1/clone/tries_controller.rb
@@ -16,7 +16,7 @@ module Api
             number_of_rows: @try.number_of_rows,
             queryParams:    @try.queryParams,
             search_engine:  @try.search_engine,
-            searchUrl:      @try.searchUrl,
+            search_url:     @try.search_url,
           }
 
           @new_try = @case.tries.build new_try_params
@@ -51,7 +51,7 @@ module Api
         def try_params
           params.permit(
             :name,
-            :searchUrl,
+            :search_url,
             :fieldSpec,
             :queryParams,
             :search_engine,

--- a/app/controllers/api/v1/clone/tries_controller.rb
+++ b/app/controllers/api/v1/clone/tries_controller.rb
@@ -11,7 +11,7 @@ module Api
         # rubocop:disable Metrics/MethodLength
         def create
           new_try_params = {
-            escapeQuery:    @try.escapeQuery,
+            escape_query:   @try.escape_query,
             fieldSpec:      @try.fieldSpec,
             number_of_rows: @try.number_of_rows,
             queryParams:    @try.queryParams,
@@ -55,7 +55,7 @@ module Api
             :fieldSpec,
             :queryParams,
             :search_engine,
-            :escapeQuery,
+            :escape_query,
             :number_of_rows
           )
         end

--- a/app/controllers/api/v1/scorers_controller.rb
+++ b/app/controllers/api/v1/scorers_controller.rb
@@ -124,7 +124,7 @@ module Api
           render(
             json:   {
               # rubocop:disable Metrics/LineLength
-              error: "Cannot delete the scorer because it is the default for #{@cases.count} #{'case'.pluralize(@cases.count)}: [#{@cases.take(3).map(&:caseName).to_sentence}]",
+              error: "Cannot delete the scorer because it is the default for #{@cases.count} #{'case'.pluralize(@cases.count)}: [#{@cases.take(3).map(&:case_name).to_sentence}]",
               # rubocop:enable Metrics/LineLength
             },
             status: :bad_request

--- a/app/controllers/api/v1/tries_controller.rb
+++ b/app/controllers/api/v1/tries_controller.rb
@@ -66,7 +66,7 @@ module Api
           :name,
           :number_of_rows,
           :queryParams,
-          :searchEngine,
+          :search_engine,
           :searchUrl
         )
       end

--- a/app/controllers/api/v1/tries_controller.rb
+++ b/app/controllers/api/v1/tries_controller.rb
@@ -16,7 +16,7 @@ module Api
         @try = @case.tries.build try_params
 
         try_number = @case.last_try_number + 1
-        
+
         @try.try_number       = try_number
         @case.last_try_number = try_number
 

--- a/app/controllers/api/v1/tries_controller.rb
+++ b/app/controllers/api/v1/tries_controller.rb
@@ -15,9 +15,9 @@ module Api
       def create
         @try = @case.tries.build try_params
 
-        try_number      = @case.lastTry + 1
-        @try.try_number = try_number
-        @case.lastTry   = try_number
+        try_number      = @case.last_try_number + 1
+        @try.try_number       = try_number
+        @case.last_try_number = try_number
 
         if @try.save && @case.save
           @try.add_curator_vars params[:curatorVars]

--- a/app/controllers/api/v1/tries_controller.rb
+++ b/app/controllers/api/v1/tries_controller.rb
@@ -62,7 +62,7 @@ module Api
       def try_params
         params.permit(
           :escape_query,
-          :fieldSpec,
+          :field_spec,
           :name,
           :number_of_rows,
           :queryParams,

--- a/app/controllers/api/v1/tries_controller.rb
+++ b/app/controllers/api/v1/tries_controller.rb
@@ -65,7 +65,7 @@ module Api
           :field_spec,
           :name,
           :number_of_rows,
-          :queryParams,
+          :query_params,
           :search_engine,
           :search_url
         )

--- a/app/controllers/api/v1/tries_controller.rb
+++ b/app/controllers/api/v1/tries_controller.rb
@@ -67,7 +67,7 @@ module Api
           :number_of_rows,
           :queryParams,
           :search_engine,
-          :searchUrl
+          :search_url
         )
       end
     end

--- a/app/controllers/api/v1/tries_controller.rb
+++ b/app/controllers/api/v1/tries_controller.rb
@@ -15,7 +15,8 @@ module Api
       def create
         @try = @case.tries.build try_params
 
-        try_number      = @case.last_try_number + 1
+        try_number = @case.last_try_number + 1
+        
         @try.try_number       = try_number
         @case.last_try_number = try_number
 

--- a/app/controllers/api/v1/tries_controller.rb
+++ b/app/controllers/api/v1/tries_controller.rb
@@ -15,9 +15,9 @@ module Api
       def create
         @try = @case.tries.build try_params
 
-        try_number    = @case.lastTry + 1
-        @try.tryNo    = try_number
-        @case.lastTry = try_number
+        try_number      = @case.lastTry + 1
+        @try.try_number = try_number
+        @case.lastTry   = try_number
 
         if @try.save && @case.save
           @try.add_curator_vars params[:curatorVars]
@@ -50,7 +50,7 @@ module Api
       private
 
       def set_try
-        @try = @case.tries.where(tryNo: params[:tryNo]).first
+        @try = @case.tries.where(try_number: params[:try_number]).first
 
         render json: { message: 'Try not found!' }, status: :not_found unless @try
       end

--- a/app/controllers/api/v1/tries_controller.rb
+++ b/app/controllers/api/v1/tries_controller.rb
@@ -61,7 +61,7 @@ module Api
 
       def try_params
         params.permit(
-          :escapeQuery,
+          :escape_query,
           :fieldSpec,
           :name,
           :number_of_rows,

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -37,7 +37,7 @@ class HomeController < ApplicationController
       else
         @triggerWizard = true unless current_user.firstLogin?
 
-        bootstrapCase     = current_user.cases.create caseName: Case::DEFAULT_NAME
+        bootstrapCase     = current_user.cases.create case_name: Case::DEFAULT_NAME
         @bootstrapCaseNo  = bootstrapCase.id
         @bootstrapTryNo   = bootstrapCase.tries.best.try_number
       end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -33,13 +33,13 @@ class HomeController < ApplicationController
       if bootstrapCase
         @bootstrapCaseNo  = bootstrapCase.id
         best_try          = bootstrapCase.tries.best
-        @bootstrapTryNo   = best_try.tryNo if best_try.present?
+        @bootstrapTryNo   = best_try.try_number if best_try.present?
       else
         @triggerWizard = true unless current_user.firstLogin?
 
         bootstrapCase     = current_user.cases.create caseName: Case::DEFAULT_NAME
         @bootstrapCaseNo  = bootstrapCase.id
-        @bootstrapTryNo   = bootstrapCase.tries.best.tryNo
+        @bootstrapTryNo   = bootstrapCase.tries.best.try_number
       end
     end
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -5,7 +5,7 @@
 # Table name: cases
 #
 #  id              :integer          not null, primary key
-#  caseName        :string(191)
+#  case_name       :string(191)
 #  search_url      :string(500)
 #  field_spec      :string(500)
 #  lastTry         :integer
@@ -67,7 +67,7 @@ class Case < ActiveRecord::Base
              source_type: 'DefaultScorer'
 
   # Validations
-  validates :caseName, presence: true
+  validates :case_name, presence: true
   validates_with DefaultScorerExistsValidator
 
   # Callbacks

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -170,7 +170,7 @@ class Case < ActiveRecord::Base
       escape_query:  the_try.escape_query,
       field_spec:    the_try.field_spec,
       name:          the_try.name,
-      queryParams:   the_try.queryParams,
+      query_params:  the_try.query_params,
       search_engine: the_try.search_engine,
       search_url:    the_try.search_url,
       tryNo:         0

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -168,7 +168,7 @@ class Case < ActiveRecord::Base
   # rubocop:disable Metrics/MethodLength
   def clone_try the_try
     new_try = Try.new(
-      escapeQuery:   the_try.escapeQuery,
+      escape_query:  the_try.escape_query,
       fieldSpec:     the_try.fieldSpec,
       name:          the_try.name,
       queryParams:   the_try.queryParams,

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -10,7 +10,6 @@
 #  field_spec      :string(500)
 #  lastTry         :integer
 #  user_id         :integer
-#  displayPosition :integer
 #  archived        :boolean
 #  scorer_id       :integer
 #  created_at      :datetime         not null

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -6,7 +6,7 @@
 #
 #  id              :integer          not null, primary key
 #  caseName        :string(191)
-#  searchUrl       :string(500)
+#  search_url      :string(500)
 #  fieldSpec       :string(500)
 #  lastTry         :integer
 #  user_id         :integer
@@ -173,7 +173,7 @@ class Case < ActiveRecord::Base
       name:          the_try.name,
       queryParams:   the_try.queryParams,
       search_engine: the_try.search_engine,
-      searchUrl:     the_try.searchUrl,
+      search_url:    the_try.search_url,
       tryNo:         0
     )
     tries << new_try

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -168,13 +168,13 @@ class Case < ActiveRecord::Base
   # rubocop:disable Metrics/MethodLength
   def clone_try the_try
     new_try = Try.new(
-      escapeQuery:  the_try.escapeQuery,
-      fieldSpec:    the_try.fieldSpec,
-      name:         the_try.name,
-      queryParams:  the_try.queryParams,
-      searchEngine: the_try.searchEngine,
-      searchUrl:    the_try.searchUrl,
-      tryNo:        0
+      escapeQuery:   the_try.escapeQuery,
+      fieldSpec:     the_try.fieldSpec,
+      name:          the_try.name,
+      queryParams:   the_try.queryParams,
+      search_engine: the_try.search_engine,
+      searchUrl:     the_try.searchUrl,
+      tryNo:         0
     )
     tries << new_try
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -113,7 +113,7 @@ class Case < ActiveRecord::Base
       elsif try
         clone_try try
       end
-      self.lastTry = tries.last.tryNo
+      self.lastTry = tries.last.try_number
 
       if clone_queries
         original_case.queries.each do |query|
@@ -160,8 +160,8 @@ class Case < ActiveRecord::Base
 
   def add_default_try
     try_number  = (lastTry || -1) + 1
-    the_try     = tries.create(tryNo: try_number)
-    update lastTry: the_try.tryNo
+    the_try     = tries.create(try_number: try_number)
+    update lastTry: the_try.try_number
   end
 
   # rubocop:disable Metrics/MethodLength
@@ -173,7 +173,7 @@ class Case < ActiveRecord::Base
       query_params:  the_try.query_params,
       search_engine: the_try.search_engine,
       search_url:    the_try.search_url,
-      tryNo:         0
+      try_number:    0
     )
     tries << new_try
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -7,7 +7,7 @@
 #  id              :integer          not null, primary key
 #  caseName        :string(191)
 #  search_url      :string(500)
-#  fieldSpec       :string(500)
+#  field_spec      :string(500)
 #  lastTry         :integer
 #  user_id         :integer
 #  displayPosition :integer
@@ -169,7 +169,7 @@ class Case < ActiveRecord::Base
   def clone_try the_try
     new_try = Try.new(
       escape_query:  the_try.escape_query,
-      fieldSpec:     the_try.fieldSpec,
+      field_spec:    the_try.field_spec,
       name:          the_try.name,
       queryParams:   the_try.queryParams,
       search_engine: the_try.search_engine,

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -8,7 +8,7 @@
 #  case_name       :string(191)
 #  search_url      :string(500)
 #  field_spec      :string(500)
-#  lastTry         :integer
+#  last_try_number :integer
 #  user_id         :integer
 #  archived        :boolean
 #  scorer_id       :integer
@@ -113,7 +113,7 @@ class Case < ActiveRecord::Base
       elsif try
         clone_try try
       end
-      self.lastTry = tries.last.try_number
+      self.last_try_number = tries.last.try_number
 
       if clone_queries
         original_case.queries.each do |query|
@@ -159,9 +159,9 @@ class Case < ActiveRecord::Base
   end
 
   def add_default_try
-    try_number  = (lastTry || -1) + 1
+    try_number  = (last_try_number || -1) + 1
     the_try     = tries.create(try_number: try_number)
-    update lastTry: the_try.try_number
+    update last_try_number: the_try.try_number
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/app/models/try.rb
+++ b/app/models/try.rb
@@ -8,7 +8,7 @@
 #  tryNo          :integer
 #  queryParams    :text(65535)
 #  case_id        :integer
-#  fieldSpec      :string(500)
+#  field_spec     :string(500)
 #  search_url     :string(500)
 #  name           :string(50)
 #  search_engine  :string(50)       default("solr")
@@ -97,7 +97,7 @@ class Try < ActiveRecord::Base
     self.name = "Try #{tryNo}" if name.blank?
 
     self.search_engine = DEFAULTS[:search_engine] if search_engine.blank?
-    self.fieldSpec     = DEFAULTS[search_engine.to_sym][:field_spec]    if fieldSpec.blank?
+    self.field_spec    = DEFAULTS[search_engine.to_sym][:field_spec]    if field_spec.blank?
     self.queryParams   = DEFAULTS[search_engine.to_sym][:query_params]  if queryParams.blank?
     self.search_url    = DEFAULTS[search_engine.to_sym][:search_url]    if search_url.blank?
   end

--- a/app/models/try.rb
+++ b/app/models/try.rb
@@ -5,7 +5,7 @@
 # Table name: tries
 #
 #  id             :integer          not null, primary key
-#  tryNo          :integer
+#  try_number     :integer
 #  query_params   :text(65535)
 #  case_id        :integer
 #  field_spec     :string(500)
@@ -24,7 +24,7 @@ require 'es_arg_parser'
 class Try < ActiveRecord::Base
   # Scopes
   scope :best, -> { order(id: :desc).first }
-  scope :latest, -> { order(tryNo: :desc).limit(1).first }
+  scope :latest, -> { order(try_number: :desc).limit(1).first }
 
   # Constants
   DEFAULTS = {
@@ -68,7 +68,7 @@ class Try < ActiveRecord::Base
   end
 
   def param
-    tryNo
+    try_number
   end
 
   def add_curator_vars vars = {}
@@ -94,7 +94,7 @@ class Try < ActiveRecord::Base
   private
 
   def set_defaults
-    self.name = "Try #{tryNo}" if name.blank?
+    self.name = "Try #{try_number}" if name.blank?
 
     self.search_engine = DEFAULTS[:search_engine] if search_engine.blank?
     self.field_spec    = DEFAULTS[search_engine.to_sym][:field_spec]    if field_spec.blank?

--- a/app/models/try.rb
+++ b/app/models/try.rb
@@ -9,7 +9,7 @@
 #  queryParams    :text(65535)
 #  case_id        :integer
 #  fieldSpec      :string(500)
-#  searchUrl      :string(500)
+#  search_url     :string(500)
 #  name           :string(50)
 #  search_engine  :string(50)       default("solr")
 #  escape_query   :boolean          default(TRUE)
@@ -97,8 +97,8 @@ class Try < ActiveRecord::Base
     self.name = "Try #{tryNo}" if name.blank?
 
     self.search_engine = DEFAULTS[:search_engine] if search_engine.blank?
-    self.fieldSpec    = DEFAULTS[search_engine.to_sym][:field_spec]    if fieldSpec.blank?
-    self.queryParams  = DEFAULTS[search_engine.to_sym][:query_params]  if queryParams.blank?
-    self.searchUrl    = DEFAULTS[search_engine.to_sym][:search_url]    if searchUrl.blank?
+    self.fieldSpec     = DEFAULTS[search_engine.to_sym][:field_spec]    if fieldSpec.blank?
+    self.queryParams   = DEFAULTS[search_engine.to_sym][:query_params]  if queryParams.blank?
+    self.search_url    = DEFAULTS[search_engine.to_sym][:search_url]    if search_url.blank?
   end
 end

--- a/app/models/try.rb
+++ b/app/models/try.rb
@@ -6,7 +6,7 @@
 #
 #  id             :integer          not null, primary key
 #  tryNo          :integer
-#  queryParams    :text(65535)
+#  query_params   :text(65535)
 #  case_id        :integer
 #  field_spec     :string(500)
 #  search_url     :string(500)
@@ -84,11 +84,11 @@ class Try < ActiveRecord::Base
   end
 
   def solr_args
-    SolrArgParser.parse(queryParams, curator_vars_map)
+    SolrArgParser.parse(query_params, curator_vars_map)
   end
 
   def es_args
-    EsArgParser.parse(queryParams, curator_vars_map)
+    EsArgParser.parse(query_params, curator_vars_map)
   end
 
   private
@@ -98,7 +98,7 @@ class Try < ActiveRecord::Base
 
     self.search_engine = DEFAULTS[:search_engine] if search_engine.blank?
     self.field_spec    = DEFAULTS[search_engine.to_sym][:field_spec]    if field_spec.blank?
-    self.queryParams   = DEFAULTS[search_engine.to_sym][:query_params]  if queryParams.blank?
+    self.query_params  = DEFAULTS[search_engine.to_sym][:query_params]  if query_params.blank?
     self.search_url    = DEFAULTS[search_engine.to_sym][:search_url]    if search_url.blank?
   end
 end

--- a/app/models/try.rb
+++ b/app/models/try.rb
@@ -11,7 +11,7 @@
 #  fieldSpec      :string(500)
 #  searchUrl      :string(500)
 #  name           :string(50)
-#  searchEngine   :string(50)       default("solr")
+#  search_engine  :string(50)       default("solr")
 #  escapeQuery    :boolean          default(TRUE)
 #  number_of_rows :integer          default(10)
 #  created_at     :datetime         not null
@@ -60,9 +60,9 @@ class Try < ActiveRecord::Base
   before_create :set_defaults
 
   def args
-    if 'solr' == searchEngine
+    if 'solr' == search_engine
       solr_args
-    elsif 'es' == searchEngine
+    elsif 'es' == search_engine
       es_args
     end
   end
@@ -96,9 +96,9 @@ class Try < ActiveRecord::Base
   def set_defaults
     self.name = "Try #{tryNo}" if name.blank?
 
-    self.searchEngine = DEFAULTS[:search_engine] if searchEngine.blank?
-    self.fieldSpec    = DEFAULTS[searchEngine.to_sym][:field_spec]    if fieldSpec.blank?
-    self.queryParams  = DEFAULTS[searchEngine.to_sym][:query_params]  if queryParams.blank?
-    self.searchUrl    = DEFAULTS[searchEngine.to_sym][:search_url]    if searchUrl.blank?
+    self.search_engine = DEFAULTS[:search_engine] if search_engine.blank?
+    self.fieldSpec    = DEFAULTS[search_engine.to_sym][:field_spec]    if fieldSpec.blank?
+    self.queryParams  = DEFAULTS[search_engine.to_sym][:query_params]  if queryParams.blank?
+    self.searchUrl    = DEFAULTS[search_engine.to_sym][:search_url]    if searchUrl.blank?
   end
 end

--- a/app/models/try.rb
+++ b/app/models/try.rb
@@ -12,7 +12,7 @@
 #  searchUrl      :string(500)
 #  name           :string(50)
 #  search_engine  :string(50)       default("solr")
-#  escapeQuery    :boolean          default(TRUE)
+#  escape_query   :boolean          default(TRUE)
 #  number_of_rows :integer          default(10)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -162,6 +162,6 @@ class User < ActiveRecord::Base
   end
 
   def add_default_case
-    cases.create caseName: Case::DEFAULT_NAME
+    cases.create case_name: Case::DEFAULT_NAME
   end
 end

--- a/app/views/api/v1/cases/_case.json.jbuilder
+++ b/app/views/api/v1/cases/_case.json.jbuilder
@@ -10,7 +10,7 @@ unless no_teams
   end
 end
 
-json.caseName         acase.caseName
+json.case_name        acase.case_name
 json.caseNo           acase.id
 json.scorerId         acase.scorer_id
 json.scorerType       acase.scorer_type

--- a/app/views/api/v1/cases/_case.json.jbuilder
+++ b/app/views/api/v1/cases/_case.json.jbuilder
@@ -19,7 +19,7 @@ json.queriesCount     acase.queries.count
 
 json.teams            teams unless no_teams
 
-json.lastTry acase.tries.best.try_number unless no_tries || acase.tries.blank? || acase.tries.best.blank?
+json.last_try_number acase.tries.best.try_number unless no_tries || acase.tries.blank? || acase.tries.best.blank?
 
 unless shallow
   json.queries do

--- a/app/views/api/v1/cases/_case.json.jbuilder
+++ b/app/views/api/v1/cases/_case.json.jbuilder
@@ -19,7 +19,7 @@ json.queriesCount     acase.queries.count
 
 json.teams            teams unless no_teams
 
-json.lastTry acase.tries.best.tryNo unless no_tries || acase.tries.blank? || acase.tries.best.blank?
+json.lastTry acase.tries.best.try_number unless no_tries || acase.tries.blank? || acase.tries.best.blank?
 
 unless shallow
   json.queries do

--- a/app/views/api/v1/cases/dropdown/index.json.jbuilder
+++ b/app/views/api/v1/cases/dropdown/index.json.jbuilder
@@ -6,7 +6,7 @@ json.allCases do
     json.caseNo           acase.id
     json.owned            acase.user_id == current_user.id
 
-    json.lastTry acase.tries.best.tryNo if acase.tries.present? && acase.tries.best.present?
+    json.lastTry acase.tries.best.try_number if acase.tries.present? && acase.tries.best.present?
   end
 end
 

--- a/app/views/api/v1/cases/dropdown/index.json.jbuilder
+++ b/app/views/api/v1/cases/dropdown/index.json.jbuilder
@@ -2,7 +2,7 @@
 
 json.allCases do
   json.array! @cases do |acase|
-    json.caseName         acase.caseName
+    json.case_name        acase.case_name
     json.caseNo           acase.id
     json.owned            acase.user_id == current_user.id
 

--- a/app/views/api/v1/cases/dropdown/index.json.jbuilder
+++ b/app/views/api/v1/cases/dropdown/index.json.jbuilder
@@ -6,7 +6,7 @@ json.allCases do
     json.caseNo           acase.id
     json.owned            acase.user_id == current_user.id
 
-    json.lastTry acase.tries.best.try_number if acase.tries.present? && acase.tries.best.present?
+    json.last_try_number acase.tries.best.try_number if acase.tries.present? && acase.tries.best.present?
   end
 end
 

--- a/app/views/api/v1/tries/_try.json.jbuilder
+++ b/app/views/api/v1/tries/_try.json.jbuilder
@@ -7,6 +7,6 @@ json.fieldSpec      try.fieldSpec
 json.name           try.name
 json.numberOfRows   try.number_of_rows || 10
 json.queryParams    try.queryParams
-json.searchEngine  try.search_engine
+json.searchEngine   try.search_engine
 json.searchUrl      try.searchUrl
 json.tryNo          try.tryNo

--- a/app/views/api/v1/tries/_try.json.jbuilder
+++ b/app/views/api/v1/tries/_try.json.jbuilder
@@ -3,7 +3,7 @@
 json.args           try.args
 json.curatorVars    try.curator_vars_map
 json.escape_query   try.escape_query
-json.fieldSpec      try.fieldSpec
+json.field_spec     try.field_spec
 json.name           try.name
 json.numberOfRows   try.number_of_rows || 10
 json.queryParams    try.queryParams

--- a/app/views/api/v1/tries/_try.json.jbuilder
+++ b/app/views/api/v1/tries/_try.json.jbuilder
@@ -6,7 +6,7 @@ json.escape_query   try.escape_query
 json.field_spec     try.field_spec
 json.name           try.name
 json.numberOfRows   try.number_of_rows || 10
-json.queryParams    try.queryParams
+json.query_params   try.query_params
 json.search_engine  try.search_engine
 json.search_url     try.search_url
 json.tryNo          try.tryNo

--- a/app/views/api/v1/tries/_try.json.jbuilder
+++ b/app/views/api/v1/tries/_try.json.jbuilder
@@ -7,6 +7,6 @@ json.fieldSpec      try.fieldSpec
 json.name           try.name
 json.numberOfRows   try.number_of_rows || 10
 json.queryParams    try.queryParams
-json.searchEngine   try.searchEngine
+json.searchEngine  try.search_engine
 json.searchUrl      try.searchUrl
 json.tryNo          try.tryNo

--- a/app/views/api/v1/tries/_try.json.jbuilder
+++ b/app/views/api/v1/tries/_try.json.jbuilder
@@ -9,4 +9,4 @@ json.number_of_rows try.number_of_rows || 10
 json.query_params   try.query_params
 json.search_engine  try.search_engine
 json.search_url     try.search_url
-json.tryNo          try.tryNo
+json.try_number     try.try_number

--- a/app/views/api/v1/tries/_try.json.jbuilder
+++ b/app/views/api/v1/tries/_try.json.jbuilder
@@ -2,11 +2,11 @@
 
 json.args           try.args
 json.curatorVars    try.curator_vars_map
-json.escapeQuery    try.escape_query
+json.escape_query   try.escape_query
 json.fieldSpec      try.fieldSpec
 json.name           try.name
 json.numberOfRows   try.number_of_rows || 10
 json.queryParams    try.queryParams
-json.searchEngine   try.search_engine
-json.searchUrl      try.searchUrl
+json.search_engine  try.search_engine
+json.search_url     try.search_url
 json.tryNo          try.tryNo

--- a/app/views/api/v1/tries/_try.json.jbuilder
+++ b/app/views/api/v1/tries/_try.json.jbuilder
@@ -2,7 +2,7 @@
 
 json.args           try.args
 json.curatorVars    try.curator_vars_map
-json.escapeQuery    try.escapeQuery
+json.escapeQuery    try.escape_query
 json.fieldSpec      try.fieldSpec
 json.name           try.name
 json.numberOfRows   try.number_of_rows || 10

--- a/app/views/api/v1/tries/_try.json.jbuilder
+++ b/app/views/api/v1/tries/_try.json.jbuilder
@@ -5,7 +5,7 @@ json.curatorVars    try.curator_vars_map
 json.escape_query   try.escape_query
 json.field_spec     try.field_spec
 json.name           try.name
-json.numberOfRows   try.number_of_rows || 10
+json.number_of_rows try.number_of_rows || 10
 json.query_params   try.query_params
 json.search_engine  try.search_engine
 json.search_url     try.search_url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
       resources :cases, except: %i[new edit], param: :case_id
       resources :cases, only: [] do
         # Case Tries
-        resources :tries, param: :tryNo, except: %i[new edit] do
+        resources :tries, param: :try_number, except: %i[new edit] do
           post '/duplicate' => 'duplicate_tries#create', as: :duplicate_try
         end
 
@@ -108,7 +108,7 @@ Rails.application.routes.draw do
 
       namespace :clone do
         resources :cases, only: [ :create ] do
-          post 'tries/:tryNo' => 'tries#create', as: :try
+          post 'tries/:try_number' => 'tries#create', as: :try
         end
       end
 

--- a/db/migrate/20200111143938_rename_search_engine.rb
+++ b/db/migrate/20200111143938_rename_search_engine.rb
@@ -1,0 +1,5 @@
+class RenameSearchEngine < ActiveRecord::Migration
+  def change
+    rename_column :tries, :searchEngine, :search_engine
+  end
+end

--- a/db/migrate/20200113123124_rename_escape_query_in_tries.rb
+++ b/db/migrate/20200113123124_rename_escape_query_in_tries.rb
@@ -1,0 +1,5 @@
+class RenameEscapeQueryInTries < ActiveRecord::Migration
+  def change
+    rename_column :tries, :escapeQuery, :escape_query
+  end
+end

--- a/db/migrate/20200113153327_rename_search_url_in_tries.rb
+++ b/db/migrate/20200113153327_rename_search_url_in_tries.rb
@@ -1,0 +1,5 @@
+class RenameSearchUrlInTries < ActiveRecord::Migration
+  def change
+    rename_column :tries, :searchUrl, :search_url
+  end
+end

--- a/db/migrate/20200113154244_rename_search_url_in_cases.rb
+++ b/db/migrate/20200113154244_rename_search_url_in_cases.rb
@@ -1,0 +1,5 @@
+class RenameSearchUrlInCases < ActiveRecord::Migration
+  def change
+    rename_column :cases, :searchUrl, :search_url
+  end
+end

--- a/db/migrate/20200115011043_rename_field_spec_in_tries.rb
+++ b/db/migrate/20200115011043_rename_field_spec_in_tries.rb
@@ -1,0 +1,5 @@
+class RenameFieldSpecInTries < ActiveRecord::Migration
+  def change
+    rename_column :tries, :fieldSpec, :field_spec
+  end
+end

--- a/db/migrate/20200115011742_rename_field_spec_in_cases.rb
+++ b/db/migrate/20200115011742_rename_field_spec_in_cases.rb
@@ -1,0 +1,5 @@
+class RenameFieldSpecInCases < ActiveRecord::Migration
+  def change
+    rename_column :cases, :fieldSpec, :field_spec
+  end
+end

--- a/db/migrate/20200115015024_drop_unused_columns_from_cases.rb
+++ b/db/migrate/20200115015024_drop_unused_columns_from_cases.rb
@@ -1,0 +1,6 @@
+class DropUnusedColumnsFromCases < ActiveRecord::Migration
+  def change
+    remove_column :cases, :field_spec
+    remove_column :cases, :search_url
+  end
+end

--- a/db/migrate/20200115020540_drop_display_position_from_cases.rb
+++ b/db/migrate/20200115020540_drop_display_position_from_cases.rb
@@ -1,0 +1,5 @@
+class DropDisplayPositionFromCases < ActiveRecord::Migration
+  def change
+    remove_column :cases, :displayPosition
+  end
+end

--- a/db/migrate/20200115021550_rename_query_params_in_tries.rb
+++ b/db/migrate/20200115021550_rename_query_params_in_tries.rb
@@ -1,0 +1,5 @@
+class RenameQueryParamsInTries < ActiveRecord::Migration
+  def change
+    rename_column :tries, :queryParams, :query_params
+  end
+end

--- a/db/migrate/20200115131622_rename_try_no_in_tries.rb
+++ b/db/migrate/20200115131622_rename_try_no_in_tries.rb
@@ -1,0 +1,5 @@
+class RenameTryNoInTries < ActiveRecord::Migration
+  def change
+    rename_column :tries, :tryNo, :try_number
+  end
+end

--- a/db/migrate/20200115152546_fix_case_name.rb
+++ b/db/migrate/20200115152546_fix_case_name.rb
@@ -1,0 +1,5 @@
+class FixCaseName < ActiveRecord::Migration
+  def change
+    rename_column :cases, :caseName, :case_name
+  end
+end

--- a/db/migrate/20200115205420_fix_last_try_in_case.rb
+++ b/db/migrate/20200115205420_fix_last_try_in_case.rb
@@ -1,0 +1,5 @@
+class FixLastTryInCase < ActiveRecord::Migration
+  def change
+    rename_column :cases, :lastTry, :last_try_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200115015024) do
+ActiveRecord::Schema.define(version: 20200115020540) do
 
   create_table "annotations", force: :cascade do |t|
     t.text     "message",    limit: 65535
@@ -49,15 +49,14 @@ ActiveRecord::Schema.define(version: 20200115015024) do
   add_index "case_scores", ["user_id"], name: "user_id", using: :btree
 
   create_table "cases", force: :cascade do |t|
-    t.string   "caseName",        limit: 191
-    t.integer  "lastTry",         limit: 4
-    t.integer  "user_id",         limit: 4
-    t.integer  "displayPosition", limit: 4
+    t.string   "caseName",    limit: 191
+    t.integer  "lastTry",     limit: 4
+    t.integer  "user_id",     limit: 4
     t.boolean  "archived"
-    t.integer  "scorer_id",       limit: 4
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.string   "scorer_type",     limit: 255
+    t.integer  "scorer_id",   limit: 4
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+    t.string   "scorer_type", limit: 255
   end
 
   add_index "cases", ["scorer_type"], name: "index_cases_on_scorer_type", length: {"scorer_type"=>191}, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200115131622) do
+ActiveRecord::Schema.define(version: 20200115152546) do
 
   create_table "annotations", force: :cascade do |t|
     t.text     "message",    limit: 65535
@@ -49,7 +49,7 @@ ActiveRecord::Schema.define(version: 20200115131622) do
   add_index "case_scores", ["user_id"], name: "user_id", using: :btree
 
   create_table "cases", force: :cascade do |t|
-    t.string   "caseName",    limit: 191
+    t.string   "case_name",   limit: 191
     t.integer  "lastTry",     limit: 4
     t.integer  "user_id",     limit: 4
     t.boolean  "archived"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200115020540) do
+ActiveRecord::Schema.define(version: 20200115021550) do
 
   create_table "annotations", force: :cascade do |t|
     t.text     "message",    limit: 65535
@@ -205,7 +205,7 @@ ActiveRecord::Schema.define(version: 20200115020540) do
 
   create_table "tries", force: :cascade do |t|
     t.integer  "tryNo",          limit: 4
-    t.text     "queryParams",    limit: 65535
+    t.text     "query_params",   limit: 65535
     t.integer  "case_id",        limit: 4
     t.string   "field_spec",     limit: 500
     t.string   "search_url",     limit: 500

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200113154244) do
+ActiveRecord::Schema.define(version: 20200115015024) do
 
   create_table "annotations", force: :cascade do |t|
     t.text     "message",    limit: 65535
@@ -50,8 +50,6 @@ ActiveRecord::Schema.define(version: 20200113154244) do
 
   create_table "cases", force: :cascade do |t|
     t.string   "caseName",        limit: 191
-    t.string   "search_url",      limit: 500
-    t.string   "fieldSpec",       limit: 500
     t.integer  "lastTry",         limit: 4
     t.integer  "user_id",         limit: 4
     t.integer  "displayPosition", limit: 4
@@ -210,7 +208,7 @@ ActiveRecord::Schema.define(version: 20200113154244) do
     t.integer  "tryNo",          limit: 4
     t.text     "queryParams",    limit: 65535
     t.integer  "case_id",        limit: 4
-    t.string   "fieldSpec",      limit: 500
+    t.string   "field_spec",     limit: 500
     t.string   "search_url",     limit: 500
     t.string   "name",           limit: 50
     t.string   "search_engine",  limit: 50,    default: "solr"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200113123124) do
+ActiveRecord::Schema.define(version: 20200113154244) do
 
   create_table "annotations", force: :cascade do |t|
     t.text     "message",    limit: 65535
@@ -50,7 +50,7 @@ ActiveRecord::Schema.define(version: 20200113123124) do
 
   create_table "cases", force: :cascade do |t|
     t.string   "caseName",        limit: 191
-    t.string   "searchUrl",       limit: 500
+    t.string   "search_url",      limit: 500
     t.string   "fieldSpec",       limit: 500
     t.integer  "lastTry",         limit: 4
     t.integer  "user_id",         limit: 4
@@ -211,7 +211,7 @@ ActiveRecord::Schema.define(version: 20200113123124) do
     t.text     "queryParams",    limit: 65535
     t.integer  "case_id",        limit: 4
     t.string   "fieldSpec",      limit: 500
-    t.string   "searchUrl",      limit: 500
+    t.string   "search_url",     limit: 500
     t.string   "name",           limit: 50
     t.string   "search_engine",  limit: 50,    default: "solr"
     t.boolean  "escape_query",                 default: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200115021550) do
+ActiveRecord::Schema.define(version: 20200115131622) do
 
   create_table "annotations", force: :cascade do |t|
     t.text     "message",    limit: 65535
@@ -204,7 +204,7 @@ ActiveRecord::Schema.define(version: 20200115021550) do
   add_index "teams_scorers", ["team_id"], name: "index_teams_scorers_on_team_id", using: :btree
 
   create_table "tries", force: :cascade do |t|
-    t.integer  "tryNo",          limit: 4
+    t.integer  "try_number",     limit: 4
     t.text     "query_params",   limit: 65535
     t.integer  "case_id",        limit: 4
     t.string   "field_spec",     limit: 500
@@ -218,7 +218,7 @@ ActiveRecord::Schema.define(version: 20200115021550) do
   end
 
   add_index "tries", ["case_id"], name: "case_id", using: :btree
-  add_index "tries", ["tryNo"], name: "ix_queryparam_tryNo", using: :btree
+  add_index "tries", ["try_number"], name: "ix_queryparam_tryNo", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "username",               limit: 80

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200115152546) do
+ActiveRecord::Schema.define(version: 20200115205420) do
 
   create_table "annotations", force: :cascade do |t|
     t.text     "message",    limit: 65535
@@ -49,14 +49,14 @@ ActiveRecord::Schema.define(version: 20200115152546) do
   add_index "case_scores", ["user_id"], name: "user_id", using: :btree
 
   create_table "cases", force: :cascade do |t|
-    t.string   "case_name",   limit: 191
-    t.integer  "lastTry",     limit: 4
-    t.integer  "user_id",     limit: 4
+    t.string   "case_name",       limit: 191
+    t.integer  "last_try_number", limit: 4
+    t.integer  "user_id",         limit: 4
     t.boolean  "archived"
-    t.integer  "scorer_id",   limit: 4
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-    t.string   "scorer_type", limit: 255
+    t.integer  "scorer_id",       limit: 4
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.string   "scorer_type",     limit: 255
   end
 
   add_index "cases", ["scorer_type"], name: "index_cases_on_scorer_type", length: {"scorer_type"=>191}, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200111143938) do
+ActiveRecord::Schema.define(version: 20200113123124) do
 
   create_table "annotations", force: :cascade do |t|
     t.text     "message",    limit: 65535
@@ -214,7 +214,7 @@ ActiveRecord::Schema.define(version: 20200111143938) do
     t.string   "searchUrl",      limit: 500
     t.string   "name",           limit: 50
     t.string   "search_engine",  limit: 50,    default: "solr"
-    t.boolean  "escapeQuery",                  default: true
+    t.boolean  "escape_query",                 default: true
     t.integer  "number_of_rows", limit: 4,     default: 10
     t.datetime "created_at",                                    null: false
     t.datetime "updated_at",                                    null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200110023326) do
+ActiveRecord::Schema.define(version: 20200111143938) do
 
   create_table "annotations", force: :cascade do |t|
     t.text     "message",    limit: 65535
@@ -213,7 +213,7 @@ ActiveRecord::Schema.define(version: 20200110023326) do
     t.string   "fieldSpec",      limit: 500
     t.string   "searchUrl",      limit: 500
     t.string   "name",           limit: 50
-    t.string   "searchEngine",   limit: 50,    default: "solr"
+    t.string   "search_engine",  limit: 50,    default: "solr"
     t.boolean  "escapeQuery",                  default: true
     t.integer  "number_of_rows", limit: 4,     default: 10
     t.datetime "created_at",                                    null: false

--- a/db/test_seeds.rb
+++ b/db/test_seeds.rb
@@ -214,7 +214,7 @@ es_case.update caseName: 'ES CASE'
 es_try = es_case.tries.best
 es_params = {
   search_engine: :es,
-  searchUrl:    Try::DEFAULTS[:es][:search_url],
+  search_url:   Try::DEFAULTS[:es][:search_url],
   fieldSpec:    Try::DEFAULTS[:es][:field_spec],
   queryParams:  Try::DEFAULTS[:es][:query_params],
 }

--- a/db/test_seeds.rb
+++ b/db/test_seeds.rb
@@ -216,7 +216,7 @@ es_params = {
   search_engine: :es,
   search_url:   Try::DEFAULTS[:es][:search_url],
   field_spec:   Try::DEFAULTS[:es][:field_spec],
-  queryParams:  Try::DEFAULTS[:es][:query_params],
+  query_params: Try::DEFAULTS[:es][:query_params],
 }
 es_try.update es_params
 print_case_info es_case

--- a/db/test_seeds.rb
+++ b/db/test_seeds.rb
@@ -215,7 +215,7 @@ es_try = es_case.tries.best
 es_params = {
   search_engine: :es,
   search_url:   Try::DEFAULTS[:es][:search_url],
-  fieldSpec:    Try::DEFAULTS[:es][:field_spec],
+  field_spec:   Try::DEFAULTS[:es][:field_spec],
   queryParams:  Try::DEFAULTS[:es][:query_params],
 }
 es_try.update es_params

--- a/db/test_seeds.rb
+++ b/db/test_seeds.rb
@@ -189,11 +189,11 @@ puts "End of seeding users................"
 puts "Seeding cases................"
 
 def print_case_info the_case
-  puts "Seeded case: name: #{the_case.caseName}, ID: #{the_case.id} for: #{the_case.user.username}"
+  puts "Seeded case: name: #{the_case.case_name}, ID: #{the_case.id} for: #{the_case.user.username}"
 end
 
 unless two_case_user.cases.count == 2
-  second_case = two_case_user.cases.create caseName: 'Second Case'
+  second_case = two_case_user.cases.create case_name: 'Second Case'
   print_case_info second_case
 end
 
@@ -202,7 +202,7 @@ end
 ######################################
 
 solr_case = solr_case_user.cases.first
-solr_case.update caseName: 'SOLR CASE'
+solr_case.update case_name: 'SOLR CASE'
 print_case_info solr_case
 
 ######################################
@@ -210,7 +210,7 @@ print_case_info solr_case
 ######################################
 
 es_case = es_case_user.cases.first
-es_case.update caseName: 'ES CASE'
+es_case.update case_name: 'ES CASE'
 es_try = es_case.tries.best
 es_params = {
   search_engine: :es,
@@ -263,7 +263,7 @@ puts "Seeding ratings................"
 search_url = "http://quepid-solr.dev.o19s.com/solr/statedecoded"
 
 tens_of_queries_case = tens_of_queries_user.cases.first
-tens_of_queries_case.update caseName: '10s of Queries'
+tens_of_queries_case.update case_name: '10s of Queries'
 
 unless tens_of_queries_case.queries.count >= 20
   generator = RatingsGenerator.new search_url, { number: 20 }
@@ -321,7 +321,7 @@ if ENV['LARGE_SEEDS']
   print_user_info user_params
 
   hundreds_of_queries_case = hundreds_of_queries_user.cases.first
-  hundreds_of_queries_case.update caseName: '100s of Queries'
+  hundreds_of_queries_case.update case_name: '100s of Queries'
 
   unless hundreds_of_queries_case.queries.count >= 200
     generator = RatingsGenerator.new search_url, { number: 200 }
@@ -336,7 +336,7 @@ if ENV['LARGE_SEEDS']
   end
 
   thousands_of_queries_case = thousands_of_queries_user.cases.first
-  thousands_of_queries_case.update caseName: '1000s of Queries'
+  thousands_of_queries_case.update case_name: '1000s of Queries'
 
   unless thousands_of_queries_case.queries.count >= 2000
     generator = RatingsGenerator.new search_url, { number: 2000 }

--- a/db/test_seeds.rb
+++ b/db/test_seeds.rb
@@ -213,7 +213,7 @@ es_case = es_case_user.cases.first
 es_case.update caseName: 'ES CASE'
 es_try = es_case.tries.best
 es_params = {
-  searchEngine: :es,
+  search_engine: :es,
   searchUrl:    Try::DEFAULTS[:es][:search_url],
   fieldSpec:    Try::DEFAULTS[:es][:field_spec],
   queryParams:  Try::DEFAULTS[:es][:query_params],

--- a/lib/analytics/google_analytics/events.rb
+++ b/lib/analytics/google_analytics/events.rb
@@ -138,7 +138,7 @@ module Analytics
         data = {
           category: 'Cases',
           action:   'Created a Case',
-          label:    the_case.caseName,
+          label:    the_case.case_name,
           value:    user.cases.count,
           bounce:   false,
         }
@@ -156,7 +156,7 @@ module Analytics
         data = {
           category: 'Cases',
           action:   'Updated a Case',
-          label:    the_case.caseName,
+          label:    the_case.case_name,
           value:    nil,
           bounce:   false,
         }
@@ -174,7 +174,7 @@ module Analytics
         data = {
           category: 'Cases',
           action:   'Archived a Case',
-          label:    the_case.caseName,
+          label:    the_case.case_name,
           value:    nil,
           bounce:   false,
         }
@@ -194,7 +194,7 @@ module Analytics
         data = {
           category: 'Case Tries',
           action:   'Saved a Case Try',
-          label:    the_case.caseName,
+          label:    the_case.case_name,
           value:    the_try.try_number,
           bounce:   false,
         }
@@ -214,7 +214,7 @@ module Analytics
         data = {
           category: 'Cases',
           action:   'Shared a Case',
-          label:    the_case.caseName,
+          label:    the_case.case_name,
           value:    nil,
           bounce:   false,
         }

--- a/lib/analytics/google_analytics/events.rb
+++ b/lib/analytics/google_analytics/events.rb
@@ -195,7 +195,7 @@ module Analytics
           category: 'Case Tries',
           action:   'Saved a Case Try',
           label:    the_case.caseName,
-          value:    the_try.tryNo,
+          value:    the_try.try_number,
           bounce:   false,
         }
 

--- a/spec/javascripts/angular/controllers/queryParams_spec.js
+++ b/spec/javascripts/angular/controllers/queryParams_spec.js
@@ -17,7 +17,7 @@ describe('Controller: QueryparamsCtrl', function () {
     var queryParams = 'q=#$query##';
     var curatorVars = {};
 
-    testTry = new TryFactory({ tryNo: 0, queryParams: queryParams, curatorVars: curatorVars });
+    testTry = new TryFactory({ tryNo: 0, query_params: queryParams, curatorVars: curatorVars });
     scope.settings = {selectedTry: testTry};
 
     QueryparamsCtrl = $controller('QueryParamsCtrl', {

--- a/spec/javascripts/angular/services/caseSvc_spec.js
+++ b/spec/javascripts/angular/services/caseSvc_spec.js
@@ -581,7 +581,6 @@ describe('Service: caseSvc', function () {
       {
         'caseNo': 1,
         'caseName': 'test case 1',
-        'displayPosition': 0,
         'lastTry': 3,
         'owned': true
       },
@@ -589,7 +588,6 @@ describe('Service: caseSvc', function () {
         'caseNo': 2,
         'caseName': 'test case 2',
         'lastTry': 4,
-        'displayPosition': 0,
         'owned': true
       }
     ];

--- a/spec/javascripts/angular/services/caseSvc_spec.js
+++ b/spec/javascripts/angular/services/caseSvc_spec.js
@@ -9,25 +9,25 @@ describe('Service: caseSvc', function () {
     allCases: [
       {
         'caseNo':   1,
-        'caseName': 'test case',
+        'case_name': 'test case',
         'lastTry':  4,
         'owned':    true
       },
       {
         'caseNo':   2,
-        'caseName': 'test case 2',
+        'case_name': 'test case 2',
         'lastTry':  3,
         'owned':    true
       },
       {
         'caseNo':   3,
-        'caseName': 'test case 3',
+        'case_name': 'test case 3',
         'lastTry':  0,
         'owned':    false
       },
       {
         'caseNo':   4,
-        'caseName': 'test case 4',
+        'case_name': 'test case 4',
         'lastTry':  0,
         'owned':    false
       }
@@ -94,7 +94,7 @@ describe('Service: caseSvc', function () {
     var mockNewTry = {
       lastTry: 1,
       caseNo: 5,
-      caseName: 'new case'
+      case_name: 'new case'
     };
 
     it('filters cases', function() {
@@ -123,7 +123,7 @@ describe('Service: caseSvc', function () {
       $httpBackend.flush();
       caseSvc.selectCase(mockNewTry.caseNo);
       var newCase = caseSvc.getSelectedCase();
-      expect(newCase.caseName).toBe(mockNewTry.caseName);
+      expect(newCase.caseName).toBe(mockNewTry.case_name);
     });
 
     it('renames case with expected name', function() {
@@ -132,7 +132,7 @@ describe('Service: caseSvc', function () {
       $httpBackend.flush();
       caseSvc.selectCase(mockNewTry.caseNo);
       var newCase = caseSvc.getSelectedCase();
-      expect(newCase.caseName).toBe(mockNewTry.caseName);
+      expect(newCase.caseName).toBe(mockNewTry.case_name);
 
       var newName = 'blah';
       $httpBackend.expectPUT('/api/cases/' + newCase.caseNo).respond(201, {});
@@ -152,14 +152,14 @@ describe('Service: caseSvc', function () {
       var name = 'El Case-o-dilla';
       $httpBackend.expectPOST('/api/cases', function(content) {
         var addCaseParsed = angular.fromJson(content);
-        return addCaseParsed.caseName === name;
+        return addCaseParsed.case_name === name;
       }
       ).respond(201, mockNewTry);
       caseSvc.createCase(name);
       $httpBackend.flush();
       caseSvc.selectCase(mockNewTry.caseNo);
       var newCase = caseSvc.getSelectedCase();
-      expect(newCase.caseName).toBe(mockNewTry.caseName);
+      expect(newCase.caseName).toBe(mockNewTry.case_name);
 
     });
 
@@ -174,7 +174,7 @@ describe('Service: caseSvc', function () {
       $httpBackend.flush();
       caseSvc.selectCase(mockNewTry.caseNo);
       var newCase = caseSvc.getSelectedCase();
-      expect(newCase.caseName).toBe(mockNewTry.caseName);
+      expect(newCase.caseName).toBe(mockNewTry.case_name);
     });
 
     it('creates cases with passed in tries', function() {
@@ -188,7 +188,7 @@ describe('Service: caseSvc', function () {
       $httpBackend.flush();
       caseSvc.selectCase(mockNewTry.caseNo);
       var newCase = caseSvc.getSelectedCase();
-      expect(newCase.caseName).toBe(mockNewTry.caseName);
+      expect(newCase.caseName).toBe(mockNewTry.case_name);
     });
 
     it('gets a case by number', function() {
@@ -256,7 +256,7 @@ describe('Service: caseSvc', function () {
       allCases: [
         {
           'caseNo':   6,
-          'caseName': 'archived',
+          'case_name': 'archived',
           'lastTry':  4
         }
       ]
@@ -293,7 +293,7 @@ describe('Service: caseSvc', function () {
       expect(called).toBe(2);
     });
 
-    it('refetcth archive', function() {
+    it('refetch archive', function() {
       $httpBackend.expectGET('/api/cases?archived=true').respond(200, archivedCases);
       var called = 0;
       caseSvc.fetchArchived()
@@ -330,7 +330,7 @@ describe('Service: caseSvc', function () {
       for (var i = 0; i < numArchived - 1; i++) {
         var newCase = {
           'caseNo':   baseNo + (i + 1),
-          'caseName': baseName + (i + 1),
+          'case_name': baseName + (i + 1),
           'lastTry':  i
         };
         archive.allCases.push(newCase);
@@ -392,12 +392,12 @@ describe('Service: caseSvc', function () {
         allCases: [
           {
             'caseNo':   2,
-            'caseName': 'test case 2',
+            'case_name': 'test case 2',
             'lastTry':  3
           },
           {
             'caseNo':   1,
-            'caseName': 'test case',
+            'case_name': 'test case',
             'lastTry':  4,
           }
         ]
@@ -421,13 +421,13 @@ describe('Service: caseSvc', function () {
     var cases = [
       {
         'caseNo': 1,
-        'caseName': 'test case 1',
+        'case_name': 'test case 1',
         'lastTry': 3,
         'owned': true
       },
       {
         'caseNo': 2,
-        'caseName': 'test case 2',
+        'case_name': 'test case 2',
         'lastTry': 4,
         'owned': true
       }
@@ -533,7 +533,7 @@ describe('Service: caseSvc', function () {
   describe('Fetch last score', function() {
     var caseData = {
       'caseNo':   1,
-      'caseName': 'test case 1',
+      'case_name': 'test case 1',
       'lastTry':  3,
       'owned':    true
     };
@@ -580,13 +580,13 @@ describe('Service: caseSvc', function () {
     var cases = [
       {
         'caseNo': 1,
-        'caseName': 'test case 1',
+        'case_name': 'test case 1',
         'lastTry': 3,
         'owned': true
       },
       {
         'caseNo': 2,
-        'caseName': 'test case 2',
+        'case_name': 'test case 2',
         'lastTry': 4,
         'owned': true
       }
@@ -596,7 +596,7 @@ describe('Service: caseSvc', function () {
 
     var expectedResponse = {
       'caseNo':   3,
-      'caseName': 'Clone: test case 1',
+      'case_name': 'Clone: test case 1',
       'lastTry':  0,
       'owned':    true
     };

--- a/spec/javascripts/angular/services/caseSvc_spec.js
+++ b/spec/javascripts/angular/services/caseSvc_spec.js
@@ -252,18 +252,18 @@ describe('Service: caseSvc', function () {
       expect(caseSvc.getSelectedCase().caseNo).toEqual(2);
     });
 
-    var archivedCases = {
+    var archivedCasesAPIResponse = {
       allCases: [
         {
           'caseNo':   6,
           'case_name': 'archived',
-          'lastTry':  4
+          'last_try_number':  4
         }
       ]
     };
 
     it('add back archived case', function() {
-      $httpBackend.expectGET('/api/cases?archived=true').respond(200, archivedCases);
+      $httpBackend.expectGET('/api/cases?archived=true').respond(200, archivedCasesAPIResponse);
       var called = 0;
       caseSvc.fetchArchived()
       .then(function() {
@@ -278,7 +278,7 @@ describe('Service: caseSvc', function () {
       expect(called).toBe(1);
 
       var archivedCaseNo = caseSvc.archived[0].caseNo;
-      $httpBackend.expectPUT('/api/cases/' + archivedCaseNo).respond(200, archivedCases.allCases[0]);
+      $httpBackend.expectPUT('/api/cases/' + archivedCaseNo).respond(200, archivedCasesAPIResponse.allCases[0]);
 
       var casesBefore = caseSvc.allCases.length;
       caseSvc.undeleteCase(caseSvc.archived[0]).then(function() {
@@ -294,7 +294,7 @@ describe('Service: caseSvc', function () {
     });
 
     it('refetch archive', function() {
-      $httpBackend.expectGET('/api/cases?archived=true').respond(200, archivedCases);
+      $httpBackend.expectGET('/api/cases?archived=true').respond(200, archivedCasesAPIResponse);
       var called = 0;
       caseSvc.fetchArchived()
       .then(function() {
@@ -308,7 +308,7 @@ describe('Service: caseSvc', function () {
       $httpBackend.flush();
       expect(called).toBe(1);
 
-      $httpBackend.expectGET('/api/cases?archived=true').respond(200, archivedCases);
+      $httpBackend.expectGET('/api/cases?archived=true').respond(200, archivedCasesAPIResponse);
       caseSvc.fetchArchived()
       .then(function() {
         called++;
@@ -323,9 +323,9 @@ describe('Service: caseSvc', function () {
     });
 
     it('larger archive', function() {
-      var archive = angular.copy(archivedCases);
-      var baseNo = archive.allCases[0].caseNo;
-      var baseName = archive.allCases[0].caseName;
+      var archiveAPIResponse = angular.copy(archivedCasesAPIResponse);
+      var baseNo = archiveAPIResponse.allCases[0].caseNo;
+      var baseName = archiveAPIResponse.allCases[0].case_name;
       var numArchived = 10;
       for (var i = 0; i < numArchived - 1; i++) {
         var newCase = {
@@ -333,10 +333,10 @@ describe('Service: caseSvc', function () {
           'case_name': baseName + (i + 1),
           'lastTry':  i
         };
-        archive.allCases.push(newCase);
+        archiveAPIResponse.allCases.push(newCase);
       }
 
-      $httpBackend.expectGET('/api/cases?archived=true').respond(200, archive);
+      $httpBackend.expectGET('/api/cases?archived=true').respond(200, archiveAPIResponse);
       var called = 0;
       caseSvc.fetchArchived()
       .then(function() {
@@ -351,7 +351,7 @@ describe('Service: caseSvc', function () {
       angular.forEach(caseSvc.archived, function(aCase) {
         if (aCase.caseNo % 2 === 1) {
           undeleted.push(aCase.caseNo);
-          $httpBackend.expectPUT('/api/cases/' + aCase.caseNo).respond(200, archive.allCases[aCase.caseNo - baseNo]);
+          $httpBackend.expectPUT('/api/cases/' + aCase.caseNo).respond(200, archiveAPIResponse.allCases[aCase.caseNo - baseNo]);
           caseSvc.undeleteCase(aCase)
           .then(function() {
             called++;

--- a/spec/javascripts/angular/services/settingsSvc_spec.js
+++ b/spec/javascripts/angular/services/settingsSvc_spec.js
@@ -20,7 +20,7 @@ describe('Service: settingsSvc', function () {
        'args': {'q': ['#$query##'],
                     'fq': ['title:foo', 'sub:bar']},
        'search_url': 'http://example.com:1234/solr/collection1',
-       'fieldSpec': 'thumb:field1 title sub',
+       'field_spec': 'thumb:field1 title sub',
        'escape_query': true,
        'name': 'try 0',
       },
@@ -31,7 +31,7 @@ describe('Service: settingsSvc', function () {
        'args': {'q': ['#$query##'],
                     'fq': ['title:foo', 'sub:2']},
        'search_url': 'http://example.com:1234/solr/collection1',
-       'fieldSpec': 'thumb:field1 title sub',
+       'field_spec': 'thumb:field1 title sub',
        'escape_query': true,
        'name': 'try 1',
       }
@@ -48,7 +48,7 @@ describe('Service: settingsSvc', function () {
        'args': {'q': ['#$query##'],
                     'fq': ['title:foo', 'sub:bar']},
        'search_url': 'http://doug.com:1234/solr/collection1',
-       'fieldSpec': 'thumb:field1 title sub2',
+       'field_spec': 'thumb:field1 title sub2',
        'escape_query': true,
        'name': 'try 0',
       },
@@ -59,7 +59,7 @@ describe('Service: settingsSvc', function () {
        'args': {'q': ['#$query##'],
                     'bq': ['title:foo^5', 'sub:2']},
        'search_url': 'http://doug.com:1234/solr/collection1',
-       'fieldSpec': 'thumb:field1 title sub2',
+       'field_spec': 'thumb:field1 title sub2',
        'escape_query': true,
        'name': 'try 1',
       },
@@ -71,7 +71,7 @@ describe('Service: settingsSvc', function () {
                     'bq': ['title:foo^5', 'sub:2'],
                     'qf': ['title']},
        'search_url': 'http://doug.com:1234/solr/collection1',
-       'fieldSpec': 'thumb:field1 title sub2',
+       'field_spec': 'thumb:field1 title sub2',
        'escape_query': true,
        'name': 'try 2',
       }
@@ -110,7 +110,7 @@ describe('Service: settingsSvc', function () {
     settingsSvc.bootstrap(0, 0)
     .then(function() {
       var settingsCpy = settingsSvc.editableSettings();
-      expect(settingsCpy.fieldSpec).toBe(mockSettings0.tries[0].fieldSpec);
+      expect(settingsCpy.fieldSpec).toBe(mockSettings0.tries[0].field_spec);
       expect(settingsCpy.searchUrl).toBe(mockSettings0.tries[0].search_url);
       expect(settingsCpy.tries[0].queryParams)
             .toEqual(mockSettings0.tries[0].queryParams);
@@ -135,8 +135,8 @@ describe('Service: settingsSvc', function () {
          'args': {'q': ['#$query##'],
                       'bq': ['title:foo^5', 'sub:2'],
                       'qf': ['title']},
-         'searchUrl': 'http://doug.com:1234/solr/collection1',
-         'fieldSpec': 'thumb:field1 title sub2',
+         'search_url': 'http://doug.com:1234/solr/collection1',
+         'field_spec': 'thumb:field1 title sub2',
          'name': 'try 0'
         }
       ]
@@ -187,7 +187,7 @@ describe('Service: settingsSvc', function () {
     settingsSvc.bootstrap()
     .then(function() {
       var settingsCpy = settingsSvc.editableSettings();
-      expect(settingsCpy.fieldSpec).toBe(mockSettings1.tries[0].fieldSpec);
+      expect(settingsCpy.fieldSpec).toBe(mockSettings1.tries[0].field_spec);
       expect(settingsCpy.searchUrl).toBe(mockSettings1.tries[0].search_url);
       expect(settingsCpy.tries[0].queryParams)
             .toEqual(mockSettings1.tries[0].queryParams);
@@ -207,26 +207,12 @@ describe('Service: settingsSvc', function () {
 
   });
 
-  var mockSettingsAddResp = {
-    tries: [
-      {'queryParams': 'ADDED',
-       'curatorVars': {},
-       'args': {},
-       'searchUrl': 'http://doug.com:1234/solr/collection1',
-       'fieldSpec': 'thumb:field1 title sub2',
-       'tryNo': 2,
-       'name': 'try 2'
-      },
-    ]
-
-  };
-
   var mockTry = {
     'queryParams': 'ADDED',
     'curatorVars': {},
     'args': {},
-    'searchUrl': 'http://doug.com:1234/solr/collection1',
-    'fieldSpec': 'thumb:field1 title sub2',
+    'search_url': 'http://doug.com:1234/solr/collection1',
+    'field_spec': 'thumb:field1 title sub2',
     'tryNo': 2,
     'name': 'try 2'
   };
@@ -259,7 +245,7 @@ describe('Service: settingsSvc', function () {
     },
     curatorVars: { titleboost: 5 },
     escape_query: false,
-    fieldSpec:   'CHANGED',
+    field_spec:   'CHANGED',
     name:        'try 2',
     queryParams: 'q=#$query##&bq=title:##titleboost##&bq=sub:2&qf=title',
     search_url:   'http://doug.com:1234/solr/collection1',
@@ -305,20 +291,6 @@ describe('Service: settingsSvc', function () {
     expect(currSettings.selectedTry.escapeQuery).toBe(false);
   });
 
-  var mockSettingsVersionResp = {
-    args:        {
-      'q':    ['#$query##'],
-      'fq':   ['title:foo', 'sub:bar'],
-      'new':  ['10']
-    },
-    curatorVars: { newvar: 10 },
-    escape_query: true,
-    fieldSpec:   'thumb:field1 title sub2',
-    queryParams: 'q=#$query##&fq=title:foo&fq=sub:bar&new=##newvar##',
-    search_url:   'http://doug.com:1234/solr/collection1',
-    tryNo:       2,
-  };
-
   var mockSettingsAddNewVarsResp = {
     'tryNo': 2,
     'queryParams': 'q=#$query##&fq=title:foo&fq=sub:bar&new=##newvar##',
@@ -330,7 +302,7 @@ describe('Service: settingsSvc', function () {
     },
     'search_url': 'http://doug.com:1234/solr/collection1',
     'escape_query': true,
-    'fieldSpec': 'thumb:field1 title sub2'
+    'field_spec': 'thumb:field1 title sub2'
   };
 
   it('gathers new curatorVars on submit', function() {

--- a/spec/javascripts/angular/services/settingsSvc_spec.js
+++ b/spec/javascripts/angular/services/settingsSvc_spec.js
@@ -20,6 +20,7 @@ describe('Service: settingsSvc', function () {
        'args': {'q': ['#$query##'],
                     'fq': ['title:foo', 'sub:bar']},
        'search_url': 'http://example.com:1234/solr/collection1',
+       'search_engine': 'solr',
        'field_spec': 'thumb:field1 title sub',
        'escape_query': true,
        'name': 'try 0',
@@ -31,6 +32,7 @@ describe('Service: settingsSvc', function () {
        'args': {'q': ['#$query##'],
                     'fq': ['title:foo', 'sub:2']},
        'search_url': 'http://example.com:1234/solr/collection1',
+       'search_engine': 'solr',
        'field_spec': 'thumb:field1 title sub',
        'escape_query': true,
        'name': 'try 1',
@@ -48,6 +50,7 @@ describe('Service: settingsSvc', function () {
        'args': {'q': ['#$query##'],
                     'fq': ['title:foo', 'sub:bar']},
        'search_url': 'http://doug.com:1234/solr/collection1',
+       'search_engine':'solr',
        'field_spec': 'thumb:field1 title sub2',
        'escape_query': true,
        'name': 'try 0',
@@ -59,6 +62,7 @@ describe('Service: settingsSvc', function () {
        'args': {'q': ['#$query##'],
                     'bq': ['title:foo^5', 'sub:2']},
        'search_url': 'http://doug.com:1234/solr/collection1',
+       'search_engine':'solr',
        'field_spec': 'thumb:field1 title sub2',
        'escape_query': true,
        'name': 'try 1',
@@ -71,6 +75,7 @@ describe('Service: settingsSvc', function () {
                     'bq': ['title:foo^5', 'sub:2'],
                     'qf': ['title']},
        'search_url': 'http://doug.com:1234/solr/collection1',
+       'search_engine':'solr',
        'field_spec': 'thumb:field1 title sub2',
        'escape_query': true,
        'name': 'try 2',
@@ -136,6 +141,7 @@ describe('Service: settingsSvc', function () {
                       'bq': ['title:foo^5', 'sub:2'],
                       'qf': ['title']},
          'search_url': 'http://doug.com:1234/solr/collection1',
+         'search_engine':'solr',
          'field_spec': 'thumb:field1 title sub2',
          'name': 'try 0'
         }
@@ -212,6 +218,7 @@ describe('Service: settingsSvc', function () {
     'curatorVars': {},
     'args': {},
     'search_url': 'http://doug.com:1234/solr/collection1',
+    'search_engine':'solr',
     'field_spec': 'thumb:field1 title sub2',
     'try_number': 2,
     'name': 'try 2'
@@ -243,12 +250,13 @@ describe('Service: settingsSvc', function () {
       'bq': ['title:foo^5', 'sub:2'],
       'qf': ['title']
     },
-    curatorVars: { titleboost: 5 },
-    escape_query: false,
-    field_spec:   'CHANGED',
-    name:         'try 2',
-    query_params: 'q=#$query##&bq=title:##titleboost##&bq=sub:2&qf=title',
-    search_url:   'http://doug.com:1234/solr/collection1',
+    curatorVars:  { titleboost: 5 },
+    escape_query:  false,
+    field_spec:    'CHANGED',
+    name:          'try 2',
+    query_params:  'q=#$query##&bq=title:##titleboost##&bq=sub:2&qf=title',
+    search_url:    'http://doug.com:1234/solr/collection1',
+    search_engine: 'solr',
     try_number:    2,
   };
 
@@ -286,8 +294,6 @@ describe('Service: settingsSvc', function () {
     $httpBackend.verifyNoOutstandingExpectation();
 
     var currSettings = settingsSvc.editableSettings();
-    console.log("Here comes test");
-    console.log(currSettings.selectedTry);
     expect(currSettings.selectedTry.escapeQuery).toBe(false);
   });
 
@@ -301,6 +307,7 @@ describe('Service: settingsSvc', function () {
       'new':  ['10']
     },
     'search_url': 'http://doug.com:1234/solr/collection1',
+    'search_engine':'solr',
     'escape_query': true,
     'field_spec': 'thumb:field1 title sub2'
   };
@@ -447,6 +454,7 @@ describe('Service: settingsSvc', function () {
      'args':        {'q': ['#$query##'],
                      'fq': ['title:foo', 'sub:bar']},
      'search_url':  'http://doug.com:1234/solr/collection1',
+     'search_engine':'solr',
      'field_spec':    'thumb:field1 title sub2',
      'escape_query': true,
      'name':        'try 3'

--- a/spec/javascripts/angular/services/settingsSvc_spec.js
+++ b/spec/javascripts/angular/services/settingsSvc_spec.js
@@ -14,7 +14,7 @@ describe('Service: settingsSvc', function () {
   var mockSettings0 = {
     tries: [
       {
-       'tryNo': 0,
+       'try_number': 0,
        'query_params': 'q=#$query##&fq=title:foo&fq=sub:bar',
        'curatorVars': {},
        'args': {'q': ['#$query##'],
@@ -25,7 +25,7 @@ describe('Service: settingsSvc', function () {
        'name': 'try 0',
       },
       {
-       'tryNo': 1,
+       'try_number': 1,
        'query_params': 'q=#$query##&fq=title:2&fq=ub:2',
        'curatorVars': {},
        'args': {'q': ['#$query##'],
@@ -42,7 +42,7 @@ describe('Service: settingsSvc', function () {
   var mockSettings1 = {
     tries: [
       {
-       'tryNo': 0,
+       'try_number': 0,
        'query_params': 'q=#$query##&fq=title:foo&fq=sub:bar',
        'curatorVars': {},
        'args': {'q': ['#$query##'],
@@ -53,7 +53,7 @@ describe('Service: settingsSvc', function () {
        'name': 'try 0',
       },
       {
-       'tryNo': 1,
+       'try_number': 1,
        'query_params': 'q=#$query##&bq=title:foo^##titleboost##&bq=sub:2',
        'curatorVars': {titleboost: 5},
        'args': {'q': ['#$query##'],
@@ -64,7 +64,7 @@ describe('Service: settingsSvc', function () {
        'name': 'try 1',
       },
       {
-       'tryNo': 2,
+       'try_number': 2,
        'query_params': 'q=#$query##&bq=title:##titleboost##&bq=sub:2&qf=title',
        'curatorVars': {titleboost: 5},
        'args': {'q': ['#$query##'],
@@ -129,7 +129,7 @@ describe('Service: settingsSvc', function () {
     var mockCvSettings = {
       tries: [
         {
-         'tryNo': 0,
+         'try_number': 0,
          'query_params': 'q=#$query##&bq=title:##titleboost##&bq=sub:2&qf=title',
          'curatorVars': {titleboost: 5, missing: 11},
          'args': {'q': ['#$query##'],
@@ -213,7 +213,7 @@ describe('Service: settingsSvc', function () {
     'args': {},
     'search_url': 'http://doug.com:1234/solr/collection1',
     'field_spec': 'thumb:field1 title sub2',
-    'tryNo': 2,
+    'try_number': 2,
     'name': 'try 2'
   };
 
@@ -246,10 +246,10 @@ describe('Service: settingsSvc', function () {
     curatorVars: { titleboost: 5 },
     escape_query: false,
     field_spec:   'CHANGED',
-    name:        'try 2',
+    name:         'try 2',
     query_params: 'q=#$query##&bq=title:##titleboost##&bq=sub:2&qf=title',
     search_url:   'http://doug.com:1234/solr/collection1',
-    tryNo:       2,
+    try_number:    2,
   };
 
   it('saves changes to fieldSpec', function() {
@@ -292,7 +292,7 @@ describe('Service: settingsSvc', function () {
   });
 
   var mockSettingsAddNewVarsResp = {
-    'tryNo': 2,
+    'try_number': 2,
     'query_params': 'q=#$query##&fq=title:foo&fq=sub:bar&new=##newvar##',
     'curatorVars': {newvar: 10},
     'args': {
@@ -343,7 +343,7 @@ describe('Service: settingsSvc', function () {
   it('handles deleting selected try', function() {
     $httpBackend.expectGET('/api/cases/0/tries')
                 .respond(200,  mockSettings1);
-    var lastTry = mockSettings1.tries[2].tryNo;
+    var lastTry = mockSettings1.tries[2].try_number;
     settingsSvc.bootstrap(0, 0);
     $httpBackend.flush();
     var settingsCpy = settingsSvc.editableSettings();
@@ -392,7 +392,7 @@ describe('Service: settingsSvc', function () {
 
   it('bootstraps with deleted tries', function() {
     var mockSettingsDel = angular.copy(mockSettings1);
-    var splicedTry = mockSettingsDel.tries[1].tryNo;
+    var splicedTry = mockSettingsDel.tries[1].try_number;
     mockSettingsDel.tries.splice(1,1);
     $httpBackend.expectGET('/api/cases/0/tries')
                 .respond(200,  mockSettingsDel);
@@ -439,15 +439,15 @@ describe('Service: settingsSvc', function () {
   });
 
   it('clones a try', function() {
-    var aTry  = mockSettings1.tries[0];
-    var url   = '/api/clone/cases/0/tries/0';
+    //var aTry  = mockSettings1.tries[0];
     var mockResponse = {
-     'tryNo':       3,
-     'query_params': aTry.query_params,
+     'try_number':   3,
+     'query_params': 'q=#$query##&fq=title:foo&fq=sub:bar',
      'curatorVars': {},
-     'args':        aTry.args,
-     'search_url':  aTry.search_url,
-     'field_spec':   aTry.field_spec,
+     'args':        {'q': ['#$query##'],
+                     'fq': ['title:foo', 'sub:bar']},
+     'search_url':  'http://doug.com:1234/solr/collection1',
+     'field_spec':    'thumb:field1 title sub2',
      'escape_query': true,
      'name':        'try 3'
     };
@@ -460,7 +460,11 @@ describe('Service: settingsSvc', function () {
     var settingsCpy = settingsSvc.editableSettings();
     var tries = settingsCpy.tries;
 
-    $httpBackend.expectPOST(url).respond(200,  mockResponse);
+    var aTry = tries[0];
+
+    $httpBackend.expectPOST('/api/clone/cases/0/tries/0')
+                .respond(200,  mockResponse);
+
     settingsSvc.duplicateTry(aTry.tryNo);
 
     $httpBackend.flush();

--- a/spec/javascripts/angular/services/settingsSvc_spec.js
+++ b/spec/javascripts/angular/services/settingsSvc_spec.js
@@ -9,6 +9,8 @@ describe('Service: settingsSvc', function () {
   var settingsSvc = null;
   var caseTryNavSvc = null;
   var $httpBackend = null;
+  // TODO think about renaming mockSettings0 to mockSettings0Api to
+  // be clear these are mocked up API calls.
   var mockSettings0 = {
     tries: [
       {
@@ -17,9 +19,9 @@ describe('Service: settingsSvc', function () {
        'curatorVars': {},
        'args': {'q': ['#$query##'],
                     'fq': ['title:foo', 'sub:bar']},
-       'searchUrl': 'http://example.com:1234/solr/collection1',
+       'search_url': 'http://example.com:1234/solr/collection1',
        'fieldSpec': 'thumb:field1 title sub',
-       'escapeQuery': true,
+       'escape_query': true,
        'name': 'try 0',
       },
       {
@@ -28,9 +30,9 @@ describe('Service: settingsSvc', function () {
        'curatorVars': {},
        'args': {'q': ['#$query##'],
                     'fq': ['title:foo', 'sub:2']},
-       'searchUrl': 'http://example.com:1234/solr/collection1',
+       'search_url': 'http://example.com:1234/solr/collection1',
        'fieldSpec': 'thumb:field1 title sub',
-       'escapeQuery': true,
+       'escape_query': true,
        'name': 'try 1',
       }
     ]
@@ -45,9 +47,9 @@ describe('Service: settingsSvc', function () {
        'curatorVars': {},
        'args': {'q': ['#$query##'],
                     'fq': ['title:foo', 'sub:bar']},
-       'searchUrl': 'http://doug.com:1234/solr/collection1',
+       'search_url': 'http://doug.com:1234/solr/collection1',
        'fieldSpec': 'thumb:field1 title sub2',
-       'escapeQuery': true,
+       'escape_query': true,
        'name': 'try 0',
       },
       {
@@ -56,9 +58,9 @@ describe('Service: settingsSvc', function () {
        'curatorVars': {titleboost: 5},
        'args': {'q': ['#$query##'],
                     'bq': ['title:foo^5', 'sub:2']},
-       'searchUrl': 'http://doug.com:1234/solr/collection1',
+       'search_url': 'http://doug.com:1234/solr/collection1',
        'fieldSpec': 'thumb:field1 title sub2',
-       'escapeQuery': true,
+       'escape_query': true,
        'name': 'try 1',
       },
       {
@@ -68,9 +70,9 @@ describe('Service: settingsSvc', function () {
        'args': {'q': ['#$query##'],
                     'bq': ['title:foo^5', 'sub:2'],
                     'qf': ['title']},
-       'searchUrl': 'http://doug.com:1234/solr/collection1',
+       'search_url': 'http://doug.com:1234/solr/collection1',
        'fieldSpec': 'thumb:field1 title sub2',
-       'escapeQuery': true,
+       'escape_query': true,
        'name': 'try 2',
       }
     ]
@@ -109,7 +111,7 @@ describe('Service: settingsSvc', function () {
     .then(function() {
       var settingsCpy = settingsSvc.editableSettings();
       expect(settingsCpy.fieldSpec).toBe(mockSettings0.tries[0].fieldSpec);
-      expect(settingsCpy.searchUrl).toBe(mockSettings0.tries[0].searchUrl);
+      expect(settingsCpy.searchUrl).toBe(mockSettings0.tries[0].search_url);
       expect(settingsCpy.tries[0].queryParams)
             .toEqual(mockSettings0.tries[0].queryParams);
       expect(settingsCpy.tries[0].curatorVarsDict())
@@ -186,7 +188,7 @@ describe('Service: settingsSvc', function () {
     .then(function() {
       var settingsCpy = settingsSvc.editableSettings();
       expect(settingsCpy.fieldSpec).toBe(mockSettings1.tries[0].fieldSpec);
-      expect(settingsCpy.searchUrl).toBe(mockSettings1.tries[0].searchUrl);
+      expect(settingsCpy.searchUrl).toBe(mockSettings1.tries[0].search_url);
       expect(settingsCpy.tries[0].queryParams)
             .toEqual(mockSettings1.tries[0].queryParams);
       expect(settingsCpy.tries[0].curatorVarsDict())
@@ -256,11 +258,11 @@ describe('Service: settingsSvc', function () {
       'qf': ['title']
     },
     curatorVars: { titleboost: 5 },
-    escapeQuery: false,
+    escape_query: false,
     fieldSpec:   'CHANGED',
     name:        'try 2',
     queryParams: 'q=#$query##&bq=title:##titleboost##&bq=sub:2&qf=title',
-    searchUrl:   'http://doug.com:1234/solr/collection1',
+    search_url:   'http://doug.com:1234/solr/collection1',
     tryNo:       2,
   };
 
@@ -298,6 +300,8 @@ describe('Service: settingsSvc', function () {
     $httpBackend.verifyNoOutstandingExpectation();
 
     var currSettings = settingsSvc.editableSettings();
+    console.log("Here comes test");
+    console.log(currSettings.selectedTry);
     expect(currSettings.selectedTry.escapeQuery).toBe(false);
   });
 
@@ -308,10 +312,10 @@ describe('Service: settingsSvc', function () {
       'new':  ['10']
     },
     curatorVars: { newvar: 10 },
-    escapeQuery: true,
+    escape_query: true,
     fieldSpec:   'thumb:field1 title sub2',
     queryParams: 'q=#$query##&fq=title:foo&fq=sub:bar&new=##newvar##',
-    searchUrl:   'http://doug.com:1234/solr/collection1',
+    search_url:   'http://doug.com:1234/solr/collection1',
     tryNo:       2,
   };
 
@@ -324,8 +328,8 @@ describe('Service: settingsSvc', function () {
       'fq':   ['title:foo', 'sub:bar'],
       'new':  ['10']
     },
-    'searchUrl': 'http://doug.com:1234/solr/collection1',
-    'escapeQuery': true,
+    'search_url': 'http://doug.com:1234/solr/collection1',
+    'escape_query': true,
     'fieldSpec': 'thumb:field1 title sub2'
   };
 

--- a/spec/javascripts/angular/services/settingsSvc_spec.js
+++ b/spec/javascripts/angular/services/settingsSvc_spec.js
@@ -15,7 +15,7 @@ describe('Service: settingsSvc', function () {
     tries: [
       {
        'tryNo': 0,
-       'queryParams': 'q=#$query##&fq=title:foo&fq=sub:bar',
+       'query_params': 'q=#$query##&fq=title:foo&fq=sub:bar',
        'curatorVars': {},
        'args': {'q': ['#$query##'],
                     'fq': ['title:foo', 'sub:bar']},
@@ -26,7 +26,7 @@ describe('Service: settingsSvc', function () {
       },
       {
        'tryNo': 1,
-       'queryParams': 'q=#$query##&fq=title:2&fq=ub:2',
+       'query_params': 'q=#$query##&fq=title:2&fq=ub:2',
        'curatorVars': {},
        'args': {'q': ['#$query##'],
                     'fq': ['title:foo', 'sub:2']},
@@ -43,7 +43,7 @@ describe('Service: settingsSvc', function () {
     tries: [
       {
        'tryNo': 0,
-       'queryParams': 'q=#$query##&fq=title:foo&fq=sub:bar',
+       'query_params': 'q=#$query##&fq=title:foo&fq=sub:bar',
        'curatorVars': {},
        'args': {'q': ['#$query##'],
                     'fq': ['title:foo', 'sub:bar']},
@@ -54,7 +54,7 @@ describe('Service: settingsSvc', function () {
       },
       {
        'tryNo': 1,
-       'queryParams': 'q=#$query##&bq=title:foo^##titleboost##&bq=sub:2',
+       'query_params': 'q=#$query##&bq=title:foo^##titleboost##&bq=sub:2',
        'curatorVars': {titleboost: 5},
        'args': {'q': ['#$query##'],
                     'bq': ['title:foo^5', 'sub:2']},
@@ -65,7 +65,7 @@ describe('Service: settingsSvc', function () {
       },
       {
        'tryNo': 2,
-       'queryParams': 'q=#$query##&bq=title:##titleboost##&bq=sub:2&qf=title',
+       'query_params': 'q=#$query##&bq=title:##titleboost##&bq=sub:2&qf=title',
        'curatorVars': {titleboost: 5},
        'args': {'q': ['#$query##'],
                     'bq': ['title:foo^5', 'sub:2'],
@@ -113,11 +113,11 @@ describe('Service: settingsSvc', function () {
       expect(settingsCpy.fieldSpec).toBe(mockSettings0.tries[0].field_spec);
       expect(settingsCpy.searchUrl).toBe(mockSettings0.tries[0].search_url);
       expect(settingsCpy.tries[0].queryParams)
-            .toEqual(mockSettings0.tries[0].queryParams);
+            .toEqual(mockSettings0.tries[0].query_params);
       expect(settingsCpy.tries[0].curatorVarsDict())
             .toEqual(mockSettings0.tries[0].curatorVars);
       expect(settingsCpy.tries[1].queryParams)
-            .toEqual(mockSettings0.tries[1].queryParams);
+            .toEqual(mockSettings0.tries[1].query_params);
       expect(settingsCpy.tries[1].curatorVarsDict())
             .toEqual(mockSettings0.tries[1].curatorVars);
     });
@@ -130,7 +130,7 @@ describe('Service: settingsSvc', function () {
       tries: [
         {
          'tryNo': 0,
-         'queryParams': 'q=#$query##&bq=title:##titleboost##&bq=sub:2&qf=title',
+         'query_params': 'q=#$query##&bq=title:##titleboost##&bq=sub:2&qf=title',
          'curatorVars': {titleboost: 5, missing: 11},
          'args': {'q': ['#$query##'],
                       'bq': ['title:foo^5', 'sub:2'],
@@ -190,15 +190,15 @@ describe('Service: settingsSvc', function () {
       expect(settingsCpy.fieldSpec).toBe(mockSettings1.tries[0].field_spec);
       expect(settingsCpy.searchUrl).toBe(mockSettings1.tries[0].search_url);
       expect(settingsCpy.tries[0].queryParams)
-            .toEqual(mockSettings1.tries[0].queryParams);
+            .toEqual(mockSettings1.tries[0].query_params);
       expect(settingsCpy.tries[0].curatorVarsDict())
             .toEqual(mockSettings1.tries[0].curatorVars);
       expect(settingsCpy.tries[1].queryParams)
-            .toEqual(mockSettings1.tries[1].queryParams);
+            .toEqual(mockSettings1.tries[1].query_params);
       expect(settingsCpy.tries[1].curatorVarsDict())
             .toEqual(mockSettings1.tries[1].curatorVars);
       expect(settingsCpy.tries[2].queryParams)
-            .toEqual(mockSettings1.tries[2].queryParams);
+            .toEqual(mockSettings1.tries[2].query_params);
       expect(settingsCpy.tries[2].curatorVarsDict())
             .toEqual(mockSettings1.tries[2].curatorVars);
     });
@@ -208,7 +208,7 @@ describe('Service: settingsSvc', function () {
   });
 
   var mockTry = {
-    'queryParams': 'ADDED',
+    'query_params': 'ADDED',
     'curatorVars': {},
     'args': {},
     'search_url': 'http://doug.com:1234/solr/collection1',
@@ -247,7 +247,7 @@ describe('Service: settingsSvc', function () {
     escape_query: false,
     field_spec:   'CHANGED',
     name:        'try 2',
-    queryParams: 'q=#$query##&bq=title:##titleboost##&bq=sub:2&qf=title',
+    query_params: 'q=#$query##&bq=title:##titleboost##&bq=sub:2&qf=title',
     search_url:   'http://doug.com:1234/solr/collection1',
     tryNo:       2,
   };
@@ -293,7 +293,7 @@ describe('Service: settingsSvc', function () {
 
   var mockSettingsAddNewVarsResp = {
     'tryNo': 2,
-    'queryParams': 'q=#$query##&fq=title:foo&fq=sub:bar&new=##newvar##',
+    'query_params': 'q=#$query##&fq=title:foo&fq=sub:bar&new=##newvar##',
     'curatorVars': {newvar: 10},
     'args': {
       'q':    ['#$query##'],
@@ -443,12 +443,12 @@ describe('Service: settingsSvc', function () {
     var url   = '/api/clone/cases/0/tries/0';
     var mockResponse = {
      'tryNo':       3,
-     'queryParams': aTry.queryParams,
+     'query_params': aTry.query_params,
      'curatorVars': {},
      'args':        aTry.args,
-     'searchUrl':   aTry.searchUrl,
-     'fieldSpec':   aTry.fieldSpec,
-     'escapeQuery': true,
+     'search_url':  aTry.search_url,
+     'field_spec':   aTry.field_spec,
+     'escape_query': true,
      'name':        'try 3'
     };
 

--- a/spec/javascripts/angular/services/teamSvc_spec.js
+++ b/spec/javascripts/angular/services/teamSvc_spec.js
@@ -55,7 +55,7 @@ describe('Service: teamSvc', function () {
   var mockCase = {
     'caseNo':           1,
     'lastTry':          0,
-    'caseName':         'Case'
+    'case_name':         'Case'
   };
 
   var mockScorer = {
@@ -119,6 +119,41 @@ describe('Service: teamSvc', function () {
         expect(response).toEqual(mockTeam);
       });
     $httpBackend.flush();
+  });
+
+  it('fetches an team with its cases', function() {
+    var url = '/api/teams/' + mockTeam.id + '?load_cases=true';
+
+    var mockTeamWithCasesResponse = {
+        id:       1,
+        name:     'Team 1',
+        owner_id: 1,
+        members:  [],
+        cases:    [
+          {
+          'caseNo':           1,
+          'lastTry':          0,
+          'case_name':         'Case'
+          }
+        ],
+        scorers:  [],
+      }
+
+    $httpBackend.expectGET(url).respond(200, mockTeamWithCasesResponse);
+
+    var load_cases = true;
+
+    teamSvc.get(mockTeam.id, load_cases)
+      .then(function(response) {
+        expect(response.cases[0].caseName).toBe('Case');
+    });
+    //var team = teamSvc.get(mockTeam.id, load_cases);
+    $httpBackend.flush();
+    //$httpBackend.verifyNoOutstandingExpectation();
+    //console.log("Lets see what we go");
+    //console.log(team);
+    //expect(team.cases[0].caseName).toBe('Case');
+
   });
 
   it('adds a member to the team', function() {

--- a/spec/javascripts/angular/services/teamSvc_spec.js
+++ b/spec/javascripts/angular/services/teamSvc_spec.js
@@ -55,8 +55,7 @@ describe('Service: teamSvc', function () {
   var mockCase = {
     'caseNo':           1,
     'lastTry':          0,
-    'caseName':         'Case',
-    'displayPosition':  0,
+    'caseName':         'Case'
   };
 
   var mockScorer = {

--- a/test/controllers/api/v1/cases_controller_test.rb
+++ b/test/controllers/api/v1/cases_controller_test.rb
@@ -24,14 +24,14 @@ module Api
           count     = joe.cases.count
           case_name = 'test case'
 
-          post :create, caseName: case_name
+          post :create, case_name: case_name
 
           assert_response :ok
 
-          assert_equal json_response['caseName'], case_name
+          assert_equal json_response['case_name'], case_name
 
-          assert_equal joe.cases.count,          count + 1
-          assert_equal joe.cases.first.caseName, case_name
+          assert_equal joe.cases.count,             count + 1
+          assert_equal joe.cases.first.case_name, case_name
         end
 
         test 'requires a case name' do
@@ -40,18 +40,18 @@ module Api
           assert_response :bad_request
 
           body = JSON.parse(response.body)
-          assert body['caseName'].include? "can't be blank"
+          assert body['case_name'].include? "can't be blank"
         end
 
         test 'creates an initial defaults try' do
           case_name = 'test case'
 
-          post :create, caseName: case_name
+          post :create, case_name: case_name
 
           assert_response :ok
 
-          assert_equal json_response['caseName'], case_name
-          acase = Case.where(caseName: case_name).first
+          assert_equal json_response['case_name'], case_name
+          acase = Case.where(case_name: case_name).first
 
           assert_equal 1, acase.tries.count
         end
@@ -63,7 +63,7 @@ module Api
             case_name = 'test case'
 
             perform_enqueued_jobs do
-              post :create, caseName: case_name
+              post :create, case_name: case_name
 
               assert_response :ok
             end
@@ -86,8 +86,8 @@ module Api
 
           body = JSON.parse(response.body)
 
-          assert_equal body['caseName'], the_case.caseName
-          assert_equal body['caseNo'],   the_case.id
+          assert_equal body['case_name'], the_case.case_name
+          assert_equal body['caseNo'],    the_case.id
         end
       end
 
@@ -173,29 +173,29 @@ module Api
 
         describe 'when case does not exist' do
           test 'returns not found error' do
-            patch :update, case_id: 'foo', caseName: 'foo'
+            patch :update, case_id: 'foo', case_name: 'foo'
             assert_response :not_found
 
-            put :update, case_id: 'foo', caseName: 'foo'
+            put :update, case_id: 'foo', case_name: 'foo'
             assert_response :not_found
           end
         end
 
         describe 'when changing the case name' do
           test 'updates name successfully using PATCH verb' do
-            patch :update, case_id: one.id, caseName: 'New Name'
+            patch :update, case_id: one.id, case_name: 'New Name'
             assert_response :ok
 
             one.reload
-            assert_equal one.caseName, 'New Name'
+            assert_equal one.case_name, 'New Name'
           end
 
           test 'updates name successfully using PUT verb' do
-            put :update, case_id: one.id, caseName: 'New Name'
+            put :update, case_id: one.id, case_name: 'New Name'
             assert_response :ok
 
             one.reload
-            assert_equal one.caseName, 'New Name'
+            assert_equal one.case_name, 'New Name'
           end
         end
 
@@ -238,7 +238,7 @@ module Api
             expects_any_ga_event_call
 
             perform_enqueued_jobs do
-              patch :update, case_id: one.id, caseName: 'New Name'
+              patch :update, case_id: one.id, case_name: 'New Name'
               assert_response :ok
             end
           end
@@ -378,8 +378,8 @@ module Api
           cases = body['allCases']
 
           assert cases.length == doug.cases.where(archived: true).length
-          assert_equal cases.first['caseName'],  archived.caseName
-          assert_equal cases.first['caseNo'],    archived.id
+          assert_equal cases.first['case_name'],  archived.case_name
+          assert_equal cases.first['caseNo'],     archived.id
         end
 
         test 'archived flag works as a string' do
@@ -391,8 +391,8 @@ module Api
           cases = body['allCases']
 
           assert cases.length == doug.cases.where(archived: true).length
-          assert_equal cases.first['caseName'],  archived.caseName
-          assert_equal cases.first['caseNo'],    archived.id
+          assert_equal cases.first['case_name'],  archived.case_name
+          assert_equal cases.first['caseNo'],     archived.id
         end
 
         test 'only returns owned archived cases' do
@@ -403,9 +403,9 @@ module Api
           assert_response :ok
 
           cases = json_response['allCases']
-          names = cases.map { |c| c['caseName'] }
+          names = cases.map { |c| c['case_name'] }
 
-          assert_not_includes names, shared.caseName
+          assert_not_includes names, shared.case_name
         end
 
         test 'limits list to 3 cases if sorting by last_viewed_at' do

--- a/test/controllers/api/v1/cases_controller_test.rb
+++ b/test/controllers/api/v1/cases_controller_test.rb
@@ -29,9 +29,8 @@ module Api
           assert_response :ok
 
           assert_equal json_response['case_name'], case_name
-
-          assert_equal joe.cases.count,             count + 1
-          assert_equal joe.cases.first.case_name, case_name
+          assert_equal joe.cases.count,            count + 1
+          assert_equal joe.cases.first.case_name,  case_name
         end
 
         test 'requires a case name' do

--- a/test/controllers/api/v1/clone/cases_controller_test.rb
+++ b/test/controllers/api/v1/clone/cases_controller_test.rb
@@ -43,8 +43,8 @@ module Api
             assert_difference 'Case.count' do
               assert_difference 'Try.count' do
                 data = {
-                  case_id: the_case.id,
-                  tryNo:   the_try.tryNo,
+                  case_id:    the_case.id,
+                  try_number: the_try.try_number,
                 }
 
                 post :create, data

--- a/test/controllers/api/v1/clone/cases_controller_test.rb
+++ b/test/controllers/api/v1/clone/cases_controller_test.rb
@@ -61,7 +61,7 @@ module Api
                 cloned_try = cloned_case.tries.best
 
                 assert_equal the_try.queryParams,   cloned_try.queryParams
-                assert_equal 'title',               cloned_try.fieldSpec
+                assert_equal 'title',               cloned_try.field_spec
                 assert_equal the_try.search_url,    cloned_try.search_url
                 assert_equal 'Try 0',               cloned_try.name
                 assert_equal the_try.search_engine, cloned_try.search_engine

--- a/test/controllers/api/v1/clone/cases_controller_test.rb
+++ b/test/controllers/api/v1/clone/cases_controller_test.rb
@@ -65,7 +65,7 @@ module Api
                 assert_equal the_try.searchUrl,     cloned_try.searchUrl
                 assert_equal 'Try 0',               cloned_try.name
                 assert_equal the_try.search_engine, cloned_try.search_engine
-                assert_equal the_try.escapeQuery,   cloned_try.escapeQuery
+                assert_equal the_try.escape_query,  cloned_try.escape_query
                 assert_equal the_try.curator_variables.size, cloned_try.curator_variables.size
               end
             end

--- a/test/controllers/api/v1/clone/cases_controller_test.rb
+++ b/test/controllers/api/v1/clone/cases_controller_test.rb
@@ -34,7 +34,7 @@ module Api
                 assert_equal the_case.tries.count, cloned_case.tries.count
                 assert_equal 0, cloned_case.queries.count
                 assert_equal user.id, cloned_case.user_id
-                assert_equal "Cloned: #{the_case.caseName}", cloned_case.caseName
+                assert_equal "Cloned: #{the_case.case_name}", cloned_case.case_name
               end
             end
           end
@@ -56,7 +56,7 @@ module Api
                 assert_equal 1, cloned_case.tries.count
                 assert_equal 0, cloned_case.queries.count
                 assert_equal user.id, cloned_case.user_id
-                assert_equal "Cloned: #{the_case.caseName}", cloned_case.caseName
+                assert_equal "Cloned: #{the_case.case_name}", cloned_case.case_name
 
                 cloned_try = cloned_case.tries.best
 

--- a/test/controllers/api/v1/clone/cases_controller_test.rb
+++ b/test/controllers/api/v1/clone/cases_controller_test.rb
@@ -64,7 +64,7 @@ module Api
                 assert_equal 'title',               cloned_try.fieldSpec
                 assert_equal the_try.searchUrl,     cloned_try.searchUrl
                 assert_equal 'Try 0',               cloned_try.name
-                assert_equal the_try.searchEngine,  cloned_try.searchEngine
+                assert_equal the_try.search_engine, cloned_try.search_engine
                 assert_equal the_try.escapeQuery,   cloned_try.escapeQuery
                 assert_equal the_try.curator_variables.size, cloned_try.curator_variables.size
               end

--- a/test/controllers/api/v1/clone/cases_controller_test.rb
+++ b/test/controllers/api/v1/clone/cases_controller_test.rb
@@ -62,7 +62,7 @@ module Api
 
                 assert_equal the_try.queryParams,   cloned_try.queryParams
                 assert_equal 'title',               cloned_try.fieldSpec
-                assert_equal the_try.searchUrl,     cloned_try.searchUrl
+                assert_equal the_try.search_url,    cloned_try.search_url
                 assert_equal 'Try 0',               cloned_try.name
                 assert_equal the_try.search_engine, cloned_try.search_engine
                 assert_equal the_try.escape_query,  cloned_try.escape_query

--- a/test/controllers/api/v1/clone/cases_controller_test.rb
+++ b/test/controllers/api/v1/clone/cases_controller_test.rb
@@ -60,7 +60,7 @@ module Api
 
                 cloned_try = cloned_case.tries.best
 
-                assert_equal the_try.queryParams,   cloned_try.queryParams
+                assert_equal the_try.query_params,  cloned_try.query_params
                 assert_equal 'title',               cloned_try.field_spec
                 assert_equal the_try.search_url,    cloned_try.search_url
                 assert_equal 'Try 0',               cloned_try.name

--- a/test/controllers/api/v1/clone/tries_controller_test.rb
+++ b/test/controllers/api/v1/clone/tries_controller_test.rb
@@ -15,7 +15,7 @@ module Api
         end
 
         def assert_try_matches_response response, try
-          assert_equal try.queryParams,  response['queryParams']
+          assert_equal try.query_params, response['query_params']
           assert_equal try.field_spec,   response['field_spec']
           assert_equal try.search_url,   response['search_url']
           assert_equal try.tryNo,        response['tryNo']
@@ -28,7 +28,7 @@ module Api
 
         def assert_tries_match a_try, try
           assert_equal try.case_id,      a_try.case_id
-          assert_equal try.queryParams,  a_try.queryParams
+          assert_equal try.query_params, a_try.query_params
           assert_equal try.search_url,   a_try.search_url
           assert_equal try.escape_query, a_try.escape_query
         end

--- a/test/controllers/api/v1/clone/tries_controller_test.rb
+++ b/test/controllers/api/v1/clone/tries_controller_test.rb
@@ -21,7 +21,7 @@ module Api
           assert_equal try.tryNo,       response['tryNo']
           assert_equal try.name,        response['name']
           assert_equal try.solr_args,   response['args']
-          assert_equal try.escapeQuery, response['escapeQuery']
+          assert_equal try.escape_query,response['escape_query']
 
           assert_curator_vars_equal try.curator_vars_map, response['curatorVars']
         end
@@ -30,7 +30,7 @@ module Api
           assert_equal try.case_id,     a_try.case_id
           assert_equal try.queryParams, a_try.queryParams
           assert_equal try.searchUrl,   a_try.searchUrl
-          assert_equal try.escapeQuery, a_try.escapeQuery
+          assert_equal try.escape_query,a_try.escape_query
         end
 
         def assert_curator_vars_equal vars, response_vars

--- a/test/controllers/api/v1/clone/tries_controller_test.rb
+++ b/test/controllers/api/v1/clone/tries_controller_test.rb
@@ -18,7 +18,7 @@ module Api
           assert_equal try.query_params, response['query_params']
           assert_equal try.field_spec,   response['field_spec']
           assert_equal try.search_url,   response['search_url']
-          assert_equal try.tryNo,        response['tryNo']
+          assert_equal try.try_number,   response['try_number']
           assert_equal try.name,         response['name']
           assert_equal try.solr_args,    response['args']
           assert_equal try.escape_query, response['escape_query']
@@ -48,14 +48,14 @@ module Api
           let(:the_try)   { tries(:first_for_case_with_two_tries) }
 
           it 'returns a not found error if try does not exist' do
-            post :create, case_id: the_case.id, tryNo: 123_456
+            post :create, case_id: the_case.id, try_number: 123_456
 
             assert_response :not_found
           end
 
           it 'successfully duplicates try for case' do
             assert_difference 'the_case.tries.count' do
-              post :create, case_id: the_case.id, tryNo: the_try.tryNo
+              post :create, case_id: the_case.id, try_number: the_try.try_number
 
               assert_response :ok
 
@@ -73,7 +73,7 @@ module Api
               expects_any_ga_event_call
 
               perform_enqueued_jobs do
-                post :create, case_id: the_case.id, tryNo: the_try.tryNo
+                post :create, case_id: the_case.id, try_number: the_try.try_number
 
                 assert_response :ok
               end

--- a/test/controllers/api/v1/clone/tries_controller_test.rb
+++ b/test/controllers/api/v1/clone/tries_controller_test.rb
@@ -15,22 +15,22 @@ module Api
         end
 
         def assert_try_matches_response response, try
-          assert_equal try.queryParams, response['queryParams']
-          assert_equal try.fieldSpec,   response['fieldSpec']
-          assert_equal try.search_url,  response['search_url']
-          assert_equal try.tryNo,       response['tryNo']
-          assert_equal try.name,        response['name']
-          assert_equal try.solr_args,   response['args']
-          assert_equal try.escape_query,response['escape_query']
+          assert_equal try.queryParams,  response['queryParams']
+          assert_equal try.field_spec,   response['field_spec']
+          assert_equal try.search_url,   response['search_url']
+          assert_equal try.tryNo,        response['tryNo']
+          assert_equal try.name,         response['name']
+          assert_equal try.solr_args,    response['args']
+          assert_equal try.escape_query, response['escape_query']
 
           assert_curator_vars_equal try.curator_vars_map, response['curatorVars']
         end
 
         def assert_tries_match a_try, try
-          assert_equal try.case_id,     a_try.case_id
-          assert_equal try.queryParams, a_try.queryParams
-          assert_equal try.search_url,  a_try.search_url
-          assert_equal try.escape_query,a_try.escape_query
+          assert_equal try.case_id,      a_try.case_id
+          assert_equal try.queryParams,  a_try.queryParams
+          assert_equal try.search_url,   a_try.search_url
+          assert_equal try.escape_query, a_try.escape_query
         end
 
         def assert_curator_vars_equal vars, response_vars

--- a/test/controllers/api/v1/clone/tries_controller_test.rb
+++ b/test/controllers/api/v1/clone/tries_controller_test.rb
@@ -17,7 +17,7 @@ module Api
         def assert_try_matches_response response, try
           assert_equal try.queryParams, response['queryParams']
           assert_equal try.fieldSpec,   response['fieldSpec']
-          assert_equal try.searchUrl,   response['searchUrl']
+          assert_equal try.search_url,  response['search_url']
           assert_equal try.tryNo,       response['tryNo']
           assert_equal try.name,        response['name']
           assert_equal try.solr_args,   response['args']
@@ -29,7 +29,7 @@ module Api
         def assert_tries_match a_try, try
           assert_equal try.case_id,     a_try.case_id
           assert_equal try.queryParams, a_try.queryParams
-          assert_equal try.searchUrl,   a_try.searchUrl
+          assert_equal try.search_url,  a_try.search_url
           assert_equal try.escape_query,a_try.escape_query
         end
 

--- a/test/controllers/api/v1/tries_controller_test.rb
+++ b/test/controllers/api/v1/tries_controller_test.rb
@@ -168,7 +168,7 @@ module Api
             search_engine: 'solr',
           }
 
-          case_last_try = the_case.lastTry
+          case_last_try = the_case.last_try_number
 
           assert_difference 'the_case.tries.count' do
             post :create, try_params.merge(case_id: the_case.id)
@@ -180,7 +180,7 @@ module Api
             try_response  = JSON.parse(response.body)
             created_try   = the_case.tries.where(try_number: try_response['try_number']).first
 
-            assert_equal the_case.lastTry, case_last_try + 1
+            assert_equal the_case.last_try_number, case_last_try + 1
 
             assert_try_matches_response try_response,  created_try
             assert_try_matches_params   try_params,    created_try
@@ -240,12 +240,12 @@ module Api
           try_response  = JSON.parse(response.body)
           created_try   = the_case.tries.where(try_number: try_response['try_number']).first
 
-          assert_match( /Try/,                        created_try.name )
-          assert_match( /#{the_case.lastTry}/,        created_try.name )
-          assert_match( /#{created_try.try_number}/,  created_try.name )
+          assert_match( /Try/,                         created_try.name )
+          assert_match( /#{the_case.last_try_number}/, created_try.name )
+          assert_match( /#{created_try.try_number}/,   created_try.name )
 
           assert_match( /Try/,                            try_response['name'] )
-          assert_match( /#{the_case.lastTry}/,            try_response['name'] )
+          assert_match( /#{the_case.last_try_number}/,    try_response['name'] )
           assert_match( /#{try_response['try_number']}/,  try_response['name'] )
         end
 
@@ -291,9 +291,9 @@ module Api
           try_response  = JSON.parse(response.body)
           created_try   = the_case.tries.where(try_number: try_response['try_number']).first
 
-          assert_match( /Try/,                        created_try.name )
-          assert_match( /#{the_case.lastTry}/,        created_try.name )
-          assert_match( /#{created_try.try_number}/,  created_try.name )
+          assert_match( /Try/,                         created_try.name )
+          assert_match( /#{the_case.last_try_number}/, created_try.name )
+          assert_match( /#{created_try.try_number}/,   created_try.name )
 
           assert_not_nil created_try.search_engine
           assert_not_nil created_try.field_spec
@@ -364,9 +364,9 @@ module Api
             try_response  = JSON.parse(response.body)
             created_try   = the_case.tries.where(try_number: try_response['try_number']).first
 
-            assert_match( /Try/,                        created_try.name )
-            assert_match( /#{the_case.lastTry}/,        created_try.name )
-            assert_match( /#{created_try.try_number}/,  created_try.name )
+            assert_match( /Try/,                         created_try.name )
+            assert_match( /#{the_case.last_try_number}/, created_try.name )
+            assert_match( /#{created_try.try_number}/,   created_try.name )
 
             assert_not_nil created_try.search_engine
             assert_not_nil created_try.field_spec
@@ -393,9 +393,9 @@ module Api
             try_response  = JSON.parse(response.body)
             created_try   = the_case.tries.where(try_number: try_response['try_number']).first
 
-            assert_match( /Try/,                        created_try.name )
-            assert_match( /#{the_case.lastTry}/,        created_try.name )
-            assert_match( /#{created_try.try_number}/,  created_try.name )
+            assert_match( /Try/,                         created_try.name )
+            assert_match( /#{the_case.last_try_number}/, created_try.name )
+            assert_match( /#{created_try.try_number}/,   created_try.name )
 
             assert_not_nil created_try.search_engine
             assert_not_nil created_try.field_spec

--- a/test/controllers/api/v1/tries_controller_test.rb
+++ b/test/controllers/api/v1/tries_controller_test.rb
@@ -16,7 +16,7 @@ module Api
       def assert_try_matches_response response, try
         assert_equal try.queryParams, response['queryParams']
         assert_equal try.fieldSpec,   response['fieldSpec']
-        assert_equal try.searchUrl,   response['searchUrl']
+        assert_equal try.search_url,  response['search_url']
         assert_equal try.tryNo,       response['tryNo']
         assert_equal try.name,        response['name']
         assert_equal try.solr_args,   response['args']
@@ -28,7 +28,7 @@ module Api
       def assert_try_matches_params params, try
         assert_equal try.queryParams,  params[:queryParams]  if params[:queryParams]
         assert_equal try.fieldSpec,    params[:fieldSpec]    if params[:fieldSpec]
-        assert_equal try.searchUrl,    params[:searchUrl]    if params[:searchUrl]
+        assert_equal try.search_url,   params[:search_url]   if params[:search_url]
         assert_equal try.name,         params[:name]         if params[:name]
         assert_equal try.escape_query, params[:escape_query] if params[:escape_query]
       end
@@ -162,7 +162,7 @@ module Api
 
         test 'sets attribute successfully and assigns try to case' do
           try_params = {
-            searchUrl:     'http://solr.quepid.com',
+            search_url:    'http://solr.quepid.com',
             fieldSpec:     'catch_line',
             queryParams:   'q=#$query##',
             search_engine: 'solr',
@@ -193,7 +193,7 @@ module Api
 
         test 'adds curator vars to the try' do
           try_params = {
-            searchUrl:     'http://solr.quepid.com',
+            search_url:    'http://solr.quepid.com',
             fieldSpec:     'catch_line',
             queryParams:   'q=#$query##',
             search_engine: 'solr',
@@ -225,7 +225,7 @@ module Api
 
         test 'sets default name properly' do
           try_params = {
-            searchUrl:     'http://solr.quepid.com',
+            search_url:    'http://solr.quepid.com',
             fieldSpec:     'catch_line',
             queryParams:   'q=#$query##',
             search_engine: 'solr',
@@ -297,13 +297,13 @@ module Api
 
           assert_not_nil created_try.search_engine
           assert_not_nil created_try.fieldSpec
-          assert_not_nil created_try.searchUrl
+          assert_not_nil created_try.search_url
           assert_not_nil created_try.queryParams
           assert_not_nil created_try.escape_query
 
           assert_equal created_try.search_engine,   Try::DEFAULTS[:search_engine]
           assert_equal created_try.fieldSpec,       Try::DEFAULTS[:solr][:field_spec]
-          assert_equal created_try.searchUrl,       Try::DEFAULTS[:solr][:search_url]
+          assert_equal created_try.search_url,      Try::DEFAULTS[:solr][:search_url]
           assert_equal created_try.escape_query,    true
           assert_equal created_try.number_of_rows,  10
         end
@@ -370,13 +370,13 @@ module Api
 
             assert_not_nil created_try.search_engine
             assert_not_nil created_try.fieldSpec
-            assert_not_nil created_try.searchUrl
+            assert_not_nil created_try.search_url
             assert_not_nil created_try.queryParams
             assert_not_nil created_try.escape_query
 
             assert_equal created_try.search_engine, Try::DEFAULTS[:search_engine]
             assert_equal created_try.fieldSpec,     Try::DEFAULTS[:solr][:field_spec]
-            assert_equal created_try.searchUrl,     Try::DEFAULTS[:solr][:search_url]
+            assert_equal created_try.search_url,    Try::DEFAULTS[:solr][:search_url]
             assert_equal created_try.queryParams,   Try::DEFAULTS[:solr][:query_params]
             assert_equal created_try.escape_query,  true
           end
@@ -399,13 +399,13 @@ module Api
 
             assert_not_nil created_try.search_engine
             assert_not_nil created_try.fieldSpec
-            assert_not_nil created_try.searchUrl
+            assert_not_nil created_try.search_url
             assert_not_nil created_try.queryParams
             assert_not_nil created_try.escape_query
 
             assert_equal created_try.search_engine, 'es'
             assert_equal created_try.fieldSpec,     Try::DEFAULTS[:es][:field_spec]
-            assert_equal created_try.searchUrl,     Try::DEFAULTS[:es][:search_url]
+            assert_equal created_try.search_url,    Try::DEFAULTS[:es][:search_url]
             assert_equal created_try.queryParams,   Try::DEFAULTS[:es][:query_params]
             assert_equal created_try.escape_query,  true
           end

--- a/test/controllers/api/v1/tries_controller_test.rb
+++ b/test/controllers/api/v1/tries_controller_test.rb
@@ -14,7 +14,7 @@ module Api
       end
 
       def assert_try_matches_response response, try
-        assert_equal try.queryParams,  response['queryParams']
+        assert_equal try.query_params, response['query_params']
         assert_equal try.field_spec,   response['field_spec']
         assert_equal try.search_url,   response['search_url']
         assert_equal try.tryNo,        response['tryNo']
@@ -26,7 +26,7 @@ module Api
       end
 
       def assert_try_matches_params params, try
-        assert_equal try.queryParams,  params[:queryParams]  if params[:queryParams]
+        assert_equal try.query_params, params[:query_params]  if params[:query_params]
         assert_equal try.field_spec,   params[:field_spec]   if params[:field_spec]
         assert_equal try.search_url,   params[:search_url]   if params[:search_url]
         assert_equal try.name,         params[:name]         if params[:name]
@@ -140,7 +140,7 @@ module Api
 
         test 'does nothing with params passed except name' do
           old_no = the_try.tryNo
-          put :update, case_id: the_case.id, tryNo: the_try.tryNo, queryParams: 'New No'
+          put :update, case_id: the_case.id, tryNo: the_try.tryNo, query_params: 'New No'
 
           assert_response :ok
 
@@ -164,7 +164,7 @@ module Api
           try_params = {
             search_url:    'http://solr.quepid.com',
             field_spec:    'catch_line',
-            queryParams:   'q=#$query##',
+            query_params:  'q=#$query##',
             search_engine: 'solr',
           }
 
@@ -195,7 +195,7 @@ module Api
           try_params = {
             search_url:    'http://solr.quepid.com',
             field_spec:    'catch_line',
-            queryParams:   'q=#$query##',
+            query_params:  'q=#$query##',
             search_engine: 'solr',
           }
 
@@ -227,7 +227,7 @@ module Api
           try_params = {
             search_url:    'http://solr.quepid.com',
             field_spec:    'catch_line',
-            queryParams:   'q=#$query##',
+            query_params:  'q=#$query##',
             search_engine: 'solr',
           }
 
@@ -298,7 +298,7 @@ module Api
           assert_not_nil created_try.search_engine
           assert_not_nil created_try.field_spec
           assert_not_nil created_try.search_url
-          assert_not_nil created_try.queryParams
+          assert_not_nil created_try.query_params
           assert_not_nil created_try.escape_query
 
           assert_equal created_try.search_engine,   Try::DEFAULTS[:search_engine]
@@ -371,13 +371,13 @@ module Api
             assert_not_nil created_try.search_engine
             assert_not_nil created_try.field_spec
             assert_not_nil created_try.search_url
-            assert_not_nil created_try.queryParams
+            assert_not_nil created_try.query_params
             assert_not_nil created_try.escape_query
 
             assert_equal created_try.search_engine, Try::DEFAULTS[:search_engine]
             assert_equal created_try.field_spec,    Try::DEFAULTS[:solr][:field_spec]
             assert_equal created_try.search_url,    Try::DEFAULTS[:solr][:search_url]
-            assert_equal created_try.queryParams,   Try::DEFAULTS[:solr][:query_params]
+            assert_equal created_try.query_params,  Try::DEFAULTS[:solr][:query_params]
             assert_equal created_try.escape_query,  true
           end
         end
@@ -400,20 +400,20 @@ module Api
             assert_not_nil created_try.search_engine
             assert_not_nil created_try.field_spec
             assert_not_nil created_try.search_url
-            assert_not_nil created_try.queryParams
+            assert_not_nil created_try.query_params
             assert_not_nil created_try.escape_query
 
             assert_equal created_try.search_engine, 'es'
             assert_equal created_try.field_spec,    Try::DEFAULTS[:es][:field_spec]
             assert_equal created_try.search_url,    Try::DEFAULTS[:es][:search_url]
-            assert_equal created_try.queryParams,   Try::DEFAULTS[:es][:query_params]
+            assert_equal created_try.query_params,  Try::DEFAULTS[:es][:query_params]
             assert_equal created_try.escape_query,  true
           end
 
           test 'parses args properly' do
             query_params = '{ "query": "#$query##" }'
 
-            post :create, case_id: the_case.id, search_engine: 'es', queryParams: query_params
+            post :create, case_id: the_case.id, search_engine: 'es', query_params: query_params
 
             assert_response :ok # should be :created,
             # but there's a bug currently in the responders gem
@@ -429,7 +429,7 @@ module Api
           test 'handles bad JSON in query params' do
             query_params = '{ "query": "#$query##"'
 
-            post :create, case_id: the_case.id, search_engine: 'es', queryParams: query_params
+            post :create, case_id: the_case.id, search_engine: 'es', query_params: query_params
 
             assert_response :ok # should be :created,
             # but there's a bug currently in the responders gem

--- a/test/controllers/api/v1/tries_controller_test.rb
+++ b/test/controllers/api/v1/tries_controller_test.rb
@@ -20,17 +20,17 @@ module Api
         assert_equal try.tryNo,       response['tryNo']
         assert_equal try.name,        response['name']
         assert_equal try.solr_args,   response['args']
-        assert_equal try.escapeQuery, response['escapeQuery']
+        assert_equal try.escape_query,response['escape_query']
 
         assert_curator_vars_equal try.curator_vars_map, response['curatorVars']
       end
 
       def assert_try_matches_params params, try
-        assert_equal try.queryParams, params[:queryParams] if params[:queryParams]
-        assert_equal try.fieldSpec,   params[:fieldSpec]   if params[:fieldSpec]
-        assert_equal try.searchUrl,   params[:searchUrl]   if params[:searchUrl]
-        assert_equal try.name,        params[:name]        if params[:name]
-        assert_equal try.escapeQuery, params[:escapeQuery] if params[:escapeQuery]
+        assert_equal try.queryParams,  params[:queryParams]  if params[:queryParams]
+        assert_equal try.fieldSpec,    params[:fieldSpec]    if params[:fieldSpec]
+        assert_equal try.searchUrl,    params[:searchUrl]    if params[:searchUrl]
+        assert_equal try.name,         params[:name]         if params[:name]
+        assert_equal try.escape_query, params[:escape_query] if params[:escape_query]
       end
 
       def assert_curator_vars_equal vars, response_vars
@@ -249,9 +249,9 @@ module Api
           assert_match( /#{try_response['tryNo']}/,  try_response['name'] )
         end
 
-        test 'sets escapeQuery param' do
+        test 'sets escape_query param' do
           try_params = {
-            escapeQuery: false,
+            escape_query: false,
           }
 
           post :create, try_params.merge(case_id: the_case.id)
@@ -261,8 +261,8 @@ module Api
           the_case.reload
           created_try = the_case.tries.where(tryNo: json_response['tryNo']).first
 
-          assert_equal false, json_response['escapeQuery']
-          assert_equal false, created_try.escapeQuery
+          assert_equal false, json_response['escape_query']
+          assert_equal false, created_try.escape_query
         end
 
         test 'sets number of rows' do
@@ -299,12 +299,12 @@ module Api
           assert_not_nil created_try.fieldSpec
           assert_not_nil created_try.searchUrl
           assert_not_nil created_try.queryParams
-          assert_not_nil created_try.escapeQuery
+          assert_not_nil created_try.escape_query
 
           assert_equal created_try.search_engine,   Try::DEFAULTS[:search_engine]
           assert_equal created_try.fieldSpec,       Try::DEFAULTS[:solr][:field_spec]
           assert_equal created_try.searchUrl,       Try::DEFAULTS[:solr][:search_url]
-          assert_equal created_try.escapeQuery,     true
+          assert_equal created_try.escape_query,    true
           assert_equal created_try.number_of_rows,  10
         end
 
@@ -372,13 +372,13 @@ module Api
             assert_not_nil created_try.fieldSpec
             assert_not_nil created_try.searchUrl
             assert_not_nil created_try.queryParams
-            assert_not_nil created_try.escapeQuery
+            assert_not_nil created_try.escape_query
 
             assert_equal created_try.search_engine, Try::DEFAULTS[:search_engine]
             assert_equal created_try.fieldSpec,     Try::DEFAULTS[:solr][:field_spec]
             assert_equal created_try.searchUrl,     Try::DEFAULTS[:solr][:search_url]
             assert_equal created_try.queryParams,   Try::DEFAULTS[:solr][:query_params]
-            assert_equal created_try.escapeQuery,   true
+            assert_equal created_try.escape_query,  true
           end
         end
 
@@ -401,13 +401,13 @@ module Api
             assert_not_nil created_try.fieldSpec
             assert_not_nil created_try.searchUrl
             assert_not_nil created_try.queryParams
-            assert_not_nil created_try.escapeQuery
+            assert_not_nil created_try.escape_query
 
             assert_equal created_try.search_engine, 'es'
             assert_equal created_try.fieldSpec,     Try::DEFAULTS[:es][:field_spec]
             assert_equal created_try.searchUrl,     Try::DEFAULTS[:es][:search_url]
             assert_equal created_try.queryParams,   Try::DEFAULTS[:es][:query_params]
-            assert_equal created_try.escapeQuery,   true
+            assert_equal created_try.escape_query,  true
           end
 
           test 'parses args properly' do

--- a/test/controllers/api/v1/tries_controller_test.rb
+++ b/test/controllers/api/v1/tries_controller_test.rb
@@ -14,20 +14,20 @@ module Api
       end
 
       def assert_try_matches_response response, try
-        assert_equal try.queryParams, response['queryParams']
-        assert_equal try.fieldSpec,   response['fieldSpec']
-        assert_equal try.search_url,  response['search_url']
-        assert_equal try.tryNo,       response['tryNo']
-        assert_equal try.name,        response['name']
-        assert_equal try.solr_args,   response['args']
-        assert_equal try.escape_query,response['escape_query']
+        assert_equal try.queryParams,  response['queryParams']
+        assert_equal try.field_spec,   response['field_spec']
+        assert_equal try.search_url,   response['search_url']
+        assert_equal try.tryNo,        response['tryNo']
+        assert_equal try.name,         response['name']
+        assert_equal try.solr_args,    response['args']
+        assert_equal try.escape_query, response['escape_query']
 
         assert_curator_vars_equal try.curator_vars_map, response['curatorVars']
       end
 
       def assert_try_matches_params params, try
         assert_equal try.queryParams,  params[:queryParams]  if params[:queryParams]
-        assert_equal try.fieldSpec,    params[:fieldSpec]    if params[:fieldSpec]
+        assert_equal try.field_spec,   params[:field_spec]   if params[:field_spec]
         assert_equal try.search_url,   params[:search_url]   if params[:search_url]
         assert_equal try.name,         params[:name]         if params[:name]
         assert_equal try.escape_query, params[:escape_query] if params[:escape_query]
@@ -148,12 +148,12 @@ module Api
           assert_not_equal  the_try.tryNo, 'New No'
           assert_equal      the_try.tryNo, old_no
 
-          put :update, case_id: the_case.id, tryNo: the_try.tryNo, fieldSpec: 'New fieldSpec'
+          put :update, case_id: the_case.id, tryNo: the_try.tryNo, field_spec: 'New field_spec'
 
           assert_response :ok
 
           the_try.reload
-          assert_not_equal the_try.fieldSpec, 'New fieldSpec'
+          assert_not_equal the_try.field_spec, 'New field_spec'
         end
       end
 
@@ -163,7 +163,7 @@ module Api
         test 'sets attribute successfully and assigns try to case' do
           try_params = {
             search_url:    'http://solr.quepid.com',
-            fieldSpec:     'catch_line',
+            field_spec:    'catch_line',
             queryParams:   'q=#$query##',
             search_engine: 'solr',
           }
@@ -194,7 +194,7 @@ module Api
         test 'adds curator vars to the try' do
           try_params = {
             search_url:    'http://solr.quepid.com',
-            fieldSpec:     'catch_line',
+            field_spec:    'catch_line',
             queryParams:   'q=#$query##',
             search_engine: 'solr',
           }
@@ -226,7 +226,7 @@ module Api
         test 'sets default name properly' do
           try_params = {
             search_url:    'http://solr.quepid.com',
-            fieldSpec:     'catch_line',
+            field_spec:    'catch_line',
             queryParams:   'q=#$query##',
             search_engine: 'solr',
           }
@@ -296,13 +296,13 @@ module Api
           assert_match( /#{created_try.tryNo}/,  created_try.name )
 
           assert_not_nil created_try.search_engine
-          assert_not_nil created_try.fieldSpec
+          assert_not_nil created_try.field_spec
           assert_not_nil created_try.search_url
           assert_not_nil created_try.queryParams
           assert_not_nil created_try.escape_query
 
           assert_equal created_try.search_engine,   Try::DEFAULTS[:search_engine]
-          assert_equal created_try.fieldSpec,       Try::DEFAULTS[:solr][:field_spec]
+          assert_equal created_try.field_spec,      Try::DEFAULTS[:solr][:field_spec]
           assert_equal created_try.search_url,      Try::DEFAULTS[:solr][:search_url]
           assert_equal created_try.escape_query,    true
           assert_equal created_try.number_of_rows,  10
@@ -369,13 +369,13 @@ module Api
             assert_match( /#{created_try.tryNo}/,  created_try.name )
 
             assert_not_nil created_try.search_engine
-            assert_not_nil created_try.fieldSpec
+            assert_not_nil created_try.field_spec
             assert_not_nil created_try.search_url
             assert_not_nil created_try.queryParams
             assert_not_nil created_try.escape_query
 
             assert_equal created_try.search_engine, Try::DEFAULTS[:search_engine]
-            assert_equal created_try.fieldSpec,     Try::DEFAULTS[:solr][:field_spec]
+            assert_equal created_try.field_spec,    Try::DEFAULTS[:solr][:field_spec]
             assert_equal created_try.search_url,    Try::DEFAULTS[:solr][:search_url]
             assert_equal created_try.queryParams,   Try::DEFAULTS[:solr][:query_params]
             assert_equal created_try.escape_query,  true
@@ -398,13 +398,13 @@ module Api
             assert_match( /#{created_try.tryNo}/,  created_try.name )
 
             assert_not_nil created_try.search_engine
-            assert_not_nil created_try.fieldSpec
+            assert_not_nil created_try.field_spec
             assert_not_nil created_try.search_url
             assert_not_nil created_try.queryParams
             assert_not_nil created_try.escape_query
 
             assert_equal created_try.search_engine, 'es'
-            assert_equal created_try.fieldSpec,     Try::DEFAULTS[:es][:field_spec]
+            assert_equal created_try.field_spec,    Try::DEFAULTS[:es][:field_spec]
             assert_equal created_try.search_url,    Try::DEFAULTS[:es][:search_url]
             assert_equal created_try.queryParams,   Try::DEFAULTS[:es][:query_params]
             assert_equal created_try.escape_query,  true

--- a/test/controllers/api/v1/tries_controller_test.rb
+++ b/test/controllers/api/v1/tries_controller_test.rb
@@ -26,7 +26,7 @@ module Api
       end
 
       def assert_try_matches_params params, try
-        assert_equal try.query_params, params[:query_params]  if params[:query_params]
+        assert_equal try.query_params, params[:query_params] if params[:query_params]
         assert_equal try.field_spec,   params[:field_spec]   if params[:field_spec]
         assert_equal try.search_url,   params[:search_url]   if params[:search_url]
         assert_equal try.name,         params[:name]         if params[:name]
@@ -278,7 +278,7 @@ module Api
           created_try = the_case.tries.where(tryNo: json_response['tryNo']).first
 
           assert_equal 20, created_try.number_of_rows
-          assert_equal 20, json_response['numberOfRows']
+          assert_equal 20, json_response['number_of_rows']
         end
 
         test 'assigns default attributes' do

--- a/test/controllers/api/v1/tries_controller_test.rb
+++ b/test/controllers/api/v1/tries_controller_test.rb
@@ -162,10 +162,10 @@ module Api
 
         test 'sets attribute successfully and assigns try to case' do
           try_params = {
-            searchUrl:    'http://solr.quepid.com',
-            fieldSpec:    'catch_line',
-            queryParams:  'q=#$query##',
-            searchEngine: 'solr',
+            searchUrl:     'http://solr.quepid.com',
+            fieldSpec:     'catch_line',
+            queryParams:   'q=#$query##',
+            search_engine: 'solr',
           }
 
           case_last_try = the_case.lastTry
@@ -193,10 +193,10 @@ module Api
 
         test 'adds curator vars to the try' do
           try_params = {
-            searchUrl:    'http://solr.quepid.com',
-            fieldSpec:    'catch_line',
-            queryParams:  'q=#$query##',
-            searchEngine: 'solr',
+            searchUrl:     'http://solr.quepid.com',
+            fieldSpec:     'catch_line',
+            queryParams:   'q=#$query##',
+            search_engine: 'solr',
           }
 
           curator_vars_params = {
@@ -225,10 +225,10 @@ module Api
 
         test 'sets default name properly' do
           try_params = {
-            searchUrl:    'http://solr.quepid.com',
-            fieldSpec:    'catch_line',
-            queryParams:  'q=#$query##',
-            searchEngine: 'solr',
+            searchUrl:     'http://solr.quepid.com',
+            fieldSpec:     'catch_line',
+            queryParams:   'q=#$query##',
+            search_engine: 'solr',
           }
 
           post :create, try_params.merge(case_id: the_case.id)
@@ -295,13 +295,13 @@ module Api
           assert_match( /#{the_case.lastTry}/,   created_try.name )
           assert_match( /#{created_try.tryNo}/,  created_try.name )
 
-          assert_not_nil created_try.searchEngine
+          assert_not_nil created_try.search_engine
           assert_not_nil created_try.fieldSpec
           assert_not_nil created_try.searchUrl
           assert_not_nil created_try.queryParams
           assert_not_nil created_try.escapeQuery
 
-          assert_equal created_try.searchEngine,    Try::DEFAULTS[:search_engine]
+          assert_equal created_try.search_engine,   Try::DEFAULTS[:search_engine]
           assert_equal created_try.fieldSpec,       Try::DEFAULTS[:solr][:field_spec]
           assert_equal created_try.searchUrl,       Try::DEFAULTS[:solr][:search_url]
           assert_equal created_try.escapeQuery,     true
@@ -368,23 +368,23 @@ module Api
             assert_match( /#{the_case.lastTry}/,   created_try.name )
             assert_match( /#{created_try.tryNo}/,  created_try.name )
 
-            assert_not_nil created_try.searchEngine
+            assert_not_nil created_try.search_engine
             assert_not_nil created_try.fieldSpec
             assert_not_nil created_try.searchUrl
             assert_not_nil created_try.queryParams
             assert_not_nil created_try.escapeQuery
 
-            assert_equal created_try.searchEngine, Try::DEFAULTS[:search_engine]
-            assert_equal created_try.fieldSpec,    Try::DEFAULTS[:solr][:field_spec]
-            assert_equal created_try.searchUrl,    Try::DEFAULTS[:solr][:search_url]
-            assert_equal created_try.queryParams,  Try::DEFAULTS[:solr][:query_params]
-            assert_equal created_try.escapeQuery,  true
+            assert_equal created_try.search_engine, Try::DEFAULTS[:search_engine]
+            assert_equal created_try.fieldSpec,     Try::DEFAULTS[:solr][:field_spec]
+            assert_equal created_try.searchUrl,     Try::DEFAULTS[:solr][:search_url]
+            assert_equal created_try.queryParams,   Try::DEFAULTS[:solr][:query_params]
+            assert_equal created_try.escapeQuery,   true
           end
         end
 
         describe 'Elasticsearch' do
           test 'sets the proper default values' do
-            post :create, case_id: the_case.id, searchEngine: 'es'
+            post :create, case_id: the_case.id, search_engine: 'es'
 
             assert_response :ok # should be :created,
             # but there's a bug currently in the responders gem
@@ -397,23 +397,23 @@ module Api
             assert_match( /#{the_case.lastTry}/,   created_try.name )
             assert_match( /#{created_try.tryNo}/,  created_try.name )
 
-            assert_not_nil created_try.searchEngine
+            assert_not_nil created_try.search_engine
             assert_not_nil created_try.fieldSpec
             assert_not_nil created_try.searchUrl
             assert_not_nil created_try.queryParams
             assert_not_nil created_try.escapeQuery
 
-            assert_equal created_try.searchEngine, 'es'
-            assert_equal created_try.fieldSpec,    Try::DEFAULTS[:es][:field_spec]
-            assert_equal created_try.searchUrl,    Try::DEFAULTS[:es][:search_url]
-            assert_equal created_try.queryParams,  Try::DEFAULTS[:es][:query_params]
-            assert_equal created_try.escapeQuery,  true
+            assert_equal created_try.search_engine, 'es'
+            assert_equal created_try.fieldSpec,     Try::DEFAULTS[:es][:field_spec]
+            assert_equal created_try.searchUrl,     Try::DEFAULTS[:es][:search_url]
+            assert_equal created_try.queryParams,   Try::DEFAULTS[:es][:query_params]
+            assert_equal created_try.escapeQuery,   true
           end
 
           test 'parses args properly' do
             query_params = '{ "query": "#$query##" }'
 
-            post :create, case_id: the_case.id, searchEngine: 'es', queryParams: query_params
+            post :create, case_id: the_case.id, search_engine: 'es', queryParams: query_params
 
             assert_response :ok # should be :created,
             # but there's a bug currently in the responders gem
@@ -429,7 +429,7 @@ module Api
           test 'handles bad JSON in query params' do
             query_params = '{ "query": "#$query##"'
 
-            post :create, case_id: the_case.id, searchEngine: 'es', queryParams: query_params
+            post :create, case_id: the_case.id, search_engine: 'es', queryParams: query_params
 
             assert_response :ok # should be :created,
             # but there's a bug currently in the responders gem

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -46,7 +46,7 @@ class HomeControllerTest < ActionController::TestCase
     end
 
     test 'bootstraps non deleted/archived case' do
-      deleted_case = user.cases.create caseName: Case::DEFAULT_NAME
+      deleted_case = user.cases.create case_name: Case::DEFAULT_NAME
       deleted_case.update archived: true
 
       get :index

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -42,7 +42,7 @@ class HomeControllerTest < ActionController::TestCase
       get :index
 
       try_info = TRY_INFO.match(response.body)
-      assert_equal the_try.tryNo.to_s, try_info[1]
+      assert_equal the_try.try_number.to_s, try_info[1]
     end
 
     test 'bootstraps non deleted/archived case' do
@@ -56,19 +56,19 @@ class HomeControllerTest < ActionController::TestCase
     end
 
     test 'bootstraps not deleted try' do
-      deleted_try = the_case.tries.create tryNo: 100
+      deleted_try = the_case.tries.create try_number: 100
 
       get :index
 
       try_info = TRY_INFO.match(response.body)
-      assert_equal deleted_try.tryNo.to_s, try_info[1]
+      assert_equal deleted_try.try_number.to_s, try_info[1]
 
       deleted_try.delete
 
       get :index
 
       try_info = TRY_INFO.match(response.body)
-      assert_not_equal deleted_try.tryNo.to_s, try_info[1]
+      assert_not_equal deleted_try.try_number.to_s, try_info[1]
     end
   end
 

--- a/test/fixtures/cases.yml
+++ b/test/fixtures/cases.yml
@@ -3,7 +3,7 @@
 # Table name: cases
 #
 #  id              :integer          not null, primary key
-#  caseName        :string(191)
+#  case_name       :string(191)
 #  lastTry         :integer
 #  user_id         :integer
 #  archived        :boolean
@@ -16,177 +16,177 @@
 one:
   user: :doug
   archived: false
-  caseName: one
+  case_name: one
 
 two:
   user: :doug
   archived: false
-  caseName: two
+  case_name: two
 
 case_not_marked_if_archived:
   user: :doug
-  caseName: case_not_marked_if_archived
+  case_name: case_not_marked_if_archived
 
 with_metadata:
   user: :doug
   archived: false
-  caseName: with_metadata
+  case_name: with_metadata
 
 with_scorer:
   user:     :random
   archived: false
-  caseName: with default scorer
+  case_name: with default scorer
   scorer:   for_case_with_scorer (Scorer)
 
 for_default_scorer:
   user:     :random
   archived: false
-  caseName: for default scorer
+  case_name: for default scorer
   scorer:   case_default_scorer (Scorer)
 
 shared_with_team:
   user: :random
   archived: false
-  caseName: shared with sharing team
+  case_name: shared with sharing team
 
 shared_through_owned_team:
   user: :random
   archived: false
-  caseName: shared through team doug owns
+  case_name: shared through team doug owns
 
 archived:
   user: :doug
   archived: true
-  caseName: Archived
+  case_name: Archived
 
 matt_case:
   user: :matt
   archived: false
-  caseName: Matt's Case
+  case_name: Matt's Case
 
 case_with_one_try:
   user: :joey
   archived: false
-  caseName: Case with one try
+  case_name: Case with one try
   lastTry: 0
 
 case_with_two_tries:
   user: :joey
   archived: false
-  caseName: Case with two tries
+  case_name: Case with two tries
   lastTry: 1
 
 owned_case:
   user:     :case_finder_user
-  caseName: Case owned by Case Finder User
+  case_name: Case owned by Case Finder User
   archived: false
 
 owned_team_case:
   user:           :random
-  caseName:       Case from Case Finder User's owned team
+  case_name:      Case from Case Finder User's owned team
   archived:       false
 
 shared_team_case:
   user:           :random
-  caseName:       Case from Case Finder User's shared team
+  case_name:      Case from Case Finder User's shared team
   archived:       false
 
 queries_case:
   user:     :random
-  caseName: A case to test queries positions
+  case_name: A case to test queries positions
   archived: false
 
 move_query_to_me:
   user:     :random
-  caseName: A case to test moving queries
+  case_name: A case to test moving queries
   archived: false
 
 metadata_case:
   user:     :random
-  caseName: Metadata Case
+  case_name: Metadata Case
   archived: false
 
 snapshot_case:
   user:     :random
-  caseName: Snapshot Case
+  case_name: Snapshot Case
   archived: false
 
 score_case:
   user:     :random
-  caseName: Score Case
+  case_name: Score Case
   archived: false
 
 other_score_case:
   user:     :random
-  caseName: Other Score Case
+  case_name: Other Score Case
   archived: false
 
 shared_case:
   user:     :random_2
-  caseName: Score Case
+  case_name: Score Case
   archived: false
 
 random_case:
   user:     :random_1
-  caseName: Random Case
+  case_name: Random Case
   archived: false
 
 random_case_1:
   user:     :random_1
-  caseName: Random Case 1
+  case_name: Random Case 1
   archived: false
 
 random_case_2:
   user:     :random_1
-  caseName: Random Case 2
+  case_name: Random Case 2
   archived: false
 
 bootstrap_case:
   user:     :bootstrap_user
-  caseName: Boostrapped Case
+  case_name: Boostrapped Case
   archived: false
 
 import_ratings_case:
   user:     :random
-  caseName: Import Ratings Case
+  case_name: Import Ratings Case
   archived: false
 
 not_shared:
   user:     :not_shared_case_owner
   archived: false
-  caseName: Case not shared
+  case_name: Case not shared
 
 shared_with_owner:
   user:     :random
   archived: false
-  caseName: Case shared with owner
+  case_name: Case shared with owner
 
 dropdown_case_1:
   user:     :dropdown_user
   archived: false
-  caseName: dropdown_case_1
+  case_name: dropdown_case_1
 
 dropdown_case_2:
   user:     :dropdown_user
   archived: false
-  caseName: dropdown_case_2
+  case_name: dropdown_case_2
 
 dropdown_case_archived:
   user:     :dropdown_user
   archived: true
-  caseName: dropdown_case_archived
+  case_name: dropdown_case_archived
 
 case_without_score:
   user:     :random
-  caseName: Case without Score
+  case_name: Case without Score
   archived: false
 
 case_with_score_for_first_try:
   user:     :random
-  caseName: case_with_score_for_first_try
+  case_name: case_with_score_for_first_try
   archived: false
 
 case_with_score:
   user:     :random
-  caseName: case_with_score
+  case_name: case_with_score
   archived: false

--- a/test/fixtures/cases.yml
+++ b/test/fixtures/cases.yml
@@ -4,11 +4,8 @@
 #
 #  id              :integer          not null, primary key
 #  caseName        :string(191)
-#  search_url      :string(500)
-#  field_spec      :string(500)
 #  lastTry         :integer
 #  user_id         :integer
-#  displayPosition :integer
 #  archived        :boolean
 #  scorer_id       :integer
 #  created_at      :datetime         not null

--- a/test/fixtures/cases.yml
+++ b/test/fixtures/cases.yml
@@ -4,7 +4,7 @@
 #
 #  id              :integer          not null, primary key
 #  caseName        :string(191)
-#  searchUrl       :string(500)
+#  search_url      :string(500)
 #  fieldSpec       :string(500)
 #  lastTry         :integer
 #  user_id         :integer

--- a/test/fixtures/cases.yml
+++ b/test/fixtures/cases.yml
@@ -5,7 +5,7 @@
 #  id              :integer          not null, primary key
 #  caseName        :string(191)
 #  search_url      :string(500)
-#  fieldSpec       :string(500)
+#  field_spec      :string(500)
 #  lastTry         :integer
 #  user_id         :integer
 #  displayPosition :integer

--- a/test/fixtures/cases.yml
+++ b/test/fixtures/cases.yml
@@ -4,7 +4,7 @@
 #
 #  id              :integer          not null, primary key
 #  case_name       :string(191)
-#  lastTry         :integer
+#  last_try_number :integer
 #  user_id         :integer
 #  archived        :boolean
 #  scorer_id       :integer
@@ -68,13 +68,13 @@ case_with_one_try:
   user: :joey
   archived: false
   case_name: Case with one try
-  lastTry: 0
+  last_try_number: 0
 
 case_with_two_tries:
   user: :joey
   archived: false
   case_name: Case with two tries
-  lastTry: 1
+  last_try_number: 1
 
 owned_case:
   user:     :case_finder_user

--- a/test/fixtures/tries.yml
+++ b/test/fixtures/tries.yml
@@ -4,7 +4,7 @@
 #
 #  id             :integer          not null, primary key
 #  tryNo          :integer
-#  queryParams    :text(65535)
+#  query_params   :text(65535)
 #  case_id        :integer
 #  field_spec     :string(500)
 #  search_url     :string(500)
@@ -19,174 +19,174 @@
 one:
   case:           :one
   tryNo:          0
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   search_engine:  solr
 
 two:
   case:           :two
   tryNo:          1
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   search_engine:  solr
 
 for_shared_team_case:
   case:           :shared_team_case
   tryNo:          0
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   search_engine:  solr
 
 for_shared_case:
   case:           :shared_case
   tryNo:          0
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   search_engine:  solr
 
 archived:
   case:           :archived
   tryNo:          0
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   search_engine:  solr
 
 for_metadata_case:
   case:           :with_metadata
   tryNo:          1
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   search_engine:  solr
 
 for_case_with_scorer:
   case:           :with_scorer
   tryNo:          1
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   search_engine:  solr
 
 for_case_with_one_try:
   case:           :case_with_one_try
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   tryNo:          0
   search_engine:  solr
 
 first_for_case_with_two_tries:
   case:           :case_with_two_tries
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   tryNo:          0
   search_engine:  solr
 
 second_for_case_with_two_tries:
   case:           :case_with_two_tries
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   tryNo:          1
   search_engine:  solr
 
 first_try_for_score_case:
   case:           :score_case
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   tryNo:          0
   search_engine:  solr
 
 second_try_for_score_case:
   case:           :score_case
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   tryNo:          1
   search_engine:  solr
 
 first_try_for_other_score_case:
   case:           :other_score_case
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   tryNo:          0
   search_engine:  solr
 
 second_try_for_other_score_case:
   case:           :other_score_case
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   tryNo:          1
   search_engine:  solr
 
 try_without_curator_vars:
   case:           :random_case
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   tryNo:          1
   search_engine:  solr
 
 try_with_curator_vars:
   case:           :random_case
-  queryParams:    'q=#$query##&defType=edismax&qf=text^##one## catch_line^##two##'
+  query_params:   'q=#$query##&defType=edismax&qf=text^##one## catch_line^##two##'
   search_url:     test.com
   tryNo:          2
   search_engine:  solr
 
 es_try:
   case:           :random_case
-  queryParams:    '{ "query": { "match": { "text": "#$query##" } } }'
+  query_params:   '{ "query": { "match": { "text": "#$query##" } } }'
   search_url:     test.com
   tryNo:          3
   search_engine:  es
 
 es_try_with_curator_vars:
   case:           :random_case
-  queryParams:    '{ "query": { "multi_match": { "fields": "title, overview", "query": "#$query##", "tie_breaker": "##tieBreaker##" } } }'
+  query_params:   '{ "query": { "multi_match": { "fields": "title, overview", "query": "#$query##", "tie_breaker": "##tieBreaker##" } } }'
   search_url:     test.com
   tryNo:          4
   search_engine:  es
 
 bootstrap_try_1:
   case:           :bootstrap_case
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   tryNo:          0
   search_engine:  solr
 
 bootstrap_try_2:
   case:           :bootstrap_case
-  queryParams:    '{ "query": { "match": { "text": "#$query##" } } }'
+  query_params:   '{ "query": { "match": { "text": "#$query##" } } }'
   search_url:     test.com
   tryNo:          1
   search_engine:  es
 
 for_case_without_score_try_1:
   case:           :case_without_score
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   tryNo:          0
   search_engine:  solr
 
 for_case_with_score_for_first_try_try_1:
   case:           :case_with_score_for_first_try
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   tryNo:          0
   search_engine:  solr
 
 for_case_with_score_for_first_try_try_2:
   case:           :case_with_score_for_first_try
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   tryNo:          1
   search_engine:  solr
 
 for_case_with_score_try_1:
   case:           :case_with_score
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   tryNo:          0
   search_engine:  solr
 
 for_case_with_score_try_2:
   case:           :case_with_score
-  queryParams:    'q=#$query##'
+  query_params:   'q=#$query##'
   search_url:     test.com
   tryNo:          1
   search_engine:  solr

--- a/test/fixtures/tries.yml
+++ b/test/fixtures/tries.yml
@@ -10,7 +10,7 @@
 #  searchUrl      :string(500)
 #  name           :string(50)
 #  search_engine  :string(50)       default("solr")
-#  escapeQuery    :boolean          default(TRUE)
+#  escape_query   :boolean          default(TRUE)
 #  number_of_rows :integer          default(10)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null

--- a/test/fixtures/tries.yml
+++ b/test/fixtures/tries.yml
@@ -9,7 +9,7 @@
 #  fieldSpec      :string(500)
 #  searchUrl      :string(500)
 #  name           :string(50)
-#  searchEngine   :string(50)       default("solr")
+#  search_engine  :string(50)       default("solr")
 #  escapeQuery    :boolean          default(TRUE)
 #  number_of_rows :integer          default(10)
 #  created_at     :datetime         not null
@@ -21,172 +21,172 @@ one:
   tryNo:          0
   queryParams:    'q=#$query##'
   searchUrl:      test.com
-  searchEngine:   solr
+  search_engine:  solr
 
 two:
   case:           :two
   tryNo:          1
   queryParams:    'q=#$query##'
   searchUrl:      test.com
-  searchEngine:   solr
+  search_engine:  solr
 
 for_shared_team_case:
   case:           :shared_team_case
   tryNo:          0
   queryParams:    'q=#$query##'
   searchUrl:      test.com
-  searchEngine:   solr
+  search_engine:  solr
 
 for_shared_case:
   case:           :shared_case
   tryNo:          0
   queryParams:    'q=#$query##'
   searchUrl:      test.com
-  searchEngine:   solr
+  search_engine:  solr
 
 archived:
   case:           :archived
   tryNo:          0
   queryParams:    'q=#$query##'
   searchUrl:      test.com
-  searchEngine:   solr
+  search_engine:  solr
 
 for_metadata_case:
   case:           :with_metadata
   tryNo:          1
   queryParams:    'q=#$query##'
   searchUrl:      test.com
-  searchEngine:   solr
+  search_engine:  solr
 
 for_case_with_scorer:
   case:           :with_scorer
   tryNo:          1
   queryParams:    'q=#$query##'
   searchUrl:      test.com
-  searchEngine:   solr
+  search_engine:  solr
 
 for_case_with_one_try:
   case:           :case_with_one_try
   queryParams:    'q=#$query##'
   searchUrl:      test.com
   tryNo:          0
-  searchEngine:   solr
+  search_engine:  solr
 
 first_for_case_with_two_tries:
   case:           :case_with_two_tries
   queryParams:    'q=#$query##'
   searchUrl:      test.com
   tryNo:          0
-  searchEngine:   solr
+  search_engine:  solr
 
 second_for_case_with_two_tries:
   case:           :case_with_two_tries
   queryParams:    'q=#$query##'
   searchUrl:      test.com
   tryNo:          1
-  searchEngine:   solr
+  search_engine:  solr
 
 first_try_for_score_case:
   case:           :score_case
   queryParams:    'q=#$query##'
   searchUrl:      test.com
   tryNo:          0
-  searchEngine:   solr
+  search_engine:  solr
 
 second_try_for_score_case:
   case:           :score_case
   queryParams:    'q=#$query##'
   searchUrl:      test.com
   tryNo:          1
-  searchEngine:   solr
+  search_engine:  solr
 
 first_try_for_other_score_case:
   case:           :other_score_case
   queryParams:    'q=#$query##'
   searchUrl:      test.com
   tryNo:          0
-  searchEngine:   solr
+  search_engine:  solr
 
 second_try_for_other_score_case:
   case:           :other_score_case
   queryParams:    'q=#$query##'
   searchUrl:      test.com
   tryNo:          1
-  searchEngine:   solr
+  search_engine:  solr
 
 try_without_curator_vars:
   case:           :random_case
   queryParams:    'q=#$query##'
   searchUrl:      test.com
   tryNo:          1
-  searchEngine:   solr
+  search_engine:  solr
 
 try_with_curator_vars:
   case:           :random_case
   queryParams:    'q=#$query##&defType=edismax&qf=text^##one## catch_line^##two##'
   searchUrl:      test.com
   tryNo:          2
-  searchEngine:   solr
+  search_engine:  solr
 
 es_try:
   case:           :random_case
   queryParams:    '{ "query": { "match": { "text": "#$query##" } } }'
   searchUrl:      test.com
   tryNo:          3
-  searchEngine:   es
+  search_engine:  es
 
 es_try_with_curator_vars:
   case:           :random_case
   queryParams:    '{ "query": { "multi_match": { "fields": "title, overview", "query": "#$query##", "tie_breaker": "##tieBreaker##" } } }'
   searchUrl:      test.com
   tryNo:          4
-  searchEngine:   es
+  search_engine:  es
 
 bootstrap_try_1:
   case:           :bootstrap_case
   queryParams:    'q=#$query##'
   searchUrl:      test.com
   tryNo:          0
-  searchEngine:   solr
+  search_engine:  solr
 
 bootstrap_try_2:
   case:           :bootstrap_case
   queryParams:    '{ "query": { "match": { "text": "#$query##" } } }'
   searchUrl:      test.com
   tryNo:          1
-  searchEngine:   es
+  search_engine:  es
 
 for_case_without_score_try_1:
   case:           :case_without_score
   queryParams:    'q=#$query##'
   searchUrl:      test.com
   tryNo:          0
-  searchEngine:   solr
+  search_engine:  solr
 
 for_case_with_score_for_first_try_try_1:
   case:           :case_with_score_for_first_try
   queryParams:    'q=#$query##'
   searchUrl:      test.com
   tryNo:          0
-  searchEngine:   solr
+  search_engine:  solr
 
 for_case_with_score_for_first_try_try_2:
   case:           :case_with_score_for_first_try
   queryParams:    'q=#$query##'
   searchUrl:      test.com
   tryNo:          1
-  searchEngine:   solr
+  search_engine:  solr
 
 for_case_with_score_try_1:
   case:           :case_with_score
   queryParams:    'q=#$query##'
   searchUrl:      test.com
   tryNo:          0
-  searchEngine:   solr
+  search_engine:  solr
 
 for_case_with_score_try_2:
   case:           :case_with_score
   queryParams:    'q=#$query##'
   searchUrl:      test.com
   tryNo:          1
-  searchEngine:   solr
+  search_engine:  solr

--- a/test/fixtures/tries.yml
+++ b/test/fixtures/tries.yml
@@ -6,7 +6,7 @@
 #  tryNo          :integer
 #  queryParams    :text(65535)
 #  case_id        :integer
-#  fieldSpec      :string(500)
+#  field_spec     :string(500)
 #  search_url     :string(500)
 #  name           :string(50)
 #  search_engine  :string(50)       default("solr")

--- a/test/fixtures/tries.yml
+++ b/test/fixtures/tries.yml
@@ -3,7 +3,7 @@
 # Table name: tries
 #
 #  id             :integer          not null, primary key
-#  tryNo          :integer
+#  try_number     :integer
 #  query_params   :text(65535)
 #  case_id        :integer
 #  field_spec     :string(500)
@@ -18,49 +18,49 @@
 
 one:
   case:           :one
-  tryNo:          0
+  try_number:     0
   query_params:   'q=#$query##'
   search_url:     test.com
   search_engine:  solr
 
 two:
   case:           :two
-  tryNo:          1
+  try_number:     1
   query_params:   'q=#$query##'
   search_url:     test.com
   search_engine:  solr
 
 for_shared_team_case:
   case:           :shared_team_case
-  tryNo:          0
+  try_number:     0
   query_params:   'q=#$query##'
   search_url:     test.com
   search_engine:  solr
 
 for_shared_case:
   case:           :shared_case
-  tryNo:          0
+  try_number:     0
   query_params:   'q=#$query##'
   search_url:     test.com
   search_engine:  solr
 
 archived:
   case:           :archived
-  tryNo:          0
+  try_number:     0
   query_params:   'q=#$query##'
   search_url:     test.com
   search_engine:  solr
 
 for_metadata_case:
   case:           :with_metadata
-  tryNo:          1
+  try_number:     1
   query_params:   'q=#$query##'
   search_url:     test.com
   search_engine:  solr
 
 for_case_with_scorer:
   case:           :with_scorer
-  tryNo:          1
+  try_number:     1
   query_params:   'q=#$query##'
   search_url:     test.com
   search_engine:  solr
@@ -69,124 +69,124 @@ for_case_with_one_try:
   case:           :case_with_one_try
   query_params:   'q=#$query##'
   search_url:     test.com
-  tryNo:          0
+  try_number:     0
   search_engine:  solr
 
 first_for_case_with_two_tries:
   case:           :case_with_two_tries
   query_params:   'q=#$query##'
   search_url:     test.com
-  tryNo:          0
+  try_number:     0
   search_engine:  solr
 
 second_for_case_with_two_tries:
   case:           :case_with_two_tries
   query_params:   'q=#$query##'
   search_url:     test.com
-  tryNo:          1
+  try_number:     1
   search_engine:  solr
 
 first_try_for_score_case:
   case:           :score_case
   query_params:   'q=#$query##'
   search_url:     test.com
-  tryNo:          0
+  try_number:     0
   search_engine:  solr
 
 second_try_for_score_case:
   case:           :score_case
   query_params:   'q=#$query##'
   search_url:     test.com
-  tryNo:          1
+  try_number:     1
   search_engine:  solr
 
 first_try_for_other_score_case:
   case:           :other_score_case
   query_params:   'q=#$query##'
   search_url:     test.com
-  tryNo:          0
+  try_number:     0
   search_engine:  solr
 
 second_try_for_other_score_case:
   case:           :other_score_case
   query_params:   'q=#$query##'
   search_url:     test.com
-  tryNo:          1
+  try_number:     1
   search_engine:  solr
 
 try_without_curator_vars:
   case:           :random_case
   query_params:   'q=#$query##'
   search_url:     test.com
-  tryNo:          1
+  try_number:     1
   search_engine:  solr
 
 try_with_curator_vars:
   case:           :random_case
   query_params:   'q=#$query##&defType=edismax&qf=text^##one## catch_line^##two##'
   search_url:     test.com
-  tryNo:          2
+  try_number:     2
   search_engine:  solr
 
 es_try:
   case:           :random_case
   query_params:   '{ "query": { "match": { "text": "#$query##" } } }'
   search_url:     test.com
-  tryNo:          3
+  try_number:     3
   search_engine:  es
 
 es_try_with_curator_vars:
   case:           :random_case
   query_params:   '{ "query": { "multi_match": { "fields": "title, overview", "query": "#$query##", "tie_breaker": "##tieBreaker##" } } }'
   search_url:     test.com
-  tryNo:          4
+  try_number:     4
   search_engine:  es
 
 bootstrap_try_1:
   case:           :bootstrap_case
   query_params:   'q=#$query##'
   search_url:     test.com
-  tryNo:          0
+  try_number:     0
   search_engine:  solr
 
 bootstrap_try_2:
   case:           :bootstrap_case
   query_params:   '{ "query": { "match": { "text": "#$query##" } } }'
   search_url:     test.com
-  tryNo:          1
+  try_number:     1
   search_engine:  es
 
 for_case_without_score_try_1:
   case:           :case_without_score
   query_params:   'q=#$query##'
   search_url:     test.com
-  tryNo:          0
+  try_number:     0
   search_engine:  solr
 
 for_case_with_score_for_first_try_try_1:
   case:           :case_with_score_for_first_try
   query_params:   'q=#$query##'
   search_url:     test.com
-  tryNo:          0
+  try_number:     0
   search_engine:  solr
 
 for_case_with_score_for_first_try_try_2:
   case:           :case_with_score_for_first_try
   query_params:   'q=#$query##'
   search_url:     test.com
-  tryNo:          1
+  try_number:     1
   search_engine:  solr
 
 for_case_with_score_try_1:
   case:           :case_with_score
   query_params:   'q=#$query##'
   search_url:     test.com
-  tryNo:          0
+  try_number:     0
   search_engine:  solr
 
 for_case_with_score_try_2:
   case:           :case_with_score
   query_params:   'q=#$query##'
   search_url:     test.com
-  tryNo:          1
+  try_number:     1
   search_engine:  solr

--- a/test/fixtures/tries.yml
+++ b/test/fixtures/tries.yml
@@ -7,7 +7,7 @@
 #  queryParams    :text(65535)
 #  case_id        :integer
 #  fieldSpec      :string(500)
-#  searchUrl      :string(500)
+#  search_url     :string(500)
 #  name           :string(50)
 #  search_engine  :string(50)       default("solr")
 #  escape_query   :boolean          default(TRUE)
@@ -20,173 +20,173 @@ one:
   case:           :one
   tryNo:          0
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   search_engine:  solr
 
 two:
   case:           :two
   tryNo:          1
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   search_engine:  solr
 
 for_shared_team_case:
   case:           :shared_team_case
   tryNo:          0
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   search_engine:  solr
 
 for_shared_case:
   case:           :shared_case
   tryNo:          0
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   search_engine:  solr
 
 archived:
   case:           :archived
   tryNo:          0
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   search_engine:  solr
 
 for_metadata_case:
   case:           :with_metadata
   tryNo:          1
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   search_engine:  solr
 
 for_case_with_scorer:
   case:           :with_scorer
   tryNo:          1
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   search_engine:  solr
 
 for_case_with_one_try:
   case:           :case_with_one_try
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          0
   search_engine:  solr
 
 first_for_case_with_two_tries:
   case:           :case_with_two_tries
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          0
   search_engine:  solr
 
 second_for_case_with_two_tries:
   case:           :case_with_two_tries
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          1
   search_engine:  solr
 
 first_try_for_score_case:
   case:           :score_case
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          0
   search_engine:  solr
 
 second_try_for_score_case:
   case:           :score_case
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          1
   search_engine:  solr
 
 first_try_for_other_score_case:
   case:           :other_score_case
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          0
   search_engine:  solr
 
 second_try_for_other_score_case:
   case:           :other_score_case
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          1
   search_engine:  solr
 
 try_without_curator_vars:
   case:           :random_case
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          1
   search_engine:  solr
 
 try_with_curator_vars:
   case:           :random_case
   queryParams:    'q=#$query##&defType=edismax&qf=text^##one## catch_line^##two##'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          2
   search_engine:  solr
 
 es_try:
   case:           :random_case
   queryParams:    '{ "query": { "match": { "text": "#$query##" } } }'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          3
   search_engine:  es
 
 es_try_with_curator_vars:
   case:           :random_case
   queryParams:    '{ "query": { "multi_match": { "fields": "title, overview", "query": "#$query##", "tie_breaker": "##tieBreaker##" } } }'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          4
   search_engine:  es
 
 bootstrap_try_1:
   case:           :bootstrap_case
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          0
   search_engine:  solr
 
 bootstrap_try_2:
   case:           :bootstrap_case
   queryParams:    '{ "query": { "match": { "text": "#$query##" } } }'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          1
   search_engine:  es
 
 for_case_without_score_try_1:
   case:           :case_without_score
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          0
   search_engine:  solr
 
 for_case_with_score_for_first_try_try_1:
   case:           :case_with_score_for_first_try
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          0
   search_engine:  solr
 
 for_case_with_score_for_first_try_try_2:
   case:           :case_with_score_for_first_try
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          1
   search_engine:  solr
 
 for_case_with_score_try_1:
   case:           :case_with_score
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          0
   search_engine:  solr
 
 for_case_with_score_try_2:
   case:           :case_with_score
   queryParams:    'q=#$query##'
-  searchUrl:      test.com
+  search_url:     test.com
   tryNo:          1
   search_engine:  solr

--- a/test/models/case_test.rb
+++ b/test/models/case_test.rb
@@ -6,7 +6,7 @@
 #
 #  id              :integer          not null, primary key
 #  case_name       :string(191)
-#  lastTry         :integer
+#  last_try_number :integer
 #  user_id         :integer
 #  archived        :boolean
 #  scorer_id       :integer
@@ -105,7 +105,7 @@ class CaseTest < ActiveSupport::TestCase
 
       default_try = acase.tries.first
 
-      assert_equal default_try.try_number, acase.lastTry
+      assert_equal default_try.try_number, acase.last_try_number
       assert_equal default_try.try_number, 0
     end
 
@@ -176,7 +176,7 @@ class CaseTest < ActiveSupport::TestCase
             assert_equal 1, cloned_case.tries.size
             assert_equal the_case.queries.size, cloned_case.queries.size
             assert_equal user.id, cloned_case.user_id
-            assert_equal 0, cloned_case.lastTry
+            assert_equal 0, cloned_case.last_try_number
           end
         end
       end

--- a/test/models/case_test.rb
+++ b/test/models/case_test.rb
@@ -105,8 +105,8 @@ class CaseTest < ActiveSupport::TestCase
 
       default_try = acase.tries.first
 
-      assert_equal default_try.tryNo, acase.lastTry
-      assert_equal default_try.tryNo, 0
+      assert_equal default_try.try_number, acase.lastTry
+      assert_equal default_try.try_number, 0
     end
 
     test 'sets the default try to the default search engine attributes' do

--- a/test/models/case_test.rb
+++ b/test/models/case_test.rb
@@ -5,7 +5,7 @@
 # Table name: cases
 #
 #  id              :integer          not null, primary key
-#  caseName        :string(191)
+#  case_name       :string(191)
 #  lastTry         :integer
 #  user_id         :integer
 #  archived        :boolean
@@ -20,13 +20,13 @@ require 'test_helper'
 class CaseTest < ActiveSupport::TestCase
   describe 'Creating a case' do
     test 'sets archived flag to false by default' do
-      acase = Case.create(caseName: 'test case')
+      acase = Case.create(case_name: 'test case')
 
       assert_equal acase.archived, false
     end
 
     test 'does not override archived flag if set' do
-      acase = Case.create(caseName: 'test case', archived: true)
+      acase = Case.create(case_name: 'test case', archived: true)
 
       assert_equal acase.archived, true
     end
@@ -37,7 +37,7 @@ class CaseTest < ActiveSupport::TestCase
       user.scorer = user_scorer
       user.save
 
-      acase = Case.create(caseName: 'with default scorer', user: user)
+      acase = Case.create(case_name: 'with default scorer', user: user)
 
       assert_equal acase.scorer_id, user_scorer.id
       assert_equal acase.scorer_id, user.scorer_id
@@ -49,7 +49,7 @@ class CaseTest < ActiveSupport::TestCase
       user.default_scorer = q_scorer
       user.save
 
-      acase = Case.create(caseName: 'with q scorer', user: user)
+      acase = Case.create(case_name: 'with q scorer', user: user)
 
       assert_equal acase.scorer_id,   q_scorer.id
       assert_equal acase.scorer_type, 'DefaultScorer'
@@ -63,7 +63,7 @@ class CaseTest < ActiveSupport::TestCase
       user.default_scorer = q_scorer
       user.save
 
-      acase = Case.create(caseName: 'with default scorer', user: user)
+      acase = Case.create(case_name: 'with default scorer', user: user)
 
       assert_equal acase.scorer_id,   user_scorer.id
       assert_equal acase.scorer_id,   user.scorer_id
@@ -74,7 +74,7 @@ class CaseTest < ActiveSupport::TestCase
       q_scorer2 = default_scorers(:v2)
       user      = users(:random)
 
-      acase = Case.create(caseName: 'with default scorer', user: user)
+      acase = Case.create(case_name: 'with default scorer', user: user)
 
       assert_equal acase.scorer_id,   q_scorer2.id
       assert_equal acase.scorer_type, 'DefaultScorer'
@@ -87,7 +87,7 @@ class CaseTest < ActiveSupport::TestCase
       user.scorer = user_scorer
       user.save
 
-      acase = Case.create(caseName: 'with default scorer', user: user, scorer: case_scorer)
+      acase = Case.create(case_name: 'with default scorer', user: user, scorer: case_scorer)
 
       assert_equal acase.scorer_id, case_scorer.id
       assert_not_equal acase.scorer_id, user_scorer.id
@@ -95,13 +95,13 @@ class CaseTest < ActiveSupport::TestCase
     end
 
     test 'automatically creates a default try' do
-      acase = Case.create(caseName: 'test case')
+      acase = Case.create(case_name: 'test case')
 
       assert_equal acase.tries.count, 1
     end
 
     test 'sets the last try of the case' do
-      acase = Case.create(caseName: 'test case')
+      acase = Case.create(case_name: 'test case')
 
       default_try = acase.tries.first
 
@@ -110,7 +110,7 @@ class CaseTest < ActiveSupport::TestCase
     end
 
     test 'sets the default try to the default search engine attributes' do
-      acase = Case.create(caseName: 'test case')
+      acase = Case.create(case_name: 'test case')
 
       default_try = acase.tries.first
 
@@ -126,7 +126,7 @@ class CaseTest < ActiveSupport::TestCase
     let(:user)        { users(:random) }
     let(:the_case)    { cases(:random_case) }
     let(:the_try)     { the_case.tries.best }
-    let(:cloned_case) { Case.new(caseName: 'Cloned Case') }
+    let(:cloned_case) { Case.new(case_name: 'Cloned Case') }
 
     describe 'when only cloning a try' do
       it 'creates a new case' do
@@ -138,7 +138,7 @@ class CaseTest < ActiveSupport::TestCase
             assert_equal 0, cloned_case.queries.size
             assert_equal user.id, cloned_case.user_id
 
-            assert_equal 'Cloned Case', cloned_case.caseName
+            assert_equal 'Cloned Case', cloned_case.case_name
 
             cloned_try = cloned_case.tries.best
 

--- a/test/models/case_test.rb
+++ b/test/models/case_test.rb
@@ -6,11 +6,8 @@
 #
 #  id              :integer          not null, primary key
 #  caseName        :string(191)
-#  search_url      :string(500)
-#  field_spec      :string(500)
 #  lastTry         :integer
 #  user_id         :integer
-#  displayPosition :integer
 #  archived        :boolean
 #  scorer_id       :integer
 #  created_at      :datetime         not null

--- a/test/models/case_test.rb
+++ b/test/models/case_test.rb
@@ -7,7 +7,7 @@
 #  id              :integer          not null, primary key
 #  caseName        :string(191)
 #  search_url      :string(500)
-#  fieldSpec       :string(500)
+#  field_spec      :string(500)
 #  lastTry         :integer
 #  user_id         :integer
 #  displayPosition :integer
@@ -118,7 +118,7 @@ class CaseTest < ActiveSupport::TestCase
       default_try = acase.tries.first
 
       assert_equal default_try.search_engine, Try::DEFAULTS[:search_engine]
-      assert_equal default_try.fieldSpec,     Try::DEFAULTS[:solr][:field_spec]
+      assert_equal default_try.field_spec,    Try::DEFAULTS[:solr][:field_spec]
       assert_equal default_try.search_url,    Try::DEFAULTS[:solr][:search_url]
       assert_equal default_try.queryParams,   Try::DEFAULTS[:solr][:query_params]
       assert_equal default_try.escape_query,  true
@@ -146,7 +146,7 @@ class CaseTest < ActiveSupport::TestCase
             cloned_try = cloned_case.tries.best
 
             assert_equal the_try.queryParams,   cloned_try.queryParams
-            assert_equal 'title',               cloned_try.fieldSpec
+            assert_equal 'title',               cloned_try.field_spec
             assert_equal the_try.search_url,    cloned_try.search_url
             assert_equal 'Try 0',               cloned_try.name
             assert_equal the_try.search_engine, cloned_try.search_engine

--- a/test/models/case_test.rb
+++ b/test/models/case_test.rb
@@ -121,7 +121,7 @@ class CaseTest < ActiveSupport::TestCase
       assert_equal default_try.fieldSpec,     Try::DEFAULTS[:solr][:field_spec]
       assert_equal default_try.searchUrl,     Try::DEFAULTS[:solr][:search_url]
       assert_equal default_try.queryParams,   Try::DEFAULTS[:solr][:query_params]
-      assert_equal default_try.escapeQuery,   true
+      assert_equal default_try.escape_query,  true
     end
   end
 
@@ -150,7 +150,7 @@ class CaseTest < ActiveSupport::TestCase
             assert_equal the_try.searchUrl,     cloned_try.searchUrl
             assert_equal 'Try 0',               cloned_try.name
             assert_equal the_try.search_engine, cloned_try.search_engine
-            assert_equal the_try.escapeQuery,   cloned_try.escapeQuery
+            assert_equal the_try.escape_query,  cloned_try.escape_query
           end
         end
       end

--- a/test/models/case_test.rb
+++ b/test/models/case_test.rb
@@ -6,7 +6,7 @@
 #
 #  id              :integer          not null, primary key
 #  caseName        :string(191)
-#  searchUrl       :string(500)
+#  search_url      :string(500)
 #  fieldSpec       :string(500)
 #  lastTry         :integer
 #  user_id         :integer
@@ -119,7 +119,7 @@ class CaseTest < ActiveSupport::TestCase
 
       assert_equal default_try.search_engine, Try::DEFAULTS[:search_engine]
       assert_equal default_try.fieldSpec,     Try::DEFAULTS[:solr][:field_spec]
-      assert_equal default_try.searchUrl,     Try::DEFAULTS[:solr][:search_url]
+      assert_equal default_try.search_url,    Try::DEFAULTS[:solr][:search_url]
       assert_equal default_try.queryParams,   Try::DEFAULTS[:solr][:query_params]
       assert_equal default_try.escape_query,  true
     end
@@ -147,7 +147,7 @@ class CaseTest < ActiveSupport::TestCase
 
             assert_equal the_try.queryParams,   cloned_try.queryParams
             assert_equal 'title',               cloned_try.fieldSpec
-            assert_equal the_try.searchUrl,     cloned_try.searchUrl
+            assert_equal the_try.search_url,    cloned_try.search_url
             assert_equal 'Try 0',               cloned_try.name
             assert_equal the_try.search_engine, cloned_try.search_engine
             assert_equal the_try.escape_query,  cloned_try.escape_query

--- a/test/models/case_test.rb
+++ b/test/models/case_test.rb
@@ -117,7 +117,7 @@ class CaseTest < ActiveSupport::TestCase
       assert_equal default_try.search_engine, Try::DEFAULTS[:search_engine]
       assert_equal default_try.field_spec,    Try::DEFAULTS[:solr][:field_spec]
       assert_equal default_try.search_url,    Try::DEFAULTS[:solr][:search_url]
-      assert_equal default_try.queryParams,   Try::DEFAULTS[:solr][:query_params]
+      assert_equal default_try.query_params,  Try::DEFAULTS[:solr][:query_params]
       assert_equal default_try.escape_query,  true
     end
   end
@@ -142,7 +142,7 @@ class CaseTest < ActiveSupport::TestCase
 
             cloned_try = cloned_case.tries.best
 
-            assert_equal the_try.queryParams,   cloned_try.queryParams
+            assert_equal the_try.query_params,  cloned_try.query_params
             assert_equal 'title',               cloned_try.field_spec
             assert_equal the_try.search_url,    cloned_try.search_url
             assert_equal 'Try 0',               cloned_try.name

--- a/test/models/case_test.rb
+++ b/test/models/case_test.rb
@@ -149,7 +149,7 @@ class CaseTest < ActiveSupport::TestCase
             assert_equal 'title',               cloned_try.fieldSpec
             assert_equal the_try.searchUrl,     cloned_try.searchUrl
             assert_equal 'Try 0',               cloned_try.name
-            assert_equal the_try.search_engine,  cloned_try.search_engine
+            assert_equal the_try.search_engine, cloned_try.search_engine
             assert_equal the_try.escapeQuery,   cloned_try.escapeQuery
           end
         end

--- a/test/models/case_test.rb
+++ b/test/models/case_test.rb
@@ -117,7 +117,7 @@ class CaseTest < ActiveSupport::TestCase
 
       default_try = acase.tries.first
 
-      assert_equal default_try.searchEngine,  Try::DEFAULTS[:search_engine]
+      assert_equal default_try.search_engine, Try::DEFAULTS[:search_engine]
       assert_equal default_try.fieldSpec,     Try::DEFAULTS[:solr][:field_spec]
       assert_equal default_try.searchUrl,     Try::DEFAULTS[:solr][:search_url]
       assert_equal default_try.queryParams,   Try::DEFAULTS[:solr][:query_params]

--- a/test/models/case_test.rb
+++ b/test/models/case_test.rb
@@ -149,7 +149,7 @@ class CaseTest < ActiveSupport::TestCase
             assert_equal 'title',               cloned_try.fieldSpec
             assert_equal the_try.searchUrl,     cloned_try.searchUrl
             assert_equal 'Try 0',               cloned_try.name
-            assert_equal the_try.searchEngine,  cloned_try.searchEngine
+            assert_equal the_try.search_engine,  cloned_try.search_engine
             assert_equal the_try.escapeQuery,   cloned_try.escapeQuery
           end
         end

--- a/test/models/query_test.rb
+++ b/test/models/query_test.rb
@@ -32,7 +32,7 @@ class QueryTest < ActiveSupport::TestCase
     end
 
     test 'bootstraps new query with default position values' do
-      new_case = Case.create caseName: 'New Case'
+      new_case = Case.create case_name: 'New Case'
       new_query = new_case.queries.create query_text: 'New query'
 
       assert_equal new_query.arranged_at,   Arrangement::List::STARTING_POSITION

--- a/test/models/try_test.rb
+++ b/test/models/try_test.rb
@@ -11,7 +11,7 @@
 #  fieldSpec      :string(500)
 #  searchUrl      :string(500)
 #  name           :string(50)
-#  searchEngine   :string(50)       default("solr")
+#  search_engine  :string(50)       default("solr")
 #  escapeQuery    :boolean          default(TRUE)
 #  number_of_rows :integer          default(10)
 #  created_at     :datetime         not null

--- a/test/models/try_test.rb
+++ b/test/models/try_test.rb
@@ -5,7 +5,7 @@
 # Table name: tries
 #
 #  id             :integer          not null, primary key
-#  tryNo          :integer
+#  try_number     :integer
 #  query_params   :text(65535)
 #  case_id        :integer
 #  field_spec     :string(500)

--- a/test/models/try_test.rb
+++ b/test/models/try_test.rb
@@ -8,7 +8,7 @@
 #  tryNo          :integer
 #  queryParams    :text(65535)
 #  case_id        :integer
-#  fieldSpec      :string(500)
+#  field_spec     :string(500)
 #  search_url     :string(500)
 #  name           :string(50)
 #  search_engine  :string(50)       default("solr")

--- a/test/models/try_test.rb
+++ b/test/models/try_test.rb
@@ -6,7 +6,7 @@
 #
 #  id             :integer          not null, primary key
 #  tryNo          :integer
-#  queryParams    :text(65535)
+#  query_params   :text(65535)
 #  case_id        :integer
 #  field_spec     :string(500)
 #  search_url     :string(500)

--- a/test/models/try_test.rb
+++ b/test/models/try_test.rb
@@ -12,7 +12,7 @@
 #  searchUrl      :string(500)
 #  name           :string(50)
 #  search_engine  :string(50)       default("solr")
-#  escapeQuery    :boolean          default(TRUE)
+#  escape_query   :boolean          default(TRUE)
 #  number_of_rows :integer          default(10)
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null

--- a/test/models/try_test.rb
+++ b/test/models/try_test.rb
@@ -9,7 +9,7 @@
 #  queryParams    :text(65535)
 #  case_id        :integer
 #  fieldSpec      :string(500)
-#  searchUrl      :string(500)
+#  search_url     :string(500)
 #  name           :string(50)
 #  search_engine  :string(50)       default("solr")
 #  escape_query   :boolean          default(TRUE)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -110,7 +110,7 @@ class UserTest < ActiveSupport::TestCase
         first_case = user.cases.first
 
         assert_not_nil  first_case
-        assert_equal    first_case.caseName, Case::DEFAULT_NAME
+        assert_equal    first_case.case_name, Case::DEFAULT_NAME
       end
     end
   end

--- a/test/services/user_case_finder_test.rb
+++ b/test/services/user_case_finder_test.rb
@@ -53,7 +53,7 @@ class UserCaseFinderTest < ActiveSupport::TestCase
     end
 
     test 'works with complex where clause for owned cases' do
-      result = service.where('`cases`.`caseName` LIKE ?', '%owned by%').all
+      result = service.where('`cases`.`case_name` LIKE ?', '%owned by%').all
 
       assert_instance_of  Case::ActiveRecord_Relation, result
       assert_equal        1,      result.length
@@ -61,7 +61,7 @@ class UserCaseFinderTest < ActiveSupport::TestCase
     end
 
     test "works with complex where clause for cases from user's owned team" do
-      result = service.where('`cases`.`caseName` LIKE ?', '%owned team%').all
+      result = service.where('`cases`.`case_name` LIKE ?', '%owned team%').all
 
       assert_instance_of  Case::ActiveRecord_Relation, result
       assert_equal        1,      result.length
@@ -69,7 +69,7 @@ class UserCaseFinderTest < ActiveSupport::TestCase
     end
 
     test "works with complex where clause for cases from user's shared team" do
-      result = service.where('`cases`.`caseName` LIKE ?', '%shared team%').all
+      result = service.where('`cases`.`case_name` LIKE ?', '%shared team%').all
 
       assert_instance_of  Case::ActiveRecord_Relation, result
       assert_equal        1,      result.length
@@ -77,7 +77,7 @@ class UserCaseFinderTest < ActiveSupport::TestCase
     end
 
     test 'works when querying on the name for owned cases' do
-      result = service.where(caseName: 'Case owned by Case Finder User').all
+      result = service.where(case_name: 'Case owned by Case Finder User').all
 
       assert_instance_of  Case::ActiveRecord_Relation, result
       assert_equal        1,      result.length
@@ -85,7 +85,7 @@ class UserCaseFinderTest < ActiveSupport::TestCase
     end
 
     test "works when querying on the name for cases from user's owned team" do
-      result = service.where(caseName: "Case from Case Finder User's owned team").all
+      result = service.where(case_name: "Case from Case Finder User's owned team").all
 
       assert_instance_of  Case::ActiveRecord_Relation, result
       assert_equal        1,      result.length
@@ -93,7 +93,7 @@ class UserCaseFinderTest < ActiveSupport::TestCase
     end
 
     test "works when querying on the name for cases from user's shared team" do
-      result = service.where(caseName: "Case from Case Finder User's shared team").all
+      result = service.where(case_name: "Case from Case Finder User's shared team").all
 
       assert_instance_of  Case::ActiveRecord_Relation, result
       assert_equal        1,      result.length
@@ -110,7 +110,7 @@ class UserCaseFinderTest < ActiveSupport::TestCase
 
     test 'works when filtering by id' do
       result = service.where(id: owned_case.id)
-        .order(caseName: :asc)
+        .order(case_name: :asc)
         .first
 
       assert_instance_of  Case,  result
@@ -118,42 +118,42 @@ class UserCaseFinderTest < ActiveSupport::TestCase
     end
 
     test 'works with complex where clause for owned cases' do
-      result = service.where('`cases`.`caseName` LIKE ?', '%owned by%').first
+      result = service.where('`cases`.`case_name` LIKE ?', '%owned by%').first
 
       assert_instance_of  Case, result
       assert_equal        result, owned_case
     end
 
     test "works with complex where clause for cases from user's owned team" do
-      result = service.where('`cases`.`caseName` LIKE ?', '%owned team%').first
+      result = service.where('`cases`.`case_name` LIKE ?', '%owned team%').first
 
       assert_instance_of  Case, result
       assert_equal        result, owned_team_case
     end
 
     test "works with complex where clause for cases from user's shared team" do
-      result = service.where('`cases`.`caseName` LIKE ?', '%shared team%').first
+      result = service.where('`cases`.`case_name` LIKE ?', '%shared team%').first
 
       assert_instance_of  Case, result
       assert_equal        result, shared_team_case
     end
 
     test 'works when querying on the name for owned cases' do
-      result = service.where(caseName: 'Case owned by Case Finder User').first
+      result = service.where(case_name: 'Case owned by Case Finder User').first
 
       assert_instance_of  Case, result
       assert_equal        result, owned_case
     end
 
     test "works when querying on the name for cases from user's owned team" do
-      result = service.where(caseName: "Case from Case Finder User's owned team").first
+      result = service.where(case_name: "Case from Case Finder User's owned team").first
 
       assert_instance_of  Case, result
       assert_equal        result, owned_team_case
     end
 
     test "works when querying on the name for cases from user's shared team" do
-      result = service.where(caseName: "Case from Case Finder User's shared team").first
+      result = service.where(case_name: "Case from Case Finder User's shared team").first
 
       assert_instance_of  Case, result
       assert_equal        result, shared_team_case
@@ -169,7 +169,7 @@ class UserCaseFinderTest < ActiveSupport::TestCase
 
     test 'works when filtering by id' do
       result = service.where(id: owned_case.id)
-        .order(caseName: :desc)
+        .order(case_name: :desc)
         .last
 
       assert_instance_of  Case,  result
@@ -177,42 +177,42 @@ class UserCaseFinderTest < ActiveSupport::TestCase
     end
 
     test 'works with complex where clause for owned cases' do
-      result = service.where('`cases`.`caseName` LIKE ?', '%owned by%').last
+      result = service.where('`cases`.`case_name` LIKE ?', '%owned by%').last
 
       assert_instance_of  Case, result
       assert_equal        result, owned_case
     end
 
     test "works with complex where clause for cases from user's owned team" do
-      result = service.where('`cases`.`caseName` LIKE ?', '%owned team%').last
+      result = service.where('`cases`.`case_name` LIKE ?', '%owned team%').last
 
       assert_instance_of  Case, result
       assert_equal        result, owned_team_case
     end
 
     test "works with complex where clause for cases from user's shared team" do
-      result = service.where('`cases`.`caseName` LIKE ?', '%shared team%').last
+      result = service.where('`cases`.`case_name` LIKE ?', '%shared team%').last
 
       assert_instance_of  Case, result
       assert_equal        result, shared_team_case
     end
 
     test 'works when querying on the name for owned cases' do
-      result = service.where(caseName: 'Case owned by Case Finder User').last
+      result = service.where(case_name: 'Case owned by Case Finder User').last
 
       assert_instance_of  Case, result
       assert_equal        result, owned_case
     end
 
     test "works when querying on the name for cases from user's owned team" do
-      result = service.where(caseName: "Case from Case Finder User's owned team").last
+      result = service.where(case_name: "Case from Case Finder User's owned team").last
 
       assert_instance_of  Case, result
       assert_equal        result, owned_team_case
     end
 
     test "works when querying on the name for cases from user's shared team" do
-      result = service.where(caseName: "Case from Case Finder User's shared team").last
+      result = service.where(case_name: "Case from Case Finder User's shared team").last
 
       assert_instance_of  Case, result
       assert_equal        result, shared_team_case


### PR DESCRIPTION
converting python CamelCase to Rails snake_case.  

## Description
Lots of updates!

## Motivation and Context
At somepoint, someone is going to treat Quepid as an API, and build there own front end, say for doing ratings, or otherwise want to import/extract data via API.   Having two styles of how data passes in and out of Quepid is error prone, and has bit me before.   

Let's at least get the API side all the same.   Pay down some tech debt!


## How Has This Been Tested?
unit tests, and then manual testing and looking in the database.   Especially since we don't have any true integration tests between the web app JS layer and the back end Rails app.  

This is very painful ;-)