### PR TITLE
Access top ratings globally

### DIFF
--- a/app/assets/javascripts/factories/ScorerFactory.js
+++ b/app/assets/javascripts/factories/ScorerFactory.js
@@ -13,10 +13,10 @@
       var defaultAlgorithm = [
         '// Gets the average score over a scale of 100',
         '// (assumes query rating on a scale of 1-10)',
-        'var score = avgRating100();',
+        'var score = avgRating100(10);',
         'if (score !== null) {',
         '  // Adds a distance penalty to the score',
-        '  score -= editDistanceFromBest();',
+        '  score -= editDistanceFromBest(10);',
         '}',
         'setScore(score);',
       ].join('\n');
@@ -271,16 +271,10 @@
       // return the ratings as an array from the top-N (count) documents stored in Quepid for a query
       // works globally, not restricted to just search engine results, could be from 'Explain missing'
       function getBestRatings(count, bestDocs) {
-        //var bestDocsRatings = [];
-
-        //bestDocs.slice(0, count)
-        let bestDocsRatings = bestDocs.slice(0, count).map(x => x.rating) 
-
-        // for (var i = 0; i < bestDocs.length; i++) {
-        //   bestDocsRatings.push(bestDocs[i].rating);
-        // }
+        var bestDocsRatings = bestDocs.slice(0, count).map(function(x) {return x.rating;});
+  
         return bestDocsRatings;
-      };
+      }
 
       function distanceFromBest(docs, bestDocs, count) {
         if ( angular.isUndefined(count) ) {
@@ -493,7 +487,7 @@
           }
         };
 
-        var topRatings = function(count = 5) {
+        var topRatings = function(count) {
           return getBestRatings(count, bestDocs);
         };
 

--- a/app/assets/javascripts/factories/ScorerFactory.js
+++ b/app/assets/javascripts/factories/ScorerFactory.js
@@ -77,6 +77,7 @@
       self.scaleToScaleWithLabels = scaleToScaleWithLabels;
       self.showScaleLabel         = showScaleLabel;
       self.teamNames              = teamNames;
+      self.getBestRatings         = getBestRatings;
 
 
       var DEFAULT_NUM_DOCS = 10;
@@ -267,6 +268,20 @@
         return getD(str1.length - 1, str2.length - 1);
       }
 
