### PR TITLE
Wizard Fix

### DIFF
--- a/app/assets/javascripts/controllers/wizardModal.js
+++ b/app/assets/javascripts/controllers/wizardModal.js
@@ -256,7 +256,7 @@ angular.module('QuepidApp')
 
                 createPromises.push(
                   queryPromise(q)
-                    .then(q.search)
+                    .then(q.search.bind(q))
                 );
               }
             }

--- a/app/assets/javascripts/controllers/wizardModal.js
+++ b/app/assets/javascripts/controllers/wizardModal.js
@@ -256,7 +256,11 @@ angular.module('QuepidApp')
 
                 createPromises.push(
                   queryPromise(q)
-                    .then(q.search.bind(q))
+                    /* jshint ignore:start */
+                    .then(function() {
+                        q.search();
+                    })
+                    /* jshint ignore:end */
                 );
               }
             }

--- a/spec/javascripts/angular/controllers/wizardModal_spec.js
+++ b/spec/javascripts/angular/controllers/wizardModal_spec.js
@@ -173,28 +173,26 @@ describe('Controller: WizardModalCtrl', function () {
       expect(autocompleteList).toEqual([{'text': 'thumb:image'}, {'text': 'thumb:imageAlt'}]);
     });
 
+    it('adds queries', function() {
+      $httpBackend.expectPOST('/api/cases/0/tries').respond(200, mockTry);
+      $httpBackend.expectGET('/api/cases/0/scorers').respond(200, {});
+      $httpBackend.expectGET('/api/cases/0/queries?bootstrap=true').respond(200, mockFullQueriesResp);
 
-    // it('adds queries', function() {
-    //   $httpBackend.expectPOST('/api/cases/0/tries').respond(200, mockTry);
-    //   $httpBackend.expectGET('/api/cases/0/scorers').respond(200, {});
-    //   $httpBackend.expectGET('/api/cases/0/queries?bootstrap=true').respond(200, mockFullQueriesResp);
+      for (var i = 0; i < 10; i++) {
+        var testQuery = 'foo ' + i;
+        scope.pendingWizardSettings.addQuery(testQuery);
 
-    //   for (var i = 0; i < 10; i++) {
-    //     var testQuery = 'foo ' + i;
-    //     scope.pendingWizardSettings.addQuery(testQuery);
+        expect(scope.pendingWizardSettings.newQueries).toContain({queryString: testQuery});
 
-    //     expect(scope.pendingWizardSettings.newQueries).toContain({queryString: testQuery});
-    //     expect(scope.pendingWizardSettings.newQueries).toContain({queryString: testQuery});
+        var newQueryRespIth = angular.copy(newQueryResp);
+        newQueryRespIth.query['query_text'] = testQuery;
 
-    //     var newQueryRespIth = angular.copy(newQueryResp);
-    //     newQueryRespIth.query['query_text'] = testQuery;
+        $httpBackend.whenPOST('/api/cases/0/queries').respond(200, newQueryRespIth);
+        $httpBackend.whenJSONP(expectedSolrUrl(mockTry.search_url)).respond(200, {});
+      }
 
-    //     $httpBackend.expectPOST('/api/cases/0/queries').respond(200, newQueryRespIth);
-    //     $httpBackend.expectJSONP(expectedSolrUrl(mockTry.searchUrl)).respond(200, {});
-    //   }
-
-    //   scope.pendingWizardSettings.submit();
-    //   $httpBackend.flush();
-    // });
+      scope.pendingWizardSettings.submit();
+      $httpBackend.flush();
+    });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes the issue of a stalled view after creating a new case and adding queries via the wizard.

## Description
The wizard was seemingly broken during an old promise refactor.  This modification ensures the "this" referenced by the query code doesn't go undefined.

## Motivation and Context
New cases were broken if a user entered queries in the wizard. Fixes issue #66 

## How Has This Been Tested?
A previous test has been restored that covers this functionality.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
