### PR TITLE
Import formatted ratings

### DIFF
--- a/app/assets/javascripts/components/export_case/_modal.html
+++ b/app/assets/javascripts/components/export_case/_modal.html
@@ -7,7 +7,7 @@
 
 <div class="modal-header">
   <button type="button" class="close" aria-label="Close" ng-click="ctrl.cancel()"><span aria-hidden="true">&times;</span></button>
-  <h3 class="modal-title">Export case: <span class="modal-case">{{ ctrl.theCase.caseName }}</span></h3>
+  <h3 class="modal-title">Export Case: <span class="modal-case">{{ ctrl.theCase.caseName }}</span></h3>
 </div>
 <div class="modal-body">
   <p>There are a number of formats for exporting data from Quepid.</p>

--- a/app/assets/javascripts/components/import_ratings/_modal.html
+++ b/app/assets/javascripts/components/import_ratings/_modal.html
@@ -19,7 +19,6 @@
   <ng-csv-import
     class="import"
     content="ctrl.csv.content"
-    upload-button-label="ctrl.csv.uploadButtonLabel"
     header="ctrl.csv.header"
     header-visible="true"
     separator="ctrl.csv.separator"

--- a/app/assets/javascripts/components/import_ratings/_modal.html
+++ b/app/assets/javascripts/components/import_ratings/_modal.html
@@ -55,11 +55,13 @@
     <input type="radio" id="rre" name="importSelection" value="rre" ng-model="ctrl.options.which">
     <label for="rre">RRE</label>
     <span class="help-block">
-      The RRE file should have the headers: <code>query,docid,rating</code>
+      Quepid only imports the ratings part of the <a href="https://github.com/SeaseLtd/rated-ranking-evaluator/wiki/What%20We%20Need%20To%20Provide#ratings" target="_blank">RRE judgement</a> file.
     </span>
-    <p>Select RRE ratings json file to import:</p>
+    <p>Select RRE ratings file to import:</p>
     <!-- this onchange is a code smell. -->
-    <input type="file" id="file" name="file" onchange="angular.element(this).scope().pickedFile()"/>
+    <input type="file" id="file" name="file"
+      accept="application/json"
+      onchange="angular.element(this).scope().pickedFile()"/>
 
 
   </div>

--- a/app/assets/javascripts/components/import_ratings/_modal.html
+++ b/app/assets/javascripts/components/import_ratings/_modal.html
@@ -46,7 +46,7 @@
     <div ng-if="ctrl.csv.content" class="block left">
       <h2>CSV</h2>
       <div ng-show="ctrl.import.alert" class="text-danger bg-danger" ng-bind-html="ctrl.import.alert">
-      </div>      
+      </div>
       <div class="content import-content"><pre>{{ ctrl.csv.content }}</pre></div>
     </div>
   </div>
@@ -58,6 +58,8 @@
       The RRE file should have the headers: <code>query,docid,rating</code>
     </span>
     <p>Select RRE ratings json file to import:</p>
+    <!-- this onchange is a code smell. -->
+    <input type="file" id="file" name="file" onchange="angular.element(this).scope().pickedFile()"/>
 
 
   </div>

--- a/app/assets/javascripts/components/import_ratings/_modal.html
+++ b/app/assets/javascripts/components/import_ratings/_modal.html
@@ -7,39 +7,61 @@
 
 <div class="modal-header">
   <button type="button" class="close" ng-click="ctrl.cancel()" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-  <h3 class="modal-title">Import Ratings</h3>
+  <h3 class="modal-title">Import into Case: <span class="modal-case">{{ ctrl.theCase.caseName }}</span></h3>
 </div>
 <div class="modal-body">
-  <p>Importing ratings is a great way to manage the rating process outside of Quepid, for example in your own custom application.
-    The CSV file should have the headers: <code>query,docid,rating</code>
+  <p>
+    Importing ratings is a great way to manage the rating process outside of Quepid, for example in your own custom application.
+    There are a number of formats for importing data into Quepid.
   </p>
