### PR TITLE
Revamp the base64 encoding of doc ids in ratings to only apply to eit…

### DIFF
--- a/app/assets/javascripts/services/ratingsStoreSvc.js
+++ b/app/assets/javascripts/services/ratingsStoreSvc.js
@@ -23,7 +23,9 @@ angular.module('QuepidApp')
 
         var path      = function(docId) {
           var id = docId;
-          if ( /http/.test(docId) || /\./.test(docId)) {
+          // For document id's that have either a / or a . character, we need to base64 encode them.
+          // Rails pukes on the . and the webapp pukes on the / in routing things.
+          if ( /\./.test(docId) || /\./.test(docId)) {
             id = btoa(docId);
           }
 

--- a/app/assets/javascripts/services/ratingsStoreSvc.js
+++ b/app/assets/javascripts/services/ratingsStoreSvc.js
@@ -25,7 +25,7 @@ angular.module('QuepidApp')
           var id = docId;
           // For document id's that have either a / or a . character, we need to base64 encode them.
           // Rails pukes on the . and the webapp pukes on the / in routing things.
-          if ( /\./.test(docId) || /\./.test(docId)) {
+          if ( /\//.test(docId) || /\./.test(docId)) {
             id = btoa(docId);
           }
 

--- a/app/assets/javascripts/services/ratingsStoreSvc.js
+++ b/app/assets/javascripts/services/ratingsStoreSvc.js
@@ -48,6 +48,8 @@ angular.module('QuepidApp')
           });
         };
 
