### PR TITLE
use non default ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## 6.?.? - ??
+## 6.1.? - ??
+* Community member reported the default demo TMDB Elasticsearch server on port 9200 had on data.  Having seem random "drive by vandalism" of our demo Solr and ES servers on default ports, we want to move away.  https://github.com/o19s/quepid/pull/103 by @epugh changes default used in Wizard to port 9206 and 8985.
 
 ## 6.1.1 - 03/07/2020
 * Community member reported race condition in standing up Rails and MySQL and issues with PhantomJS install in the developer `docker-compose.yml` and `Dockerfile.dev` setups.  https://github.com/o19s/quepid/pull/75 by @epugh fixes https://github.com/o19s/quepid/issues/76 and https://github.com/o19s/quepid/issues/73.

--- a/app/assets/javascripts/services/settingsSvc.js
+++ b/app/assets/javascripts/services/settingsSvc.js
@@ -27,7 +27,7 @@ angular.module('QuepidApp')
           additionalFields: ['overview','thumb:poster_path'],
           numberOfRows:     10,
           searchEngine:     'solr',
-          searchUrl:        'http://quepid-solr.dev.o19s.com/solr/tmdb/select',
+          searchUrl:        'http://quepid-solr.dev.o19s.com:8985/solr/tmdb/select',
           urlFormat:        'http(s?)://yourdomain.com:8983/<index>/select',
         },
         es: {
@@ -48,7 +48,7 @@ angular.module('QuepidApp')
           additionalFields:  ['overview','thumb:poster_path'],
           numberOfRows:      10,
           searchEngine:      'es',
-          searchUrl:         'http://quepid-elasticsearch.dev.o19s.com:9200/tmdb/_search',
+          searchUrl:         'http://quepid-elasticsearch.dev.o19s.com:9206/tmdb/_search',
           urlFormat:         'http(s?)://yourdomain.com:9200/<index>/_search',
         }
       };


### PR DESCRIPTION


## Description
change to non default ES and Solr urls in the wizard

## Motivation and Context
We get drive by vandalism of our demo ES and Solr instances because they are on default ports, but don't seem to see this on non default ports.   Security by Obsurity FTW!


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [] All new and existing tests passed.