+      // return the ratings as an array from the top-N (count) documents stored in Quepid for a query
+      // works globally, not restricted to just search engine results, could be from 'Explain missing'
+      function getBestRatings(count, bestDocs) {
+        //var bestDocsRatings = [];
+
+        //bestDocs.slice(0, count)
+        let bestDocsRatings = bestDocs.slice(0, count).map(x => x.rating) 
+
+        // for (var i = 0; i < bestDocs.length; i++) {
+        //   bestDocsRatings.push(bestDocs[i].rating);
+        // }
+        return bestDocsRatings;
+      };
+
       function distanceFromBest(docs, bestDocs, count) {
         if ( angular.isUndefined(count) ) {
           count = DEFAULT_NUM_DOCS;
@@ -306,7 +321,6 @@
         for (i = 0; i < rem; i++) {
           bestDocsRatings.push(null);
         }
-
         return Math.floor(self.editDistance(docsRatings, bestDocsRatings));
       }
 
@@ -477,6 +491,10 @@
           for (i = 0; i < bestDocs.length; i++) {
             f(bestDocs[i]);
           }
+        };
+
+        var topRatings = function(count = 5) {
+          return getBestRatings(count, bestDocs);
         };
 
         var qOption = function(key) {

--- a/app/assets/javascripts/factories/ScorerFactory.js
+++ b/app/assets/javascripts/factories/ScorerFactory.js
@@ -13,10 +13,10 @@
       var defaultAlgorithm = [
         '// Gets the average score over a scale of 100',
         '// (assumes query rating on a scale of 1-10)',
-        'var score = avgRating100(10);',
+        'var score = avgRating100();',
         'if (score !== null) {',
         '  // Adds a distance penalty to the score',
-        '  score -= editDistanceFromBest(10);',
+        '  score -= editDistanceFromBest();',
         '}',
         'setScore(score);',
       ].join('\n');
@@ -241,9 +241,17 @@
 
       function editDistance(str1, str2) {
 
+        var makeZeroArr = function(len) {
+          var rVal = new Array(len);
+          for (var i = 0; i < len; i++) {
+            rVal[i] = 0;
+          }
+          return rVal;
+        };
+
         var d = [];
         for (var i = 0; i < str1.length; i++) {
-          d[i] = new Array(str2.length).fill(0);
+          d[i] = makeZeroArr(str2.length);
         }
 
         var getD = function(i, j) {

--- a/app/assets/javascripts/factories/ScorerFactory.js
+++ b/app/assets/javascripts/factories/ScorerFactory.js
@@ -239,17 +239,10 @@
       }
 
       function editDistance(str1, str2) {
-        var makeZeroArr = function(len) {
-          var rVal = new Array(len);
-          for (var i = 0; i < len; i++) {
-            rVal[i] = 0;
-          }
-          return rVal;
-        };
 
         var d = [];
         for (var i = 0; i < str1.length; i++) {
-          d[i] = makeZeroArr(str2.length);
+          d[i] = new Array(str2.length).fill(0);
         }
 
         var getD = function(i, j) {

--- a/app/assets/javascripts/services/queriesSvc.js
+++ b/app/assets/javascripts/services/queriesSvc.js
@@ -193,7 +193,7 @@ angular.module('QuepidApp')
             }
           });
 
-          var bestDocs  = this.ratingsStore.bestDocs(10);
+          var bestDocs  = this.ratingsStore.bestDocs(this.numFound);
           var scorer    = this.effectiveScorer();
           var score     = scorer.score(this.numFound, otherDocs, bestDocs, this.options);
           var maxScore  = scorer.maxScore(this.numFound, otherDocs, bestDocs, this.options);

--- a/app/assets/javascripts/services/queriesSvc.js
+++ b/app/assets/javascripts/services/queriesSvc.js
@@ -193,7 +193,7 @@ angular.module('QuepidApp')
             }
           });
 
-          var bestDocs  = this.ratingsStore.bestDocs(this.numFound);
+          var bestDocs  = this.ratingsStore.bestDocs();
           var scorer    = this.effectiveScorer();
           var score     = scorer.score(this.numFound, otherDocs, bestDocs, this.options);
           var maxScore  = scorer.maxScore(this.numFound, otherDocs, bestDocs, this.options);

--- a/app/assets/javascripts/services/ratingsStoreSvc.js
+++ b/app/assets/javascripts/services/ratingsStoreSvc.js
@@ -122,7 +122,7 @@ angular.module('QuepidApp')
             ratingsArray.push({'id': docId, 'rating': parseInt(rating, 10)});
           });
           ratingsArray.sort(function(a, b) {return b.rating - a.rating;}); //descending order; null values are last; don't think returning null values is problematic but if it becomes we could filter them out here
-          return ratingsArray
+          return ratingsArray;
         };
 
         // A Solr doc rateable for a this RatingStore's caseNo & queryId

--- a/app/assets/javascripts/services/ratingsStoreSvc.js
+++ b/app/assets/javascripts/services/ratingsStoreSvc.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// This service handles the giant blob of docs->ratings
+// This service handles the giant blob of docs->ratingsyea
 // sent down from the backend. It comes in when the query
 // is initially retrieved and managed here.
 //
@@ -115,14 +115,14 @@ angular.module('QuepidApp')
 
         // Retrieve the best documents based on rating
         // a list of ids sorted by rating
