### PR TITLE
fixes #165 cut-n-paste of field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.2.2 - ??
+
+### Bugs
+
+* When using the case wizard, you couldn't cut'n'paste in a long list of fields like `overview_en, overview_idioms` as they became a single tag.   https://github.com/o19s/quepid/pull/166 by @epugh fixes https://github.com/o19s/quepid/issues/165. 
+
 ## 6.2.1 - 2020-06-18
 
 Thanks to some feedback from the community, we figured out that the SQL script for

--- a/app/assets/templates/views/wizardModal.html
+++ b/app/assets/templates/views/wizardModal.html
@@ -133,7 +133,7 @@ curl -X POST -H 'Content-type:application/json' -d '{
           <div class="form-group clearfix">
             <label class="col-sm-3 control-label">Additional Display Fields</label>
             <div class="col-sm-9">
-              <tags-input ng-model="pendingWizardSettings.additionalFields" placeholder="Add a field" add-on-enter="true" add-on-space="true" min-length="1">
+              <tags-input ng-model="pendingWizardSettings.additionalFields" placeholder="Add a field" add-on-enter="true" add-on-space="true" add-on-paste="true" min-length="1">
               <auto-complete source="loadFields($query)" min-length="0" load-on-focus="true" load-on-empty="true"></auto-complete>
               </tags-input>
               <p class="help-block">Would any extra fields be handy to display?</p>


### PR DESCRIPTION

## Description
Turns on a parameter

## Motivation and Context
In writing a Kata for Chorus, I wanted the user to cut n paste a long list of fields into quepid, and they couldn't!

## How Has This Been Tested?
Manually

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
