### PR TITLE
Fix tune relevance race condition and duplicate event handlers

### DIFF
--- a/app/assets/javascripts/controllers/mainCtrl.js
+++ b/app/assets/javascripts/controllers/mainCtrl.js
@@ -127,10 +127,10 @@ angular.module('QuepidApp')
           loadQueries();
           loadSnapshots();
           updateCaseMetadata();
+          paneSvc.refreshElements();
         });
 
       // Sets up the panes stuff only when needed
-      paneSvc.initPanes();
       // Makes sure state is persisted even after reload.
       // This is used when the user hits "Rerun My Searches!" and wants to
       // continue tweaking the settings, it would keep the pane open.

--- a/app/assets/javascripts/services/paneSvc.js
+++ b/app/assets/javascripts/services/paneSvc.js
@@ -4,82 +4,78 @@ angular.module('QuepidApp')
   .service('paneSvc', [
     'eastPaneWidth',
     function paneSvc(eastPaneWidth) {
-      this.initPanes = function() {
-        var self    = this;
-        var slider  = document.getElementsByClassName('east-slider')[0];
-        if (!slider) {
-          setTimeout(function() {
-            self.initPanes();
-          }, 200);
-          return;
-        }
+      var container;
+      var east;
+      var main;
+      var slider;
 
-        var container = document.getElementsByClassName('pane_container')[0];
-        var east = document.getElementsByClassName('pane_east')[0];
-        var main = document.getElementsByClassName('pane_main')[0];
-
+      this.refreshElements = function() {
+        slider  = document.getElementsByClassName('east-slider')[0];
+        container = document.getElementsByClassName('pane_container')[0];
+        east = document.getElementsByClassName('pane_east')[0];
+        main = document.getElementsByClassName('pane_main')[0];
         east.style.left = slider.style.left = (container.offsetWidth - 20) + 'px';
-
-        /* Move the left edge of east to x
-         * */
-        var moveEastTo = function(x) {
-          slider.style.left = x + 'px';
-          east.style.left = (6 + x) + 'px';
-          main.style.width = (x) + 'px';
-          east.style.width = (container.offsetWidth - x) + 'px';
-        };
-
-        var dragElement = function(evt) {
-          moveEastTo(evt.clientX);
-          eastPaneWidth = $(east).width();
-        };
-
-        var grabSlider = function() {
-          document.onmousemove = dragElement;
-          east.style.display = 'block';
-          return false;
-        };
-
-        var releaseSlider = function() {
-          document.onmousemove = null;
-        };
 
         slider.onmousedown = grabSlider;
         document.onmouseup = releaseSlider;
+      }
 
-        var toggled = false;
-        /* Toggle the pull out, unhide the
-         * east slider east pane, then
-         * bind to the slider's events for dragging
-         * */
-        var toggleEast = function() {
-          toggled = !toggled;
-          if (toggled) {
-            slider.onmousedown = grabSlider;
-            document.onmouseup = releaseSlider;
-            moveEastTo(container.offsetWidth - eastPaneWidth);
-            $(slider).show();
-            $(east).show();
-          }
-          else {
-            slider.onmousedown = null;
-            document.onmouseup = null;
-            $(slider).hide();
-            $(east).hide();
-            moveEastTo(container.offsetWidth);
-          }
-        };
-
-        $(window).on('resize', function() {
-          if (toggled) {
-            moveEastTo(container.offsetWidth - eastPaneWidth);
-          }
-          else {
-            moveEastTo(container.offsetWidth);
-          }
-        });
-
-        $(document).on('toggleEast', toggleEast);
+      /* Move the left edge of east to x
+       * */
+      var moveEastTo = function(x) {
+        slider.style.left = x + 'px';
+        east.style.left = (6 + x) + 'px';
+        main.style.width = (x) + 'px';
+        east.style.width = (container.offsetWidth - x) + 'px';
       };
+
+      var dragElement = function(evt) {
+        moveEastTo(evt.clientX);
+        eastPaneWidth = $(east).width();
+      };
+
+      var grabSlider = function() {
+        document.onmousemove = dragElement;
+        east.style.display = 'block';
+        return false;
+      };
+
+      var releaseSlider = function() {
+        document.onmousemove = null;
+      };
+
+      var toggled = false;
+      /* Toggle the pull out, unhide the
+       * east slider east pane, then
+       * bind to the slider's events for dragging
+       * */
+      var toggleEast = function() {
+        toggled = !toggled;
+        if (toggled) {
+          slider.onmousedown = grabSlider;
+          document.onmouseup = releaseSlider;
+          moveEastTo(container.offsetWidth - eastPaneWidth);
+          $(slider).show();
+          $(east).show();
+        }
+        else {
+          slider.onmousedown = null;
+          document.onmouseup = null;
+          $(slider).hide();
+          $(east).hide();
+          moveEastTo(container.offsetWidth);
+        }
+      };
+
+      $(window).on('resize', function() {
+        if (toggled) {
+          moveEastTo(container.offsetWidth - eastPaneWidth);
+        }
+        else {
+          moveEastTo(container.offsetWidth);
+        }
+      });
+
+      $(document).on('toggleEast', toggleEast);
     }
   ]);

--- a/app/assets/javascripts/services/paneSvc.js
+++ b/app/assets/javascripts/services/paneSvc.js
@@ -9,17 +9,6 @@ angular.module('QuepidApp')
       var main;
       var slider;
 
-      this.refreshElements = function() {
-        slider  = document.getElementsByClassName('east-slider')[0];
-        container = document.getElementsByClassName('pane_container')[0];
-        east = document.getElementsByClassName('pane_east')[0];
-        main = document.getElementsByClassName('pane_main')[0];
-        east.style.left = slider.style.left = (container.offsetWidth - 20) + 'px';
-
-        slider.onmousedown = grabSlider;
-        document.onmouseup = releaseSlider;
-      }
-
       /* Move the left edge of east to x
        * */
       var moveEastTo = function(x) {
@@ -42,6 +31,17 @@ angular.module('QuepidApp')
 
       var releaseSlider = function() {
         document.onmousemove = null;
+      };
+
+      this.refreshElements = function() {
+        slider  = document.getElementsByClassName('east-slider')[0];
+        container = document.getElementsByClassName('pane_container')[0];
+        east = document.getElementsByClassName('pane_east')[0];
+        main = document.getElementsByClassName('pane_main')[0];
+        east.style.left = slider.style.left = (container.offsetWidth - 20) + 'px';
+
+        slider.onmousedown = grabSlider;
+        document.onmouseup = releaseSlider;
       };
 
       var toggled = false;


### PR DESCRIPTION
## Description
Removed a repeating init call that setup multiple event handlers.  Instead refresh the elements when a new case is loaded and only make use of one event handler.

## Motivation and Context
Tune relevance was broken for a new case. Fixes #144 

## How Has This Been Tested?
Tested manually by creating a new case and clicking "Tune Relevance", also made sure to click around a few existing cases.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