-        this.bestDocs = function(numBest) {
+        this.bestDocs = function() {
           // take the object -> list of objects
           var ratingsArray = [];
           angular.forEach(ratingsDict, function(rating, docId) {
             ratingsArray.push({'id': docId, 'rating': parseInt(rating, 10)});
           });
-          ratingsArray.sort(function(a, b) {return b.rating - a.rating;});
-          return ratingsArray.slice(0, numBest);
+          ratingsArray.sort(function(a, b) {return b.rating - a.rating;}); //descending order; null values are last; don't think returning null values is problematic but if it becomes we could filter them out here
+          return ratingsArray
         };
 
         // A Solr doc rateable for a this RatingStore's caseNo & queryId

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
   # config.assets.debug = true
-  config.assets.debug = true
+  config.assets.debug = false
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.

--- a/db/migrate/20200303190724_update_default_scorers_for_legacy_v1_behavior.rb
+++ b/db/migrate/20200303190724_update_default_scorers_for_legacy_v1_behavior.rb
@@ -1,0 +1,30 @@
+class UpdateDefaultScorersForLegacyV1Behavior < ActiveRecord::Migration
+  def up
+    UpdateDefaultScorersForLegacyV1Behavior.connection.execute(
+      "UPDATE default_scorers
+      SET code =
+      '// Gets the average score over a scale of 100
+      // (assumes query rating on a scale of 1-10)
+      var score = avgRating100(10);
+      if (score !== null) {
+      // Adds a distance penalty to the score
+      score -= editDistanceFromBest(10);
+      }
+      setScore(score);'
+      WHERE name = 'v1'")
+  end
+  def down
+    UpdateDefaultScorersForLegacyV1Behavior.connection.execute(
+      "UPDATE default_scorers
+      SET code =
+      '// Gets the average score over a scale of 100
+      // (assumes query rating on a scale of 1-10)
+      var score = avgRating100();
+      if (score !== null) {
+      // Adds a distance penalty to the score
+      score -= editDistanceFromBest();
+      }
+      setScore(score);'
+      WHERE name = 'v1'")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200128133401) do
+ActiveRecord::Schema.define(version: 20200303190724) do
 
   create_table "annotations", force: :cascade do |t|
     t.text     "message",    limit: 65535
@@ -85,6 +85,7 @@ ActiveRecord::Schema.define(version: 20200128133401) do
     t.boolean  "default",                              default: false
     t.datetime "created_at",                                             null: false
     t.datetime "updated_at",                                             null: false
+    t.integer  "decimal_places",         limit: 1,     default: 0
   end
 
   create_table "permissions", force: :cascade do |t|

--- a/spec/javascripts/angular/services/scorerFactory_spec.js
+++ b/spec/javascripts/angular/services/scorerFactory_spec.js
@@ -571,6 +571,24 @@ describe('Service: ScorerFactory', function () {
       checkExpectation(521, docs, bestDocs, 0);
     });
 
+    it('topRatings() returns the proper number of rating', function() {
+      var docs = makeDocs([
+        {rating: 10},
+        {rating: 9},
+        {rating: 8},
+        {rating: 7}
+      ]);
+      var bestDocs = [
+        {rating: 10},
+        {rating: 9},
+        {rating: 8},
+        {rating: 7}
+      ];
+      scorer.code = 'assert(JSON.stringify(topRatings(2)) === "[10,9]"); pass()';
+ 
+      checkExpectation(2, docs, bestDocs, 100)
+    });
+
     //it('scripted scorer that always passes', function() {
       //var docs = makeDocs([{rating: 10, doc: {'title': 'boo'}}]);
       //scorer.code = 'pass()';


### PR DESCRIPTION
New functionality to access all rated documents for a given query.

## Description
New scorer helper function `topRatings(count = 5)` that will return the highest-N ratings available in Quepid globally for given query. New internal function `getBestRatings(count, bestDocs)` to help keep future development in ScorerFactory.js DRY.

## Motivation and Context
Provides avenue to address #78, because `topRatings()` will pull in documents rated via `Explain missing`. Also provides a long-term fix for the woes of #77, by providing the tooling to properly compute nDCG globally.

## How Has This Been Tested?
Using the "Test All" commands from the README.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
