### PR TITLE
Server side export of judgement list in csv and JSON

### DIFF
--- a/app/assets/javascripts/components/export_case/export_case_controller.js
+++ b/app/assets/javascripts/components/export_case/export_case_controller.js
@@ -29,14 +29,7 @@ angular.module('QuepidApp')
       }
 
       function exportRatingsCSV() {
-        caseCSVSvc.stringifyQueries(ctrl.theCase, true)
-          .then(function(response){
-            var blob = new Blob([response.data], {
-              type: 'text/csv'
-            });
-            /*global saveAs */
-            saveAs(blob, ctrl.theCase.caseName + '_ratings.csv');
-          });
+        caseCSVSvc.exportRatings(ctrl.theCase);        
       }
     }
   ]);

--- a/app/assets/javascripts/components/export_entire_case/_modal.html
+++ b/app/assets/javascripts/components/export_entire_case/_modal.html
@@ -46,6 +46,13 @@
       </select>
     </label>
   </div>
+  <div class="form-group">
+    <input type="radio" id="basic" name="exportSelection" value="basic" ng-model="ctrl.options.which">
+    <label for="basic">Basic</label>
+    <span class="help-block">
+      Simplest CSV file format with just <code>query,docid,rating</code>.
+    </span>
+  </div>
 </div>
 <div class="modal-footer">
   <button class="btn btn-default float-left" ng-click="ctrl.cancel()">Cancel</button>

--- a/app/assets/javascripts/components/export_entire_case/export_entire_case_controller.js
+++ b/app/assets/javascripts/components/export_entire_case/export_entire_case_controller.js
@@ -88,6 +88,11 @@ angular.module('QuepidApp')
           });
 
         }
