### PR TITLE
Feature/media embeds

### DIFF
--- a/app/assets/javascripts/directives/searchResult.js
+++ b/app/assets/javascripts/directives/searchResult.js
@@ -39,3 +39,61 @@ angular.module('QuepidApp')
       };
     }
   ]);
+
+angular.module('QuepidApp')
+  .directive('quepidEmbed', [
+    function() {
+      function isAudio(val) {
+        var audioExtensions = [
+            '.mp3',
+            '.wav',
+            '.ogg'
+        ];
+
+        return (new RegExp(audioExtensions.join('|')).test(val));
+      }
+
+      function isImage(val) {
+        var imageExtensions = [
+            '.jpg',
+            '.jpeg',
+            '.gif',
+            '.png'
+        ];
+
+        return (new RegExp(imageExtensions.join('|')).test(val));
+      }
+
+      function isVideo(val) {
+        var videoExtensions = [
+            '.mp4',
+            '.webm'
+        ];
+
+        return (new RegExp(videoExtensions.join('|')).test(val));
+      }
+
+      return {
+        restrict: 'A',
+        scope: {
+          src: '='
+        },
+        templateUrl: 'views/embed.html',
+        link: function(scope) {
+            // Init vars
+            scope.audioSrc = scope.imageSrc = scope.videoSrc = null;
+
+            // Audio Embed
+            if (isAudio(scope.src)) {
+                scope.audioSrc = scope.src;
+            // Image Embed
+            } else if (isImage(scope.src)) {
+                scope.imageSrc = scope.src;
+            // Video Embed
+            } else if(isVideo(scope.src)) {
+                scope.videoSrc = scope.src;
+            }
+        }
+      };
+    }
+  ]);

--- a/app/assets/stylesheets/_cases.scss
+++ b/app/assets/stylesheets/_cases.scss
@@ -73,3 +73,9 @@
   padding:      15px 0 0 15px;
   font-weight:  600;
 }
+
+.media-embed {
+  vertical-align: middle;
+  max-width: 640px;
+  max-height: 640px;
+}

--- a/app/assets/templates/views/embed.html
+++ b/app/assets/templates/views/embed.html
@@ -1,0 +1,3 @@
+<audio ng-if="audioSrc" ng-src="{{audioSrc}}" />
+<img ng-if="imageSrc" ng-src="{{imageSrc}}" />
+<video ng-if="videoSrc" ng-src="{{videoSrc}}" />

--- a/app/assets/templates/views/embed.html
+++ b/app/assets/templates/views/embed.html
@@ -1,3 +1,9 @@
-<audio ng-if="audioSrc" ng-src="{{audioSrc}}" />
-<img ng-if="imageSrc" ng-src="{{imageSrc}}" />
-<video ng-if="videoSrc" ng-src="{{videoSrc}}" />
+<audio class="media-embed" ng-if="audioSrc" controls>
+    <source ng-src="{{audioSrc}}">
+</audio>
+
+<img class="media-embed" ng-if="imageSrc" ng-src="{{imageSrc}}" />
+
+<video class="media-embed" ng-if="videoSrc" controls>
+    <source ng-src="{{videoSrc}}">
+</video

--- a/app/assets/templates/views/searchResult.html
+++ b/app/assets/templates/views/searchResult.html
@@ -38,6 +38,12 @@
             This document can't be uniquely identified, so Quepid can't store ratings for this document. </br> <span ng-bind-html="doc.error"></span>.
           </div>
 
+          <!-- Media Embeds -->
+          <li ng-repeat="(fieldName, fieldValue) in doc.embeds">
+            <span class="subLabel">{{fieldName}}:</span>
+            <span quepid-embed data-src="fieldValue"></span>
+          </li>
+
           <!-- Other fields -->
           <li ng-repeat="(fieldName, fieldValue) in snippets">
             <span class="subLabel">{{fieldName}}:</span>

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "karma-phantomjs-launcher": ">= 0.1.4",
     "ng-json-explorer": "https://github.com/odra/ng-json-explorer",
     "ng-tags-input": "~3.0.0",
-    "splainer-search": "2.5.5",
+    "splainer-search": "2.5.6",
     "tether-shepherd": "latest"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds support for embedding media denoted by `media:` in the fieldSpec.  Relies on https://github.com/o19s/splainer-search/pull/78 to function.

## Description
Added a new media section to the field listing that will embed any supported audio/image/video URLS.

## Motivation and Context
Fixes Issue #56 

## How Has This Been Tested?
Tests have been added to the splainer code, the rendering was tested manually for an audio/image/video embed.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
