### PR TITLE
remove method that was only used in testing

### DIFF
--- a/app/assets/javascripts/services/caseSvc.js
+++ b/app/assets/javascripts/services/caseSvc.js
@@ -160,19 +160,6 @@ angular.module('QuepidApp')
         return selectedCase;
       };
 
-      this.getCaseByNo = function(caseNo) {
-        console.log('I AM A DEAD METHOD UNLESS YOU SEE ME!');
-        var returnedCase = null;
-
-        angular.forEach(this.allCases, function(aCase) {
-          if (aCase.caseNo === caseNo) {
-            returnedCase = aCase;
-          }
-        });
-
-        return returnedCase;
-      };
-
       this.createCase = function(caseName, queries, tries) {
         // http post /cases/
         // returns as if we did http get /cases/<caseNo>

--- a/spec/javascripts/angular/services/caseSvc_spec.js
+++ b/spec/javascripts/angular/services/caseSvc_spec.js
@@ -5,14 +5,16 @@ describe('Service: caseSvc', function () {
   // load the service's module
   beforeEach(module('QuepidTest'));
 
+  var mockCase1 = {
+    'caseNo':   1,
+    'case_name': 'test case',
+    'lastTry':  4,
+    'owned':    true
+  };
+
   var mockCases = {
     allCases: [
-      {
-        'caseNo':   1,
-        'case_name': 'test case',
-        'lastTry':  4,
-        'owned':    true
-      },
+      mockCase1,
       {
         'caseNo':   2,
         'case_name': 'test case 2',
@@ -82,6 +84,8 @@ describe('Service: caseSvc', function () {
     beforeEach(function() {
       $httpBackend.expectGET('/api/cases').respond(200, mockCases);
       $httpBackend.expectGET('/api/dropdown/cases').respond(200, mockCases);
+
+
 
       caseSvc.uponBeingBootstrapped().
         then(function() {
@@ -192,22 +196,22 @@ describe('Service: caseSvc', function () {
     });
 
     it('gets a case by number', function() {
-      var caseNoOne = caseSvc.getCaseByNo(1);
-      expect(caseNoOne.caseName).toEqual('test case');
+      $httpBackend.expectGET('/api/cases/1').respond(200, mockCase1);
+      caseSvc.get(1,false).then(function(acase) {
+        expect(acase.caseName).toEqual('test case');
+      });
+      $httpBackend.flush();
     });
 
-    it('gets null if case number not present', function() {
-      var caseNoZero = caseSvc.getCaseByNo(0);
-      expect(caseNoZero).toEqual(null);
-      var caseNoOneK = caseSvc.getCaseByNo(1000);
-      expect(caseNoOneK).toEqual(null);
-    });
 
     it('deletes a case', function() {
+      $httpBackend.expectGET('/api/cases/1').respond(200, mockCase1);
       $httpBackend.expectDELETE('/api/cases/1').respond(200, '');
       expectToRefetchCases();
 
-      caseSvc.deleteCase(caseSvc.getCaseByNo(1));
+      caseSvc.get(1,false).then(function(acase) {
+        caseSvc.deleteCase(acase);
+      });
 
       $httpBackend.flush();
 
@@ -222,11 +226,14 @@ describe('Service: caseSvc', function () {
     });
 
     it('deletes and calls promise', function(){
+      $httpBackend.expectGET('/api/cases/1').respond(200, mockCase1);
       $httpBackend.expectDELETE('/api/cases/1').respond(200, '');
       expectToRefetchCases();
       var called = false;
-      caseSvc.deleteCase(caseSvc.getCaseByNo(1)).then( function() {
-        called = true;
+      caseSvc.get(1,false).then(function(acase) {
+        caseSvc.deleteCase(acase).then( function() {
+          called = true;
+        });
       });
       $httpBackend.flush();
       expect(called).toEqual(true);
@@ -235,9 +242,12 @@ describe('Service: caseSvc', function () {
     it('deletes currently selected case, calls promise', function(){
       caseSvc.selectCase(1);
       expect(caseSvc.getSelectedCase().caseNo).toEqual(1);
+      $httpBackend.expectGET('/api/cases/1').respond(200, mockCase1);
       $httpBackend.expectDELETE('/api/cases/1').respond(200, '');
       expectToRefetchCases();
-      caseSvc.deleteCase(caseSvc.getCaseByNo(1));
+      caseSvc.get(1,false).then(function(acase) {
+        caseSvc.deleteCase(acase);
+      });
       $httpBackend.flush();
       expect(caseSvc.getSelectedCase()).toEqual(null);
     });
@@ -245,9 +255,12 @@ describe('Service: caseSvc', function () {
     it('deletes currently selected case, calls promise', function(){
       caseSvc.selectCase(2);
       expect(caseSvc.getSelectedCase().caseNo).toEqual(2);
+      $httpBackend.expectGET('/api/cases/1').respond(200, mockCase1);
       $httpBackend.expectDELETE('/api/cases/1').respond(200, '');
       expectToRefetchCases();
-      caseSvc.deleteCase(caseSvc.getCaseByNo(1));
+      caseSvc.get(1,false).then(function(acase) {
+        caseSvc.deleteCase(acase);
+      });
       $httpBackend.flush();
       expect(caseSvc.getSelectedCase().caseNo).toEqual(2);
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove the getCaseByNo method that didn't seem to be used.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #172   Get rid of dead code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