+        else if ( options.which === 'basic' ) {
+         $log.info('Selected "basic" as export option.');
+         caseCSVSvc.exportRatings(ctrl.theCase);
+
+        }
       }
 
       function prompt() {

--- a/app/assets/javascripts/components/import_ratings/_modal.html
+++ b/app/assets/javascripts/components/import_ratings/_modal.html
@@ -11,7 +11,7 @@
 </div>
 <div class="modal-body">
   <p>Importing ratings is a great way to manage the rating process outside of Quepid, for example in your own custom application.
-    The CSV file should have the headers: <code>'Query Text', 'Doc ID', 'Rating'</code>
+    The CSV file should have the headers: <code>query,docid,rating</code>
   </p>
 
   <p>Select CSV file to import:</p>

--- a/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
+++ b/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
@@ -25,7 +25,7 @@ angular.module('QuepidApp')
         headers     = headers.split(ctrl.csv.separator);
 
         var expectedHeaders = [
-          'Query Text', 'Doc ID', 'Rating'
+          'query', 'docid', 'rating'
         ];
 
         if (!angular.equals(headers, expectedHeaders)) {

--- a/app/assets/javascripts/services/caseCSVSvc.js
+++ b/app/assets/javascripts/services/caseCSVSvc.js
@@ -13,8 +13,9 @@
 (function() {
   angular.module('QuepidApp')
     .service('caseCSVSvc', [
+      '$http',
       'queriesSvc',
-      function(queriesSvc) {
+      function($http, queriesSvc) {
         var self          = this;
         var EOL           = '\r\n';
         var textDelimiter = '"';
@@ -25,6 +26,7 @@
         self.snapshotHeaderToCSV        = snapshotHeaderToCSV;
         self.stringify                  = stringify;
         self.stringifyQueries           = stringifyQueries;
+        self.exportRatings              = exportRatings;
         self.stringifyQueriesDetailed   = stringifyQueriesDetailed;
         self.stringifySnapshot          = stringifySnapshot;
 
@@ -47,9 +49,9 @@
 
         function queriesHeaderToCSV () {
           var header = [
-            'Query Text',
-            'Doc ID',
-            'Rating',
+            'query',
+            'doc_id',
+            'rating',
           ];
 
           var headerString = header.join(',');
@@ -179,6 +181,25 @@
         }
 
         /**
+         * Very similar to stringifyQueries, but the logic is all
+         * on the server side.
+         *
+         * @param aCase
+         *
+         */
+        function exportRatings(aCase) {
+          $http.get('/api/export/ratings/' + aCase.caseNo + '.csv')
+            .then(function(response) {
+              var blob = new Blob([response.data], {
+                type: 'text/csv'
+              });
+              
+              /*global saveAs */
+              saveAs(blob, aCase.caseName + '_basic.csv');
+            });
+        }
+
+        /**
          * Creates CSV string of queries from a case object
          * including every field in the field list
          *
@@ -274,7 +295,7 @@
             }
             else {
               data = data.join(',');
-            }          
+            }
           }
           if (typeof data === 'string') {
             data = data.replace(/"/g, '""'); // Escape double quotes

--- a/app/assets/javascripts/services/importRatingsSvc.js
+++ b/app/assets/javascripts/services/importRatingsSvc.js
@@ -20,9 +20,9 @@ angular.module('QuepidApp')
 
         angular.forEach(csv, function(rating) {
           ratings.push({
-            query_text: rating['Query Text'],
-            doc_id:     rating['Doc ID'],
-            rating:     rating['Rating'],
+            query_text: rating['query'],
+            doc_id:     rating['docid'],
+            rating:     rating['rating'],
           });
         });
 

--- a/app/controllers/api/v1/export/ratings_controller.rb
+++ b/app/controllers/api/v1/export/ratings_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'csv'
+require 'date'
+
+module Api
+  module V1
+    module Export
+      class RatingsController < Api::ApiController
+        before_action :find_case
+        before_action :check_case
+
+        def show
+          respond_to do |format|
+            format.json
+            format.csv do
+              headers['Content-Disposition'] = "attachment; filename=\"case_#{@case.id}_judgements.csv\""
+              headers['Content-Type'] ||= 'text/csv'
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/export/ratings_controller.rb
+++ b/app/controllers/api/v1/export/ratings_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
+
 require 'csv'
-require 'date'
 
 module Api
   module V1

--- a/app/views/api/v1/export/ratings/_query.json.jbuilder
+++ b/app/views/api/v1/export/ratings/_query.json.jbuilder
@@ -1,0 +1,4 @@
+json.query query.query_text
+json.ratings do
+  query.ratings.each { |rating| json.set! rating.doc_id, rating.rating }
+end

--- a/app/views/api/v1/export/ratings/_query.json.jbuilder
+++ b/app/views/api/v1/export/ratings/_query.json.jbuilder
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 json.query query.query_text
 json.ratings do
   query.ratings.each { |rating| json.set! rating.doc_id, rating.rating }

--- a/app/views/api/v1/export/ratings/show.csv.erb
+++ b/app/views/api/v1/export/ratings/show.csv.erb
@@ -2,13 +2,9 @@
 headers = ['query','docid','rating']
 data = []
 %>
-<%= ::CSV.generate_line(headers).html_safe %>
-<%= ::CSV.generate_line(['dude',@case.id,@case.ratings.size]).html_safe %>
-<%
+<%= ::CSV.generate_line(headers).html_safe %><%
 @case.queries.each do |query|
   query.ratings.each do |rating|
-%>
-<%= ::CSV.generate_line([query.query_text,rating.doc_id, rating.rating]).html_safe %>
-<%
+%><%= ::CSV.generate_line([query.query_text,rating.doc_id, rating.rating]).html_safe %><%
   end
 end %>

--- a/app/views/api/v1/export/ratings/show.csv.erb
+++ b/app/views/api/v1/export/ratings/show.csv.erb
@@ -1,0 +1,15 @@
+<%
+headers = ['query','docid','rating']
+data = []
+%>
+<%= ::CSV.generate_line(headers).html_safe %>
+<%= ::CSV.generate_line(['dude',@case.id,@case.ratings.size]).html_safe %>
+<%
+@case.queries.each do |query|
+  query.ratings.each do |rating|
+%>
+<%= ::CSV.generate_line([query.query_text,rating.doc_id, rating.rating]).html_safe %>
+<%
+  end
+end
+%>

--- a/app/views/api/v1/export/ratings/show.csv.erb
+++ b/app/views/api/v1/export/ratings/show.csv.erb
@@ -11,5 +11,4 @@ data = []
 <%= ::CSV.generate_line([query.query_text,rating.doc_id, rating.rating]).html_safe %>
 <%
   end
-end
-%>
+end %>

--- a/app/views/api/v1/export/ratings/show.json.jbuilder
+++ b/app/views/api/v1/export/ratings/show.json.jbuilder
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 json.queries do
   json.array! @case.queries, partial: 'query', as: :query
 end

--- a/app/views/api/v1/export/ratings/show.json.jbuilder
+++ b/app/views/api/v1/export/ratings/show.json.jbuilder
@@ -1,0 +1,3 @@
+json.queries do
+  json.array! @case.queries, partial: 'query', as: :query
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,11 @@ Rails.application.routes.draw do
         resources :ratings, only: [ :create ]
       end
 
+      # Exports
+      namespace :export do
+        resources :ratings, only: [ :show ], param: :case_id
+      end
+
       namespace :bulk do
         resources :cases, only: [] do
           resources :queries, only: [ :create ]

--- a/test/controllers/api/v1/exports/ratings_controller_test.rb
+++ b/test/controllers/api/v1/exports/ratings_controller_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Api
+  module V1
+    module Export
+      class RatingsControllerTest < ActionController::TestCase
+        let(:doug) { users(:doug) }
+
+        before do
+          @controller = Api::V1::Export::RatingsController.new
+
+          login_user doug
+        end
+
+        describe 'Exporting a case in json' do
+          let(:the_case)  { cases(:one) }
+          let(:matt_case) { cases(:matt_case) }
+
+          test "returns a not found error if the case is not in the signed in user's case list" do
+            get :show, case_id: matt_case.id
+            assert_response :not_found
+          end
+
+          test 'returns case info' do
+            get :show, case_id: the_case.id
+            assert_response :ok
+
+            body = JSON.parse(response.body)
+
+            assert_equal body['queries'].size,      the_case.queries.size
+            assert_equal body['queries'][0]['query'],  the_case.queries[0].query_text
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/test/controllers/api/v1/exports/ratings_controller_test.rb
+++ b/test/controllers/api/v1/exports/ratings_controller_test.rb
@@ -29,11 +29,10 @@ module Api
 
             body = JSON.parse(response.body)
 
-            assert_equal body['queries'].size,      the_case.queries.size
+            assert_equal body['queries'].size,         the_case.queries.size
             assert_equal body['queries'][0]['query'],  the_case.queries[0].query_text
           end
         end
-
       end
     end
   end


### PR DESCRIPTION
## Description
Today Quepid only exports what is in the "view port" of the list of qeuries.  So if you have rated other queries that aren't in the top 10 or whatever you have looked at, you don't see them.  

Additionally, the current export is a bit of a hot mess, and very hard to extend.  This moves exporting over to the server side.

## Motivation and Context
Make exporting from Quepid to other tools like RRE and friends easier.  Be able to export and import your judgments.

## How Has This Been Tested?
manually and adding a itnegration test.

## Screenshots or GIFs (if appropriate):
JSON:

![Screenshot at May 16 11-13-02](https://user-images.githubusercontent.com/22395
/82123538-f66d3800-9767-11ea-8a66-56b07f7c6bca.png)

CSV:

```
query,docid,rating
dude,1,28
staR,9296,8
staR,193,8
staR,12180,8
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
