### PR TITLE
Flip the sorting of tries to newest to oldest

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ bin/docker r bin/rake db:drop RAILS_ENV=test
 bin/docker r bin/rake db:create RAILS_ENV=test
 ```
 
-View the logs generated during testing set `config.log_level:debug` in `test.rb` and then tail via:
+View the logs generated during testing set `config.log_level = :debug` in `test.rb`
+and then tail the log file via:
+
 ```
 bin/docker r tail -f -n 200 log/test.log
 ```

--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ bin/docker r bin/rake db:drop RAILS_ENV=test
 bin/docker r bin/rake db:create RAILS_ENV=test
 ```
 
+View the logs generated during testing set `config.log_level:debug` in `test.rb` and then tail via:
+```
+bin/docker r tail -f -n 200 log/test.log
+```
+
 ### JS Lint
 
 To check the JS syntax:

--- a/app/controllers/concerns/authentication/current_case_manager.rb
+++ b/app/controllers/concerns/authentication/current_case_manager.rb
@@ -30,6 +30,7 @@ module Authentication
         .case
         .where(id: params[:case_id])
         .includes([ :tries ])
+        .order('tries.try_number DESC')
         .first
     end
 

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -104,7 +104,7 @@ class Case < ActiveRecord::Base
         clone_try(try, false)
       end
 
-      self.last_try_number = tries.last.try_number
+      self.last_try_number = tries.first.try_number
 
       if clone_queries
         original_case.queries.each do |query|

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -29,7 +29,7 @@ class Case < ActiveRecord::Base
 
   belongs_to :user
 
-  has_many   :tries,
+  has_many   :tries,    -> { order(try_number: :desc) },
              dependent: :destroy
 
   has_many   :metadata,

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -29,8 +29,9 @@ class Case < ActiveRecord::Base
 
   belongs_to :user
 
-  has_many   :tries,    -> { order(try_number: :desc) },
-             dependent: :destroy
+  has_many   :tries,     -> { order(try_number: :desc) },
+             dependent:  :destroy,
+             inverse_of: :case
 
   has_many   :metadata,
              dependent: :destroy

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,9 +39,8 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
-  # Set to :debug instead of :info to see SQL and uncomment the STDOUT redirect
+  # Set to :debug instead of :info to see SQL
   config.log_level = :info
-  # ActiveRecord::Base.logger = Logger.new(STDOUT)
 
   config.after_initialize do
     Bullet.enable = true

--- a/test/controllers/api/v1/cases_controller_test.rb
+++ b/test/controllers/api/v1/cases_controller_test.rb
@@ -71,8 +71,10 @@ module Api
       end
 
       describe 'Fetching a case' do
-        let(:the_case)  { cases(:one) }
-        let(:matt_case) { cases(:matt_case) }
+        let(:the_case)            { cases(:one) }
+        let(:matt_case)           { cases(:matt_case) }
+        let(:case_with_two_tries) { cases(:case_with_two_tries) }
+        let(:joey) { users(:joey) }
 
         test "returns a not found error if the case is not in the signed in user's case list" do
           get :show, case_id: matt_case.id
@@ -87,6 +89,19 @@ module Api
 
           assert_equal body['case_name'], the_case.case_name
           assert_equal body['caseNo'],    the_case.id
+        end
+
+        test 'returns tries from newest to oldest' do
+          login_user joey
+
+          get :show, case_id: case_with_two_tries.id
+          assert_response :ok
+
+          body = JSON.parse(response.body)
+
+          assert_equal body['tries'][0]['try_number'], 1
+          assert_equal body['tries'][1]['try_number'], 0
+
         end
       end
 

--- a/test/controllers/api/v1/cases_controller_test.rb
+++ b/test/controllers/api/v1/cases_controller_test.rb
@@ -101,7 +101,6 @@ module Api
 
           assert_equal body['tries'][0]['try_number'], 1
           assert_equal body['tries'][1]['try_number'], 0
-
         end
       end
 

--- a/test/controllers/api/v1/clone/tries_controller_test.rb
+++ b/test/controllers/api/v1/clone/tries_controller_test.rb
@@ -61,7 +61,7 @@ module Api
 
               the_case.reload
               try_response  = JSON.parse(response.body)
-              created_try   = the_case.tries.last
+              created_try   = the_case.tries.first
 
               assert_try_matches_response try_response, created_try
               assert_tries_match          the_try,      created_try

--- a/test/fixtures/tries.yml
+++ b/test/fixtures/tries.yml
@@ -121,6 +121,7 @@ try_without_curator_vars:
   search_url:     test.com
   try_number:     1
   search_engine:  solr
+  field_spec:     id:id title:title
 
 try_with_curator_vars:
   case:           :random_case
@@ -128,6 +129,7 @@ try_with_curator_vars:
   search_url:     test.com
   try_number:     2
   search_engine:  solr
+  field_spec:     id:id title:title
 
 es_try:
   case:           :random_case
@@ -135,6 +137,7 @@ es_try:
   search_url:     test.com
   try_number:     3
   search_engine:  es
+  field_spec:     id:_id title:title
 
 es_try_with_curator_vars:
   case:           :random_case
@@ -142,6 +145,7 @@ es_try_with_curator_vars:
   search_url:     test.com
   try_number:     4
   search_engine:  es
+  field_spec:     id:_id title:title  
 
 bootstrap_try_1:
   case:           :bootstrap_case

--- a/test/models/case_test.rb
+++ b/test/models/case_test.rb
@@ -112,7 +112,6 @@ class CaseTest < ActiveSupport::TestCase
 
       assert_equal acase.tries.first.try_number,  1
       assert_equal acase.tries.second.try_number, 0
-
     end
 
     test 'sets the default try to the default search engine attributes' do

--- a/test/models/case_test.rb
+++ b/test/models/case_test.rb
@@ -107,6 +107,14 @@ class CaseTest < ActiveSupport::TestCase
       assert_equal default_try.try_number, 0
     end
 
+    test 'returns try from highest try number (therefore newest) to lowest' do
+      acase = cases(:case_with_two_tries)
+
+      assert_equal acase.tries.first.try_number,  1
+      assert_equal acase.tries.second.try_number, 0
+
+    end
+
     test 'sets the default try to the default search engine attributes' do
       acase = Case.create(case_name: 'test case')
 
@@ -141,7 +149,7 @@ class CaseTest < ActiveSupport::TestCase
             cloned_try = cloned_case.tries.best
 
             assert_equal the_try.query_params,  cloned_try.query_params
-            assert_equal 'id:id title:title',   cloned_try.field_spec
+            assert_equal the_try.field_spec,    cloned_try.field_spec
             assert_equal the_try.search_url,    cloned_try.search_url
             assert_equal 'Try 0',               cloned_try.name
             assert_equal 0, cloned_case.tries.first.try_number


### PR DESCRIPTION


## Description
Fixes #143 which is the list of tries int he gui should be the newest, because that what you work with, going to oldest so you only scoll a long way if you've been workign on a case for a LONG time.

## Motivation and Context
See #143 

## How Has This Been Tested?
manually and tests

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