-
-  <p>Select CSV file to import:</p>
-
-  <ng-csv-import
-    class="import"
-    content="ctrl.csv.content"
-    header="ctrl.csv.header"
-    header-visible="true"
-    separator="ctrl.csv.separator"
-    separator-visible="ctrl.csv.separatorVisible"
-    result="ctrl.csv.result">
-  </ng-csv-import>
-
-  <div ng-show="ctrl.import.alert" class="{{ ctrl.import.alert.type }}" ng-bind-html="ctrl.import.alert.text">
-  </div>
-
-  <div ng-if="ctrl.csv.content" class="block left">
-    <h2>CSV</h2>
-    <div class="content import-content"><pre>{{ ctrl.csv.content }}</pre></div>
-  </div>
-
   <div class="checkbox">
     <label>
       <input type="checkbox" ng-model='ctrl.csv.clearQueries'> Clear existing queries?
       <span class="glyphicon glyphicon-question-sign" aria-hidden="true" data-placement="right" data-toggle="tooltip"  title="Select to clear all the existing queries on a case, this is typical when you manage your queries and ratings per case outside Quepid"></span>
     </label>
   </div>
+
+  <p>Please select the file format to import:</p>
+
+  <div class="form-group">
+    <input type="radio" id="csv" name="importSelection" value="csv" ng-model="ctrl.options.which">
+    <label for="csv">CSV</label>
+    <span class="help-block">
+      The CSV file should have the headers: <code>query,docid,rating</code>
+    </span>
+    <p>Select CSV file to import:</p>
+
+    <ng-csv-import
+      class="import"
+      content="ctrl.csv.content"
+      header="ctrl.csv.header"
+      header-visible="true"
+      separator="ctrl.csv.separator"
+      separator-visible="ctrl.csv.separatorVisible"
+      result="ctrl.csv.result">
+    </ng-csv-import>
+
+
+
+    <div ng-if="ctrl.csv.content" class="block left">
+      <h2>CSV</h2>
+      <div ng-show="ctrl.import.alert" class="text-danger bg-danger" ng-bind-html="ctrl.import.alert">
+      </div>      
+      <div class="content import-content"><pre>{{ ctrl.csv.content }}</pre></div>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <input type="radio" id="rre" name="importSelection" value="rre" ng-model="ctrl.options.which">
+    <label for="rre">RRE</label>
+    <span class="help-block">
+      The RRE file should have the headers: <code>query,docid,rating</code>
+    </span>
+    <p>Select RRE ratings json file to import:</p>
+
+
+  </div>
+
 </div>
 <div class="modal-footer">
   <p class='bg-warning text-warning padded-text'>
@@ -48,15 +70,8 @@
   </p>
 
   <i class="fa fa-spinner fa-spin" aria-hidden="true" ng-show="ctrl.loading"></i>
-  <button
-    class="btn btn-primary"
-    ng-show="ctrl.csv.result"
-    ng-click="ctrl.ok()"
-    ng-disabled="ctrl.loading"
-  >Import</button>
-  <button
-    class="btn btn-default"
-    ng-click="ctrl.cancel()"
-    ng-disabled="ctrl.loading"
-  >Cancel</button>
+
+  <button class="btn btn-default float-left" ng-click="ctrl.cancel()">Cancel</button>
+  <button class="btn btn-primary" ng-click="ctrl.ok()" ng-disabled="ctrl.options.which === 'undefined'">Import</button>
+
 </div>

