### PR TITLE
Clone Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.1.? - ?
 * Community member reported race condition in standing up Rails and MySQL and issues with PhantomJS install in the developer `docker-compose.yml` and `Dockerfile.dev` setups.  https://github.com/o19s/quepid/pull/75 by @epugh fixes https://github.com/o19s/quepid/issues/76 and https://github.com/o19s/quepid/issues/73.
 * Add .dockerignore file to prevent unrelated changes from breaking Docker layer cache fixes by @TheSench https://github.com/o19s/quepid/issues/80
+* Fix issue where you couldn't clone a case without including the full history. https://github.com/o19s/quepid/pull/90 by @worleydl fixes https://github.com/o19s/quepid/issues/37 Thanks @janhoy for submitting this bug.
 
 
 ## 6.1.0 - 02/01/2020

--- a/app/assets/javascripts/components/clone_case/_modal.html
+++ b/app/assets/javascripts/components/clone_case/_modal.html
@@ -40,7 +40,7 @@
         <select
           id="try"
           ng-model="ctrl.options.tryId"
-          ng-options="try.tryNo as try.name for try in ctrl.options.tries"
+          ng-options="try.try_number as try.name for try in ctrl.options.tries"
           class="form-control"
         >
         </select>

--- a/app/assets/javascripts/services/caseSvc.js
+++ b/app/assets/javascripts/services/caseSvc.js
@@ -443,15 +443,15 @@ angular.module('QuepidApp')
           clone_queries:    options.queries,
           clone_ratings:    options.ratings,
           preserve_history: options.history,
-          tryNo:            options.tryId,
-          case_name:         options.caseName
+          try_number:       options.tryId,
+          case_name:        options.caseName
         };
         var defaultOptions  = {
           case_id:          theCase.caseNo,
           clone_queries:    false,
           clone_ratings:    false,
           preserve_history: false,
-          tryNo:            null,
+          try_number:       null,
         };
 
         var data = angular.extend({}, defaultOptions, opts);

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -108,11 +108,12 @@ class Case < ActiveRecord::Base
 
       if preserve_history
         original_case.tries.each do |a_try|
-          clone_try a_try
+          clone_try(a_try, true)
         end
       elsif try
-        clone_try try
+        clone_try(try, false)
       end
+
       self.last_try_number = tries.last.try_number
 
       if clone_queries
@@ -165,7 +166,7 @@ class Case < ActiveRecord::Base
   end
 
   # rubocop:disable Metrics/MethodLength
-  def clone_try the_try
+  def clone_try the_try, preserve_history
     new_try = Try.new(
       escape_query:  the_try.escape_query,
       field_spec:    the_try.field_spec,
@@ -173,7 +174,7 @@ class Case < ActiveRecord::Base
       query_params:  the_try.query_params,
       search_engine: the_try.search_engine,
       search_url:    the_try.search_url,
-      try_number:    0
+      try_number:    preserve_history ? the_try.try_number : 0
     )
     tries << new_try
 

--- a/test/models/case_test.rb
+++ b/test/models/case_test.rb
@@ -146,6 +146,7 @@ class CaseTest < ActiveSupport::TestCase
             assert_equal 'title',               cloned_try.field_spec
             assert_equal the_try.search_url,    cloned_try.search_url
             assert_equal 'Try 0',               cloned_try.name
+            assert_equal 0, cloned_case.tries.first.try_number
             assert_equal the_try.search_engine, cloned_try.search_engine
             assert_equal the_try.escape_query,  cloned_try.escape_query
           end
@@ -162,6 +163,10 @@ class CaseTest < ActiveSupport::TestCase
             assert_equal the_case.tries.count, cloned_case.tries.count
             assert_equal 0, cloned_case.queries.count
             assert_equal user.id, cloned_case.user_id
+
+            the_case.tries.each_with_index do |a_try, idx|
+              assert_equal cloned_case.tries[idx].try_number, a_try.try_number
+            end
           end
         end
       end
@@ -177,6 +182,7 @@ class CaseTest < ActiveSupport::TestCase
             assert_equal the_case.queries.size, cloned_case.queries.size
             assert_equal user.id, cloned_case.user_id
             assert_equal 0, cloned_case.last_try_number
+            assert_equal 0, cloned_case.tries.first.try_number
           end
         end
       end
@@ -196,6 +202,8 @@ class CaseTest < ActiveSupport::TestCase
             cloned_case.clone_case the_case, user, try: the_try, clone_queries: true, clone_ratings: true
 
             assert_equal 1, cloned_case.tries.count
+            assert_equal 0, cloned_case.last_try_number
+            assert_equal 0, cloned_case.tries.first.try_number
             assert_equal the_case.queries.count, cloned_case.queries.count
             assert_equal the_case.ratings.count, cloned_case.ratings.count
             assert_equal user.id, cloned_case.user_id


### PR DESCRIPTION
Restores single try clone functionality, fixes behavior of cloning a full case.

## Description
The recent cleanup of case syntax missed a few things on the Angular side.  This had broken the single try clone.

While fixing the issue another bug was discovered where a full case clone assigned 0 to all of the tries try_numbers.  This only allowed for the last try added in the table to be used.  That has also now been fixed.

## Motivation and Context
Fixes #86 

## How Has This Been Tested?
Updated rails tests to verify clone behavior. Angular side tested manually.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
