### PR TITLE
Fix roundtrip export to rre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ for users to use. QUEPID_DEFAULT_SCORER=AP@5 is what app.quepid.com uses.
 * Saving two annotations in a row doesn't work, you need to rescore per annotation.  Fixed in https://github.com/o19s/quepid/pull/136 by @epugh.
 * Users can opt out of community marketing emails.  Add a `/admin/users.csv` export to make keeping track of that easier.  Thanks @flaxsearch for the suggestion.
 * Inconsistent use of X icon in modal popups is frustrating.  https://github.com/o19s/quepid/pull/148 and https://github.com/o19s/quepid/pull/149 by @worleydl fixes https://github.com/o19s/quepid/issues/146 and https://github.com/o19s/quepid/issues/145.
+* Swap the sorting of tries in the history tab to the newest first, going back in time.  https://github.com/o19s/quepid/pull/151 by @epugh fixes https://github.com/o19s/quepid/issues/143 by @renekrie.
 
 ### Bugs
 

--- a/app/assets/javascripts/components/export_case/export_case_controller.js
+++ b/app/assets/javascripts/components/export_case/export_case_controller.js
@@ -53,7 +53,7 @@ angular.module('QuepidApp')
           });
 
           /*global saveAs */
-          saveAs(blob, ctrl.theCase.caseName + '_general.csv');
+          saveAs(blob, caseCSVSvc.formatDownloadFileName(ctrl.theCase.caseName + '_general.csv'));
         } else if ( options.which === 'detailed' ) {
           $log.info('Selected "detailed" as export option.');
 
@@ -68,7 +68,7 @@ angular.module('QuepidApp')
           });
 
           /*global saveAs */
-          saveAs(blob, ctrl.theCase.caseName + '_detailed.csv');
+          saveAs(blob, caseCSVSvc.formatDownloadFileName(ctrl.theCase.caseName + '_detailed.csv'));
         }
         else if ( options.which === 'snapshot' ) {
           $log.info('Selected "snapshot" as export option.');
@@ -90,7 +90,7 @@ angular.module('QuepidApp')
             });
 
             /*global saveAs */
-            saveAs(blob, ctrl.theCase.caseName + '_snapshot.csv');
+            saveAs(blob, caseCSVSvc.formatDownloadFileName(ctrl.theCase.caseName + '_snapshot.csv'));
 
           }, function (response) {
             $log.debug('error fetching snapshot:');

--- a/app/assets/javascripts/services/caseCSVSvc.js
+++ b/app/assets/javascripts/services/caseCSVSvc.js
@@ -32,6 +32,7 @@
         self.exportLTRFormat            = exportLTRFormat;
         self.stringifyQueriesDetailed   = stringifyQueriesDetailed;
         self.stringifySnapshot          = stringifySnapshot;
+        self.formatDownloadFileName     = formatDownloadFileName;
 
         function caseHeaderToCSV () {
           var header = [
@@ -198,7 +199,7 @@
               });
 
               /*global saveAs */
-              saveAs(blob, aCase.caseName + '_basic.csv');
+              saveAs(blob, formatDownloadFileName(aCase.caseName + '_basic.csv'));
             });
         }
 
@@ -210,7 +211,7 @@
               });
 
               /*global saveAs */
-              saveAs(blob, aCase.caseName + '_rre.json');
+              saveAs(blob, formatDownloadFileName(aCase.caseName + '_rre.json'));
             });
         }
 
@@ -222,7 +223,7 @@
               });
 
               /*global saveAs */
-              saveAs(blob, aCase.caseName + '_ltr.txt');
+              saveAs(blob, formatDownloadFileName(aCase.caseName + '_ltr.txt'));
             });
         }
 
@@ -312,6 +313,19 @@
 
 
           return csvContent;
+        }
+
+        /**
+         * Take a string and make it ready for downloads.
+         *
+         * @param aCase
+         *
+         */
+
+        function formatDownloadFileName (fileName) {
+          var downloadFileName = fileName.replace(/ /g,"_");
+
+          return downloadFileName;
         }
 
 

--- a/app/assets/javascripts/services/caseCSVSvc.js
+++ b/app/assets/javascripts/services/caseCSVSvc.js
@@ -316,14 +316,14 @@
         }
 
         /**
-         * Take a string and make it ready for downloads.
+         * Take a string and make it ready for being a downloaded file name
          *
          * @param aCase
          *
          */
 
         function formatDownloadFileName (fileName) {
-          var downloadFileName = fileName.replace(/ /g,"_");
+          var downloadFileName = fileName.replace(/ /g,'_');
 
           return downloadFileName;
         }

--- a/app/models/try.rb
+++ b/app/models/try.rb
@@ -92,7 +92,7 @@ class Try < ActiveRecord::Base
   end
 
   def id_from_field_spec
-    # much of this logic is inspired by https://github.com/o19s/splainer-search/blob/master/services/fieldSpecSvc.js
+    # logic is inspired by https://github.com/o19s/splainer-search/blob/master/services/fieldSpecSvc.js
 
     # rubocop:disable Style/IfUnlessModifier
     # rubocop:disable Style/MultipleComparison
@@ -101,7 +101,7 @@ class Try < ActiveRecord::Base
       return field_spec
     end
 
-    field_specs = field_spec.split
+    field_specs = field_spec.split(/[\s,]+/)
     field_specs.each do |fs|
       if 'id' == fs || '_id' == fs
         return fs

--- a/app/views/api/v1/export/ratings/show.rre.json.jbuilder
+++ b/app/views/api/v1/export/ratings/show.rre.json.jbuilder
@@ -2,7 +2,7 @@
 
 json.set!('id_field', @case.tries.latest.id_from_field_spec)
 json.set!('index', @case.case_name)
-json.set!('template', 'quepid.json')
+json.set!('template', 'template.json')
 
 json.queries do
   json.array! @case.queries, partial: 'rre_query', as: :query

--- a/spec/javascripts/angular/services/importRatingsSvc_spec.js
+++ b/spec/javascripts/angular/services/importRatingsSvc_spec.js
@@ -48,11 +48,9 @@ describe('Service: importRatingsSvc', function () {
     };
 
     var mockRREJson = {
-      "id_field": [
-        "id"
-      ],
+      "id_field": "id",
       "index": "Movies Search",
-      "template": "quepid.json",
+      "template": "template.json",
       "queries": [
         {
           "placeholders": {

--- a/test/controllers/api/v1/import/mock_rre_json.json
+++ b/test/controllers/api/v1/import/mock_rre_json.json
@@ -1,9 +1,7 @@
 {
-  "id_field": [
-    "id"
-  ],
+  "id_field": "id",
   "index": "Movies Search",
-  "template": "quepid.json",
+  "template": "template.json",
   "queries": [
     {
       "placeholders": {

--- a/test/models/try_test.rb
+++ b/test/models/try_test.rb
@@ -121,6 +121,9 @@ class TryTest < ActiveSupport::TestCase
 
       try.field_spec = 'title:title name id:id'
       assert_equal 'id', try.id_from_field_spec
+
+      try.field_spec = 'id:id, title:title, overview, thumb:poster_path'
+      assert_equal 'id', try.id_from_field_spec
     end
   end
 end


### PR DESCRIPTION


## Description
Discovered a bug in exporting field specs.   Also realizing the template file for RRE being called `quepid.json` is werid, lets go with a generic `template.json` name instead.

## Motivation and Context
From testing of Chorus.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
