### PR TITLE
Show array values with JSON explorer

### DIFF
--- a/app/assets/javascripts/controllers/searchResult.js
+++ b/app/assets/javascripts/controllers/searchResult.js
@@ -83,8 +83,8 @@ angular.module('QuepidApp')
         });
       };
 
-      $scope.isJSONObject = function(value) {
-        return typeof value === 'object' &&  value instanceof Array !== true;
+      $scope.isObjectOrArray = function(value) {
+        return typeof value === 'object';
       };
       $scope.isUrl = function(value) {
         return ( /^\s+http/.test(value));

--- a/app/assets/templates/views/detailedDoc.html
+++ b/app/assets/templates/views/detailedDoc.html
@@ -7,7 +7,7 @@
 
     <div class="col-md-8">
       <span
-        ng-if="isJSONObject(subValue)"
+        ng-if="isObjectOrArray(subValue)"
       >
         <json-explorer
           json-data="subValue"
@@ -17,7 +17,7 @@
 
       <span
         ng-bind-html="subValue"
-        ng-if="!isJSONObject(subValue)"
+        ng-if="!isObjectOrArray(subValue)"
       >
       </span>
     </div>

--- a/app/assets/templates/views/searchResult.html
+++ b/app/assets/templates/views/searchResult.html
@@ -49,7 +49,7 @@
             <span class="subLabel">{{fieldName}}:</span>
 
             <span
-              ng-if="isJSONObject(fieldValue)"
+              ng-if="isObjectOrArray(fieldValue)"
             >
               <!-- output JSON blob -->
               <json-explorer
@@ -66,7 +66,7 @@
 
             <span
               ng-bind-html="fieldValue"
-              ng-if="!isJSONObject(fieldValue) && !isUrl(fieldValue)"
+              ng-if="!isObjectOrArray(fieldValue) && !isUrl(fieldValue)"
             >
               <!-- Normal display of a snippet -->
             </span>


### PR DESCRIPTION
## Description

When the selected field is an array, don't coalesce it to a string. Instead, show it as a JSON explorer value.  This change won't do anything until https://github.com/o19s/splainer-search/pull/81 is merged and the dependency of this version is updated.

## Motivation and Context

This resolves https://github.com/o19s/quepid/issues/52

## How Has This Been Tested?

Select a field that is an array and verify that the JSON explorer is shown instead of `"[object Object], [object Object]"`. Also select a text field and verify that it's still highlighted.

## Types of changes
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.