--- a/app/assets/javascripts/components/import_ratings/import_ratings_controller.js
+++ b/app/assets/javascripts/components/import_ratings/import_ratings_controller.js
@@ -21,7 +21,7 @@ angular.module('QuepidApp')
           controller:   'ImportRatingsModalInstanceCtrl',
           controllerAs: 'ctrl',
           resolve:      {
-            selectedCase: function() {
+            theCase: function() {
               return ctrl.acase;
             }
           }

--- a/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
+++ b/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
@@ -23,7 +23,7 @@ angular.module('QuepidApp')
 
       ctrl.rre         = {
         content:           null
-      }
+      };
 
       ctrl.options = {
         which: 'undefined'
@@ -51,44 +51,14 @@ angular.module('QuepidApp')
       $scope.pickedFile = function() {
         var f = document.getElementById('file').files[0],
             r = new FileReader();
+
+        // This next two lines don't seem to trigger the watches that I wanted.
         ctrl.options.which = 'rre';
         ctrl.loading = true;
         r.onloadend = function(e) {
           var data = e.target.result;
-          console.log("Loaded data");
           ctrl.rre.content = data;
           ctrl.loading = false;
-
-          //send your binary data via $http or $resource or do anything else with it
-        }
-
-        r.readAsText(f);
-      }
-
-      $scope.add = function() {
-        var f = document.getElementById('file').files[0],
-            r = new FileReader();
-
-        ctrl.options.which = 'rre';
-        r.onloadend = function(e) {
-          var data = e.target.result;
-          console.log("Loaded data");
-          ctrl.rre.content = data;
-          //send your binary data via $http or $resource or do anything else with it
-        }
-
-        r.readAsText(f);
-      }
-
-      function readText() {
-        var f = document.getElementById('file').files[0],
-            r = new FileReader();
-
-        r.onloadend = function(e) {
-          var data = e.target.result;
-          console.log("Loaded data");
-          ctrl.rre.content = data;
-          //send your binary data via $http or $resource or do anything else with it
         }
 
         r.readAsText(f);

--- a/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
+++ b/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
@@ -2,13 +2,14 @@
 
 angular.module('QuepidApp')
   .controller('ImportRatingsModalInstanceCtrl', [
+    '$scope',
     '$uibModalInstance',
     'importRatingsSvc',
-    'selectedCase',
-    function ($uibModalInstance, importRatingsSvc, selectedCase) {
+    'theCase',
+    function ($scope, $uibModalInstance, importRatingsSvc, theCase) {
       var ctrl = this;
 
-      ctrl.selectedCase = selectedCase;
+      ctrl.selectedCase = theCase;
       ctrl.loading      = false;
       ctrl.import       = {};
       ctrl.csv          = {
@@ -19,6 +20,17 @@ angular.module('QuepidApp')
         separatorVisible: false,
         result:           null
       };
+
+      ctrl.options = {
+        which: 'undefined'
+      };
+
+      // Watches
+      $scope.$watch('ctrl.csv.content', function(newVal, oldVal) {
+        if (newVal !== oldVal) {
+          ctrl.options.which = 'csv';
+        }
+      },true);
 
       ctrl.ok = function () {
         var headers = ctrl.csv.content.split('\n')[0];
@@ -34,14 +46,12 @@ angular.module('QuepidApp')
           alert += expectedHeaders.join(',');
           alert += '</strong>';
 
-          ctrl.import.alert = {
-            'text': alert,
-            'type': 'text-danger'
-          };
+          ctrl.import.alert = alert;
+
         } else {
           ctrl.loading = true;
-          importRatingsSvc.makeCall(
-            ctrl.selectedCase,
+          importRatingsSvc.importCSVFormat(
+            ctrl.theCase,
             ctrl.csv.result,
             ctrl.csv.clearQueries
           ).then(function() {

--- a/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
+++ b/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
@@ -21,6 +21,10 @@ angular.module('QuepidApp')
         result:           null
       };
 
+      ctrl.rre         = {
+        content:           null
+      }
+
       ctrl.options = {
         which: 'undefined'
       };
@@ -32,39 +36,121 @@ angular.module('QuepidApp')
         }
       },true);
 
+      $scope.$watch('ctrl.rre.content', function(newVal, oldVal) {
+        if (newVal !== oldVal) {
+          ctrl.options.which = 'rre';
+        }
+      },true);
+
+      $scope.$watch('ctrl.rre', function(newVal, oldVal) {
+        if (newVal !== oldVal) {
+          ctrl.options.which = 'rre';
+        }
+      },true);
+
+      $scope.pickedFile = function() {
+        var f = document.getElementById('file').files[0],
+            r = new FileReader();
+        ctrl.options.which = 'rre';
+        ctrl.loading = true;
+        r.onloadend = function(e) {
+          var data = e.target.result;
+          console.log("Loaded data");
+          ctrl.rre.content = data;
+          ctrl.loading = false;
+
+          //send your binary data via $http or $resource or do anything else with it
+        }
+
+        r.readAsText(f);
+      }
+
+      $scope.add = function() {
+        var f = document.getElementById('file').files[0],
+            r = new FileReader();
+
+        ctrl.options.which = 'rre';
+        r.onloadend = function(e) {
+          var data = e.target.result;
+          console.log("Loaded data");
+          ctrl.rre.content = data;
+          //send your binary data via $http or $resource or do anything else with it
+        }
+
+        r.readAsText(f);
+      }
+
+      function readText() {
+        var f = document.getElementById('file').files[0],
+            r = new FileReader();
+
+        r.onloadend = function(e) {
+          var data = e.target.result;
+          console.log("Loaded data");
+          ctrl.rre.content = data;
+          //send your binary data via $http or $resource or do anything else with it
+        }
+
+        r.readAsText(f);
+      }
+
       ctrl.ok = function () {
-        var headers = ctrl.csv.content.split('\n')[0];
-        headers     = headers.split(ctrl.csv.separator);
+        if ( ctrl.options.which === 'csv' ) {
+          ctrl.import.alert = undefined;
+          var headers = ctrl.csv.content.split('\n')[0];
+          headers     = headers.split(ctrl.csv.separator);
 
-        var expectedHeaders = [
-          'query', 'docid', 'rating'
-        ];
+          var expectedHeaders = [
+            'query', 'docid', 'rating'
+          ];
 
-        if (!angular.equals(headers, expectedHeaders)) {
-          var alert = 'Headers mismatch! Please make sure you have the correct headers in you file (check for correct spelling and capitalization): ';
-          alert += '<br /><strong>';
-          alert += expectedHeaders.join(',');
-          alert += '</strong>';
+          if (!angular.equals(headers, expectedHeaders)) {
+            var alert = 'Headers mismatch! Please make sure you have the correct headers in you file (check for correct spelling and capitalization): ';
+            alert += '<br /><strong>';
+            alert += expectedHeaders.join(',');
+            alert += '</strong>';
 
-          ctrl.import.alert = alert;
+            ctrl.import.alert = alert;
+          }
+        }
 
-        } else {
+        // check if any alerts defined.
+        if (ctrl.import.alert === undefined) {
           ctrl.loading = true;
-          importRatingsSvc.importCSVFormat(
-            ctrl.theCase,
-            ctrl.csv.result,
-            ctrl.csv.clearQueries
-          ).then(function() {
-              ctrl.loading = false;
-              $uibModalInstance.close();
-            },
-            function(response) {
-              var error = 'Unable to import ratings: ';
-              error += response.status;
-              error += ' - ' + response.statusText;
-              ctrl.loading = false;
-              $uibModalInstance.close(error);
-            });
+          if ( ctrl.options.which === 'csv' ) {
+
+            importRatingsSvc.importCSVFormat(
+              ctrl.theCase,
+              ctrl.csv.result,
+              ctrl.csv.clearQueries
+            ).then(function() {
+                ctrl.loading = false;
+                $uibModalInstance.close();
+              },
+              function(response) {
+                var error = 'Unable to import ratings from CSV: ';
+                error += response.status;
+                error += ' - ' + response.statusText;
+                ctrl.loading = false;
+                $uibModalInstance.close(error);
+              });
+          }
+          else if (ctrl.options.which === 'rre' ) {
+            importRatingsSvc.importRREFormat(
+              ctrl.theCase,
+              ctrl.rre.content
+            ).then(function() {
+                ctrl.loading = false;
+                $uibModalInstance.close();
+              },
+              function(response) {
+                var error = 'Unable to import ratings from RRE: ';
+                error += response.status;
+                error += ' - ' + response.statusText;
+                ctrl.loading = false;
+                $uibModalInstance.close(error);
+              });
+          }
         }
       };
 

--- a/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
+++ b/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
@@ -9,7 +9,7 @@ angular.module('QuepidApp')
     function ($scope, $uibModalInstance, importRatingsSvc, theCase) {
       var ctrl = this;
 
-      ctrl.selectedCase = theCase;
+      ctrl.theCase      = theCase;
       ctrl.loading      = false;
       ctrl.import       = {};
       ctrl.csv          = {

--- a/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
+++ b/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
@@ -59,10 +59,10 @@ angular.module('QuepidApp')
           var data = e.target.result;
           ctrl.rre.content = data;
           ctrl.loading = false;
-        }
+        };
 
         r.readAsText(f);
-      }
+      };
 
       ctrl.ok = function () {
         if ( ctrl.options.which === 'csv' ) {

--- a/app/assets/javascripts/components/import_to_cases/_modal.html
+++ b/app/assets/javascripts/components/import_to_cases/_modal.html
@@ -30,7 +30,6 @@ Legacy Search, 210/15/18 18:05,2098,star trek,10592,5
   <ng-csv-import
     class="import ng-csv-import ng-isolate-scope ng-show"
     content="ctrl.csv.content"
-    upload-button-label="ctrl.csv.uploadButtonLabel"
     header="ctrl.csv.header"
     header-visible="true"
     separator="ctrl.csv.separator"

--- a/app/assets/javascripts/services/importRatingsSvc.js
+++ b/app/assets/javascripts/services/importRatingsSvc.js
@@ -31,7 +31,8 @@ angular.module('QuepidApp')
           clear_queries:  clearQueries,
         };
 
-        return $http.post('/api/import/ratings', data);
+        // The API only sees a hash of ratings.
+        return $http.post('/api/import/ratings?file_format=hash', data);
       }
 
       function importRREFormat(theCase, rreJson, clearQueries) {

--- a/app/assets/javascripts/services/importRatingsSvc.js
+++ b/app/assets/javascripts/services/importRatingsSvc.js
@@ -11,11 +11,10 @@ angular.module('QuepidApp')
       var self = this;
 
       // Functions
-      self.makeCall = makeCall;
+      self.importCSVFormat = importCSVFormat;
+      self.importRREFormat = importRREFormat;
 
-      function makeCall(theCase, csv, clearQueries) {
-        var url = '/api/import/ratings';
-
+      function importCSVFormat(theCase, csv, clearQueries) {
         var ratings = [];
 
         angular.forEach(csv, function(rating) {
@@ -32,7 +31,19 @@ angular.module('QuepidApp')
           clear_queries:  clearQueries,
         };
 
-        return $http.post(url, data);
+        return $http.post('/api/import/ratings', data);
+      }
+
+      function importRREFormat(theCase, rreJson, clearQueries) {
+
+        var data = {
+          rre_json:       rreJson,
+          case_id:        theCase.caseNo,
+          clear_queries:  clearQueries,
+        };
+
+        return $http.post('/api/import/ratings?file_format=rre', data);
+
       }
     }
   ]);

--- a/app/assets/stylesheets/bootstrap-add.css
+++ b/app/assets/stylesheets/bootstrap-add.css
@@ -1127,7 +1127,7 @@ footer {
 
 /* Import */
 .import-content {
-  max-height: 300px;
+  max-height: 200px;
   overflow:   scroll;
 }
 
@@ -1178,7 +1178,7 @@ li.annotation {
 	margin: 5px 5px 0 0;
 }
 
-.modal-body .btn-group .btn-default { 
+.modal-body .btn-group .btn-default {
 	background: linear-gradient(to bottom right, #EEE, #F8F8F8);
 }
 
@@ -1195,12 +1195,12 @@ li.annotation {
 	padding-left: 0;
 }
 
-.modal-body .glyphicon { 
+.modal-body .glyphicon {
 	font-size: 16px;
-	color: #aaa; 
+	color: #aaa;
 }
 
-.modal-body .checkbox { 
+.modal-body .checkbox {
 	margin-top: 0;
 	margin-bottom: 5px;
 	padding: 8px 0;

--- a/app/controllers/api/v1/import/ratings_controller.rb
+++ b/app/controllers/api/v1/import/ratings_controller.rb
@@ -29,7 +29,6 @@ module Api
                   }
                   ratings << rating
                 end
-
               end
             end
           end

--- a/spec/javascripts/angular/services/importRatingsSvc_spec.js
+++ b/spec/javascripts/angular/services/importRatingsSvc_spec.js
@@ -87,7 +87,7 @@ describe('Service: importRatingsSvc', function () {
 
 
     it('imports ratings multiple queries and multiple docs', function() {
-      var url = '/api/import/ratings?file_format=csv';
+      var url = '/api/import/ratings?file_format=hash';
 
       $httpBackend.expectPOST(url).respond(200, {});
 

--- a/spec/javascripts/angular/services/importRatingsSvc_spec.js
+++ b/spec/javascripts/angular/services/importRatingsSvc_spec.js
@@ -27,19 +27,19 @@ describe('Service: importRatingsSvc', function () {
 
     var mockCsv = [
       {
-        'Query Text': 'dog',
-        'Doc ID':     'i_801',
-        'Rating':     '8'
+        'query':       'dog',
+        'docid':      'i_801',
+        'rating':     '8'
       },
       {
-        'Query Text': 'dog',
-        'Doc ID':     'i_802',
-        'Rating':     '5'
+        'query':      'dog',
+        'docid':      'i_802',
+        'rating':     '5'
       },
       {
-        'Query Text': 'cat',
-        'Doc ID':     'i_803',
-        'Rating':     '3'
+        'query':     'cat',
+        'docid':     'i_803',
+        'rating':    '3'
       },
     ];
 
@@ -47,12 +47,62 @@ describe('Service: importRatingsSvc', function () {
       caseNo: 8
     };
 
+    var mockRREJson = {
+      "id_field": [
+        "id"
+      ],
+      "index": "Movies Search",
+      "template": "quepid.json",
+      "queries": [
+        {
+          "placeholders": {
+            "$query": "star trek"
+          },
+          "relevant_documents": {
+            "1": [
+              "193"
+            ],
+            "2": [
+              "157",
+              "152"
+            ]
+          }
+        },
+        {
+          "placeholders": {
+            "$query": "star wars"
+          },
+          "relevant_documents": {
+            "1": [
+              "12180"
+            ],
+            "2": [
+              "13532",
+              "1895"
+            ]
+          }
+        }
+      ]
+    }
+
+
     it('imports ratings multiple queries and multiple docs', function() {
       var url = '/api/import/ratings';
 
       $httpBackend.expectPOST(url).respond(200, {});
 
-      importRatingsSvc.makeCall(mockCase, mockCsv);
+      importRatingsSvc.importCSVFormat(mockCase, mockCsv);
+
+      $httpBackend.flush();
+      $rootScope.$apply();
+    });
+
+    it('imports rre format', function() {
+      var url = '/api/import/ratings?file_format=rre';
+
+      $httpBackend.expectPOST(url).respond(200, {});
+
+      importRatingsSvc.importRREFormat(mockCase, mockRREJson);
 
       $httpBackend.flush();
       $rootScope.$apply();

--- a/spec/javascripts/angular/services/importRatingsSvc_spec.js
+++ b/spec/javascripts/angular/services/importRatingsSvc_spec.js
@@ -87,7 +87,7 @@ describe('Service: importRatingsSvc', function () {
 
 
     it('imports ratings multiple queries and multiple docs', function() {
-      var url = '/api/import/ratings';
+      var url = '/api/import/ratings?file_format=csv';
 
       $httpBackend.expectPOST(url).respond(200, {});
 

--- a/test/controllers/api/v1/import/mock_rre_json.json
+++ b/test/controllers/api/v1/import/mock_rre_json.json
@@ -1,0 +1,37 @@
+{
+  "id_field": [
+    "id"
+  ],
+  "index": "Movies Search",
+  "template": "quepid.json",
+  "queries": [
+    {
+      "placeholders": {
+        "$query": "star trek"
+      },
+      "relevant_documents": {
+        "1": [
+          "193"
+        ],
+        "2": [
+          "157",
+          "152"
+        ]
+      }
+    },
+    {
+      "placeholders": {
+        "$query": "star wars"
+      },
+      "relevant_documents": {
+        "1": [
+          "12180"
+        ],
+        "2": [
+          "13532",
+          "1895"
+        ]
+      }
+    }
+  ]
+}

--- a/test/controllers/api/v1/import/ratings_controller_test.rb
+++ b/test/controllers/api/v1/import/ratings_controller_test.rb
@@ -128,6 +128,22 @@ module Api
             assert query.deleted
           end
         end
+        describe '#create from RRE' do
+          test 'creates new queries from rre format mapped to hash format' do
+            mock_rre_json = File.read('./test/controllers/api/v1/import/mock_rre_json.json')
+            data = {
+              case_id:       acase.id,
+              clear_queries: true,
+              rre_json:      mock_rre_json,
+              file_format:   'rre',
+            }
+
+            assert_difference 'acase.queries.count' do
+              post :create, data
+              assert_response :ok
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Now you can export and import ratings in both csv and RRE formats!

## Description
Refactors the Import Ratings screen to deal with two types of files.   Enhances the API to take a `?file_format=rre' parameter to change from the default `hash` of ratings format.

## Motivation and Context
Support migrating ratings between Quepid and RRE depending on you type of task.

Part of fixing #133 

## How Has This Been Tested?
unit tests and manually.




## Screenshots or GIFs (if appropriate):
![Screenshot at May 31 11-54-30](https://user-images.githubusercontent.com/22395/83356655-86e57400-a335-11ea-9a08-a9a8be32be60.png)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
