### PR TITLE
Fix/qgraph

### DIFF
--- a/app/assets/javascripts/components/qgraph/qgraph_controller.js
+++ b/app/assets/javascripts/components/qgraph/qgraph_controller.js
@@ -33,6 +33,11 @@ angular.module('QuepidApp')
       ctrl.scores = $scope.scores;
 
       // Watches
+      $scope.$watch('max', function() {
+        ctrl.max = $scope.max;
+        renderGraph();
+      });
+
       $scope.$watchCollection('scores', function () {
         ctrl.scores = $scope.scores;
         renderGraph();
@@ -82,7 +87,7 @@ angular.module('QuepidApp')
               return xpos;
             })
             .y(function (d) {
-              return y(parseInt(d.score));
+              return y(d.score);
             });
 
           $scope.graph.append('svg:path').attr('d', line(data));

--- a/app/assets/javascripts/components/qscore/qscore_controller.js
+++ b/app/assets/javascripts/components/qscore/qscore_controller.js
@@ -18,7 +18,7 @@ angular.module('QuepidApp')
         var scorable = ctrl.scorable.score();
 
         ctrl.score    = scorable.score;
-        ctrl.maxScore = ctrl.maxScore;
+        ctrl.maxScore = $scope.ctrl.maxScore;
 
         if ( angular.isDefined(scorable.backgroundColor) ) {
           ctrl.style = { 'backgroundColor': scorable.backgroundColor };

--- a/app/assets/javascripts/components/qscore/qscore_controller.js
+++ b/app/assets/javascripts/components/qscore/qscore_controller.js
@@ -3,8 +3,8 @@
 
 angular.module('QuepidApp')
   .controller('QscoreCtrl', [
-    '$scope',
-    function ($scope) {
+    '$scope', 'qscoreSvc',
+    function ($scope, qscoreSvc) {
       var ctrl          = this;
       var defaultStyle  = { 'background-color': 'hsl(0, 0%, 0%, 0.5)'};
 
@@ -12,7 +12,7 @@ angular.module('QuepidApp')
       ctrl.diffStyle    = {};
       ctrl.score        = '?';
       ctrl.scoreType    = ctrl.scoreType || 'normal';
-      ctrl.style        = scoreToColor(ctrl.score);
+      ctrl.style        = qscoreSvc.scoreToColor(ctrl.score, ctrl.maxScore);
 
       $scope.$watch('ctrl.scorable.score()', function() {
         var scorable = ctrl.scorable.score();
@@ -21,9 +21,9 @@ angular.module('QuepidApp')
         ctrl.maxScore = $scope.ctrl.maxScore;
 
         if ( angular.isDefined(scorable.backgroundColor) ) {
-          ctrl.style = { 'backgroundColor': scorable.backgroundColor };
+          ctrl.style = { 'background-color': scorable.backgroundColor };
         } else {
-          ctrl.style = scoreToColor(ctrl.score);
+          ctrl.style = { 'background-color': qscoreSvc.scoreToColor(ctrl.score, ctrl.maxScore)};
         }
 
         setDiff();
@@ -63,7 +63,7 @@ angular.module('QuepidApp')
           ) {
             ctrl.diffStyle = { 'background-color': diffScore.backgroundColor };
           } else {
-            ctrl.diffStyle = scoreToColor(diffScore.score);
+            ctrl.diffStyle = { 'background-color': qscoreSvc.scoreToColor(diffScore.score, ctrl.maxScore)};
           }
         } else {
           setDefaultDiff();
@@ -73,35 +73,6 @@ angular.module('QuepidApp')
       function setDefaultDiff() {
         ctrl.diffScore  = '?';
         ctrl.diffStyle  = defaultStyle;
-      }
-
-      function scoreToColor(score) {
-        // TODO add support for diff width
-        if ( score === '?' ) {
-          return defaultStyle;
-        }
-
-        if ( score === null ) {
-          return defaultStyle;
-        }
-
-        // Make the color of the score relative to the max score possible:
-        score = score * 100 / ctrl.maxScore;
-        score = Math.round(parseInt(score, 10) / 10);
-        return {
-          '-1': { 'background-color': 'hsl(0, 100%, 40%)'},
-          '0':  { 'background-color': 'hsl(5, 95%, 45%)'},
-          '1':  { 'background-color': 'hsl(10, 90%, 50%)'},
-          '2':  { 'background-color': 'hsl(15, 85%, 55%)'},
-          '3':  { 'background-color': 'hsl(20, 80%, 60%)'},
-          '4':  { 'background-color': 'hsl(24, 75%, 65%)'},
-          '5':  { 'background-color': 'hsl(28, 65%, 75%)'},
-          '6':  { 'background-color': 'hsl(60, 55%, 65%)'},
-          '7':  { 'background-color': 'hsl(70, 70%, 50%)'},
-          '8':  { 'background-color': 'hsl(80, 80%, 45%)'},
-          '9':  { 'background-color': 'hsl(90, 85%, 40%)'},
-          '10': { 'background-color': 'hsl(100, 90%, 35%)'}
-        }[score];
       }
     }
   ]);

--- a/app/assets/javascripts/components/qscore/qscore_controller.js
+++ b/app/assets/javascripts/components/qscore/qscore_controller.js
@@ -12,7 +12,7 @@ angular.module('QuepidApp')
       ctrl.diffStyle    = {};
       ctrl.score        = '?';
       ctrl.scoreType    = ctrl.scoreType || 'normal';
-      ctrl.style        = qscoreSvc.scoreToColor(ctrl.score, ctrl.maxScore);
+      ctrl.style        = { 'background-color': qscoreSvc.scoreToColor(ctrl.score, ctrl.maxScore) };
 
       $scope.$watch('ctrl.scorable.score()', function() {
         var scorable = ctrl.scorable.score();

--- a/app/assets/javascripts/components/qscore/qscore_service.js
+++ b/app/assets/javascripts/components/qscore/qscore_service.js
@@ -11,6 +11,7 @@ angular.module('QuepidApp')
         }
 
         // Make the color of the score relative to the max score possible:
+        score = Math.min(score, maxScore); // This is needed in case a user switches to a binary scorer from a nonbinary
         score = score * 100 / maxScore;
         score = Math.round(parseInt(score, 10) / 10);
         return {

--- a/app/assets/javascripts/components/qscore/qscore_service.js
+++ b/app/assets/javascripts/components/qscore/qscore_service.js
@@ -1,0 +1,34 @@
+'use strict';
+
+angular.module('QuepidApp')
+  .service('qscoreSvc', [
+    function () {
+      var defaultStyle  = { 'background-color': 'hsl(0, 0%, 0%, 0.5)'};
+
+      this.scoreToColor = function(score, maxScore) {
+        if ( score === '?' || score === null) {
+          return defaultStyle;
+        }
+
+        // Make the color of the score relative to the max score possible:
+        score = score * 100 / maxScore;
+        score = Math.round(parseInt(score, 10) / 10);
+        return {
+          '-1': 'hsl(0, 100%, 40%)',
+          '0':  'hsl(5, 95%, 45%)',
+          '1':  'hsl(10, 90%, 50%)',
+          '2':  'hsl(15, 85%, 55%)',
+          '3':  'hsl(20, 80%, 60%)',
+          '4':  'hsl(24, 75%, 65%)',
+          '5':  'hsl(28, 65%, 75%)',
+          '6':  'hsl(60, 55%, 65%)',
+          '7':  'hsl(70, 70%, 50%)',
+          '8':  'hsl(80, 80%, 45%)',
+          '9':  'hsl(90, 85%, 40%)',
+          '10': 'hsl(100, 90%, 35%)'
+        }[score];
+      };
+
+      return this;
+    }
+  ]);

--- a/app/assets/javascripts/controllers/queriesCtrl.js
+++ b/app/assets/javascripts/controllers/queriesCtrl.js
@@ -132,6 +132,7 @@ angular.module('QuepidApp')
         ) {
           var scoreInfo = resultObject.lastScore;
 
+          // TODO: This seems bugged, maybe force specification of max score?
           // Fetch the potential total max score by averaging
           // the max score of each query,
           // the same way we average the score of each query
@@ -146,6 +147,7 @@ angular.module('QuepidApp')
 
           $scope.maxScore = maxScores.
             reduce(function(a, b) { return a + b; }, 0) / maxScores.length;
+          $scope.maxScore = Math.max(1, $scope.maxScore);
 
           // Make the color of the score relative to the
           // max score possible:

--- a/app/assets/javascripts/controllers/queriesCtrl.js
+++ b/app/assets/javascripts/controllers/queriesCtrl.js
@@ -147,18 +147,9 @@ angular.module('QuepidApp')
 
           $scope.maxScore = maxScores.
             reduce(function(a, b) { return a + b; }, 0) / maxScores.length;
-          $scope.maxScore = Math.max(1, $scope.maxScore);
-
-          // Make the color of the score relative to the
-          // max score possible:
-          var normScore = scoreInfo.score * 100 / $scope.maxScore;
-          index         = Math.round(parseInt(normScore, 10) / 10);
-          color         = angular.isDefined(colors[index]) ? colors[index].color : undefined;
-          resultObject.lastScore.backgroundColor = color;
-        } else {
-          index = parseInt(resultObject.lastScore.score / 10, 10);
-          color = angular.isDefined(colors[index]) ? colors[index].color : undefined;
-          resultObject.lastScore.backgroundColor = color;
+          if (!isNaN($scope.maxScore)) {
+            $scope.maxScore = Math.max(1, $scope.maxScore);
+          }
         }
       };
 

--- a/app/assets/javascripts/controllers/queriesCtrl.js
+++ b/app/assets/javascripts/controllers/queriesCtrl.js
@@ -123,8 +123,6 @@ angular.module('QuepidApp')
 
         resultObject.lastScore = queriesSvc.scoreAll();
         lastVersion            = queriesSvc.version();
-        var colors             = customScorerSvc.defaultScorer.getColors();
-        var index, color;
 
         if (
           resultObject.lastScore &&

--- a/app/assets/javascripts/factories/ScorerFactory.js
+++ b/app/assets/javascripts/factories/ScorerFactory.js
@@ -72,7 +72,6 @@
       self.scaleToArray           = scaleToArray;
       self.scaleToColors          = scaleToColors;
       self.score                  = score;
-      self.scoreToColor           = scoreToColor;
       self.scaleToScaleWithLabels = scaleToScaleWithLabels;
       self.showScaleLabel         = showScaleLabel;
       self.teamNames              = teamNames;
@@ -534,20 +533,6 @@
         }
 
         return runCode(total, docs, bestDocs, 'max', options);
-      }
-
-      function scoreToColor (score, maxScore) {
-        if ( maxScore === 0 ) {
-          return 'hsl(0, 100%, 50%)';
-        }
-
-        var n = score * 120 / maxScore;
-
-        if ( isNaN(n) ) {
-          n = 0;
-        }
-
-        return 'hsl(' + n + ', 100%, 50%)';
       }
 
       function score(total, docs, bestDocs, options) {

--- a/app/assets/javascripts/services/queriesSvc.js
+++ b/app/assets/javascripts/services/queriesSvc.js
@@ -197,8 +197,12 @@ angular.module('QuepidApp')
 
           var bestDocs  = this.ratingsStore.bestDocs();
           var scorer    = this.effectiveScorer();
-          var score     = scorer.score(this.numFound, otherDocs, bestDocs, this.options);
-          var maxScore  = scorer.maxScore(this.numFound, otherDocs, bestDocs, this.options);
+
+          // The defaults are set below because sometimes quepid saves out scores with no values.
+          // TODO: Defaults can be removed if the quepid scoring persistence issue is cleaned up
+          var score     = scorer.score(this.numFound, otherDocs, bestDocs, this.options) || 0.0;
+          var maxScore  = scorer.maxScore(this.numFound, otherDocs, bestDocs, this.options) || 1.0;
+
           var color     = qscoreSvc.scoreToColor(score, maxScore);
 
           var othersScore = {

--- a/app/assets/javascripts/services/queriesSvc.js
+++ b/app/assets/javascripts/services/queriesSvc.js
@@ -14,6 +14,7 @@ angular.module('QuepidApp')
     'broadcastSvc',
     'caseSvc',
     'customScorerSvc',
+    'qscoreSvc',
     'searchSvc',
     'solrUrlSvc',
     'ratingsStoreSvc',
@@ -28,6 +29,7 @@ angular.module('QuepidApp')
       broadcastSvc,
       caseSvc,
       customScorerSvc,
+      qscoreSvc,
       searchSvc,
       solrUrlSvc,
       ratingsStoreSvc,
@@ -197,7 +199,7 @@ angular.module('QuepidApp')
           var scorer    = this.effectiveScorer();
           var score     = scorer.score(this.numFound, otherDocs, bestDocs, this.options);
           var maxScore  = scorer.maxScore(this.numFound, otherDocs, bestDocs, this.options);
-          var color     = scorer.scoreToColor(score, maxScore);
+          var color     = qscoreSvc.scoreToColor(score, maxScore);
 
           var othersScore = {
             score:            score,

--- a/app/assets/templates/views/queriesLayout.html
+++ b/app/assets/templates/views/queriesLayout.html
@@ -8,7 +8,7 @@
               class="case-score"
               diff-label="queries.selectedDiffName()"
               full-diff-name="queries.fullDiffName()"
-              max-score="maxScore || 100";
+              max-score="maxScore || 1";
               scorable="queries.avgQuery"
               score-label="getScorer().name"
               score-type="'header'"


### PR DESCRIPTION
## Description
Hook up a watch to max score and update the graph scale when the value comes in.  Change the default scale value to 1 while waiting on the API to return the actual max.  Fix update of maxScore in qscore so the appropriate color is chosen.  Consolidate scorer color generation.

## Motivation and Context
Fixes #140 

## How Has This Been Tested?
Manually

## Screenshots or GIFs (if appropriate):
![image](https://user-images.githubusercontent.com/615271/84081563-3660bd00-a9ac-11ea-93e2-f6ac7d1133e9.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)