+        // We do not encode doc ids with the bulk because they are in the payload
+        // instead of in the URL, so the / and . issues don't crop up.
         this.rateBulkDocuments = function(docIds, rating) {
           var url   = basePath() + '/bulk' + '/ratings';
           var data  = {

--- a/app/controllers/api/v1/queries/ratings_controller.rb
+++ b/app/controllers/api/v1/queries/ratings_controller.rb
@@ -32,24 +32,19 @@ module Api
         end
 
         def id_base64? id
-          id.is_a?(String) &&
-            Base64.strict_encode64(Base64.strict_decode64(id)) == id &&
-            (uri?(Base64.strict_decode64(id)) || contains_period?(Base64.strict_decode64(id)))
+          !is_numeric?(id) &&
+            Base64.strict_encode64(Base64.strict_decode64(id)) == id ||
+              contains_period?(Base64.strict_decode64(id))
         rescue ArgumentError
-          false
-        end
-
-        def uri? string
-          uri = URI.parse(CGI.unescape(string))
-          %w[ http https ].include?(uri.scheme)
-        rescue URI::BadURIError
-          false
-        rescue URI::InvalidURIError
           false
         end
 
         def contains_period? string
           string.include?('.')
+        end
+
+        def is_numeric? string
+          Float(string) != nil rescue false
         end
 
         def decode_id

--- a/app/controllers/api/v1/queries/ratings_controller.rb
+++ b/app/controllers/api/v1/queries/ratings_controller.rb
@@ -32,9 +32,9 @@ module Api
         end
 
         def id_base64? id
-          !is_numeric?(id) &&
+          !numeric?(id) &&
             Base64.strict_encode64(Base64.strict_decode64(id)) == id ||
-              contains_period?(Base64.strict_decode64(id))
+            contains_period?(Base64.strict_decode64(id))
         rescue ArgumentError
           false
         end
@@ -43,8 +43,10 @@ module Api
           string.include?('.')
         end
 
-        def is_numeric? string
-          Float(string) != nil rescue false
+        def numeric? string
+          nil != Float(string)
+        rescue ArgumentError
+          false
         end
 
         def decode_id

--- a/spec/javascripts/angular/services/ratingsStoreSvc_spec.js
+++ b/spec/javascripts/angular/services/ratingsStoreSvc_spec.js
@@ -54,6 +54,20 @@ describe('Service: Ratingsstoresvc', function () {
     ratingsStore.rateDocument('http://www.example.com/doc/1', 10);
     $httpBackend.flush();
     expect(ratingsStore.getRating('http://www.example.com/doc/1')).toBe(10);
+
+    var id = 'aspace-https-archives-yale-edu-repositories-5-archival_objects-2530795';
+    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings/aspace-https-archives-yale-edu-repositories-5-archival_objects-2530795').respond(200, {});
+    ratingsStore.rateDocument('aspace-https-archives-yale-edu-repositories-5-archival_objects-2530795', 10);
+    $httpBackend.flush();
+    expect(ratingsStore.getRating('aspace-https-archives-yale-edu-repositories-5-archival_objects-2530795')).toBe(10);
+
+    // Base64 encoded value of d2Vic2l0ZTpodHRwOi8vd3d3Lmdvb2dsZS5jb20= is then URL encoded.
+    id = 'website:http://www.google.com';
+    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings/d2Vic2l0ZTpodHRwOi8vd3d3Lmdvb2dsZS5jb20%3D').respond(200, {});
+    ratingsStore.rateDocument('website:http://www.google.com', 10);
+    $httpBackend.flush();
+    expect(ratingsStore.getRating('website:http://www.google.com')).toBe(10);
+
     $httpBackend.verifyNoOutstandingExpectation();
   });
   it('should base 64 and urlencode when POSTIng rating w id containing a period', function() {

--- a/spec/javascripts/angular/services/ratingsStoreSvc_spec.js
+++ b/spec/javascripts/angular/services/ratingsStoreSvc_spec.js
@@ -42,7 +42,7 @@ describe('Service: Ratingsstoresvc', function () {
 
   it('should urlencode when POSTIng rating', function() {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {});
-    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings/file%3A%2F%2Ffoo%2Fbar').respond(200, {});
+    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings/ZmlsZTovL2Zvby9iYXI%3D').respond(200, {});
     ratingsStore.rateDocument('file://foo/bar', 10);
     $httpBackend.flush();
     expect(ratingsStore.getRating('file://foo/bar')).toBe(10);
@@ -81,7 +81,7 @@ describe('Service: Ratingsstoresvc', function () {
 
   it('should urlencode when DELETING rating', function() {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {});
-    $httpBackend.expectDELETE('/api/cases/0/queries/1/ratings/file%3A%2F%2Ffoo%2Fbar').respond(200, {});
+    $httpBackend.expectDELETE('/api/cases/0/queries/1/ratings/ZmlsZTovL2Zvby9iYXI%3D').respond(200, {});
     ratingsStore.resetRating('file://foo/bar');
     $httpBackend.flush();
     expect(ratingsStore.hasRating('file://foo/bar')).toBe(false);

--- a/test/controllers/api/v1/queries/ratings_controller_test.rb
+++ b/test/controllers/api/v1/queries/ratings_controller_test.rb
@@ -132,6 +132,36 @@ module Api
             count = query.ratings.where(doc_id: doc_id).count
 
             assert_equal count, 1
+
+            # test where we have https but it's all dashes, no / or . character.
+            doc_id     = 'https-example-com-relative-path2'
+
+            assert_recognizes(
+              {
+                format:     :json,
+                controller: 'api/v1/queries/ratings',
+                action:     'update',
+                case_id:    acase.id.to_s,
+                query_id:   query.id.to_s,
+                doc_id:     doc_id,
+              },
+              path:   "/api/cases/#{acase.id}/queries/#{query.id}/ratings/#{doc_id}",
+              method: :put
+            )
+
+            put :update, case_id: acase.id, query_id: query.id, doc_id: doc_id, rating: 6
+
+            assert_response :ok
+
+            data = JSON.parse(response.body)
+
+            assert_equal data['rating'],    6
+            assert_equal data['doc_id'],    doc_id
+            assert_equal data['query_id'],  query.id
+
+            count = query.ratings.where(doc_id: doc_id).count
+
+            assert_equal count, 1
           end
 
           test 'works with a document id that contains a period' do

--- a/test/controllers/api/v1/queries/ratings_controller_test.rb
+++ b/test/controllers/api/v1/queries/ratings_controller_test.rb
@@ -134,7 +134,7 @@ module Api
             assert_equal count, 1
 
             # test where we have https but it's all dashes, no / or . character.
-            doc_id     = 'https-example-com-relative-path2'
+            doc_id = 'https-example-com-relative-path2'
 
             assert_recognizes(
               {


### PR DESCRIPTION
…her the / or the . character, and ignore if its a http url

<!--- Provide a general summary of your changes in the Title above -->

## Description
We had logic around if a doc id was a URL, i.e, looking at http...   However the real issue is that `/` and `.` are both probablamitc, and http doesn't matter.   So, instead of the URI logic, which was only done ont he rails side, not on the JS side, we simplifed, and only look at `/` and `.` to decide to do base64!

## Motivation and Context
Found werid urls in Yale docs, in bug #175 where it was like blah-blah-http-blah-blah, which is perfectly fine doc id!

## How Has This Been Tested?
unit tests.   I haven't figured out if legacy docs will blow up.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change) <-- MAYBE!

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
