### PR TITLE
Fix to #87, cleanup messy reference to query notes

### DIFF
--- a/app/assets/javascripts/controllers/queryNotes.js
+++ b/app/assets/javascripts/controllers/queryNotes.js
@@ -8,7 +8,6 @@ angular.module('QuepidApp')
     function ($scope, flash, $timeout) {
       var ctrl  = this;
       ctrl.saveInProgress = false;
-      $scope.queryNotes = ''; // need this?
       var timeout = null;
 
       var saveFinished = function() {
@@ -16,7 +15,7 @@ angular.module('QuepidApp')
       };
       var saveNotes = function() {
 
-        $scope.query.saveNotes($scope.displayNotes)
+        $scope.query.saveNotes($scope.query.notes)
           .then( function() {
 
           }, function() {
@@ -35,7 +34,7 @@ angular.module('QuepidApp')
         }
       };
 
-      $scope.$watch('displayNotes', debounceSaveUpdates);
+      $scope.$watch('query.notes', debounceSaveUpdates);
 
 
     }

--- a/app/assets/javascripts/controllers/searchResults.js
+++ b/app/assets/javascripts/controllers/searchResults.js
@@ -170,8 +170,5 @@ angular.module('QuepidApp')
           return $scope.query.rating;
         }
       };
-
-      $scope.displayNotes = $scope.query.notes;
-
     }
   ]);

--- a/app/assets/templates/views/searchResults.html
+++ b/app/assets/templates/views/searchResults.html
@@ -94,7 +94,7 @@
         <label>Notes on this Query:</label>
         <i class="fa fa-spinner fa-spin" ng-show="ctrl.saveInProgress"></i>
         <form>
-          <textarea ng-model="displayNotes" class="form-control"></textarea>
+          <textarea ng-model="query.notes" class="form-control"></textarea>
         </form>
       </div>
     </div>


### PR DESCRIPTION
The searchResults controller was creating a copy of a string value instead of using the original reference.

## Description
Clean up code to use the original reference.

## Motivation and Context
Reported by issue #87 

## How Has This Been Tested?
Manually tested, previous test cases ensure the logic is working correctly.  The view just needed to use the right variable.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
