### PR TITLE
Add link to quepid scorers for admins

### DIFF
--- a/app/views/layouts/_user_navigation.html.erb
+++ b/app/views/layouts/_user_navigation.html.erb
@@ -15,9 +15,10 @@
       </li>
       <li><a class="dropdown-link" href="/logout" target="_self">Log out</a></li>
       <% if current_user.administrator? %>
-      <li class="dropdown-header">Admin</li>
-      <li><a class="dropdown-link" href="/admin" target="_self">Index</a></li>
+      <li role="separator" class="divider"></li>
+      <li><a class="dropdown-link" href="/admin" target="_self">Admin Home</a></li>
       <li><%= link_to 'Users', admin_users_path, class: 'dropdown-link', target: '_self' %></li>
+      <li><a class="dropdown-link" href="/admin/default_scorers" target="_self">Quepid Scorers</a></li>
       <li><a class="dropdown-link" href="/admin/jobs" target="_self">Job Manager</a></li>
       <% end %>
     </ul>

--- a/app/views/layouts/_user_navigation.html.erb
+++ b/app/views/layouts/_user_navigation.html.erb
@@ -8,17 +8,13 @@
     </a>
 
     <ul class="dropdown-menu dropdown-content" uib-dropdown-menu>
-      <li>
-        <%= link_to profile_path, class: 'dropdown-link', target: '_self' do %>
-          My profile
-        <% end -%>
-      </li>
-      <li><a class="dropdown-link" href="/logout" target="_self">Log out</a></li>
+      <li><%= link_to 'My profile', profile_path, class: 'dropdown-link', target: '_self' %></li>
+      <li><%= link_to 'Log out', logout_path, class: 'dropdown-link', target: '_self' %></li>
       <% if current_user.administrator? %>
       <li role="separator" class="divider"></li>
-      <li><a class="dropdown-link" href="/admin" target="_self">Admin Home</a></li>
+      <li><%= link_to 'Admin Home', admin_path, class: 'dropdown-link', target: '_self' %></li>
       <li><%= link_to 'Users', admin_users_path, class: 'dropdown-link', target: '_self' %></li>
-      <li><a class="dropdown-link" href="/admin/default_scorers" target="_self">Quepid Scorers</a></li>
+      <li><%= link_to 'Quepid Scorers', admin_default_scorers_path, class: 'dropdown-link', target: '_self' %></li>
       <li><a class="dropdown-link" href="/admin/jobs" target="_self">Job Manager</a></li>
       <% end %>
     </ul>


### PR DESCRIPTION
The shared global scorers in Quepid are kind of hidden.  First you have to be an Admin, then you have to find it under the index page.

## Description
add a link to the drop down.

## Motivation and Context
A community user logged into Quepid to get the shared scorers and metnioned they didn't find it.  this doesn't solve that, because the person wasn't an admin...  But sparked this thought.


## How Has This Been Tested?
Manual gui testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
