### PR TITLE
Remove warning from backend about extra params sent from front end.

### DIFF
--- a/app/assets/javascripts/controllers/queriesCtrl.js
+++ b/app/assets/javascripts/controllers/queriesCtrl.js
@@ -222,26 +222,24 @@ angular.module('QuepidApp')
               lastScoreTracker = {
                 'score':      $scope.queries.avgQuery.lastScore.score,
                 'all_rated':  $scope.queries.avgQuery.lastScore.allRated,
-                'case_id':    caseNo,
                 'try_id':     tryNo,
                 'queries':    $scope.queries.avgQuery.lastScore.queries,
               };
 
               $log.info('sending score information to mothership');
-              caseSvc.trackLastScore(lastScoreTracker);
+              caseSvc.trackLastScore(caseNo, lastScoreTracker);
             });
         }
         else {
           var lastScoreTracker = {
             'score':      $scope.queries.avgQuery.lastScore.score,
             'all_rated':  $scope.queries.avgQuery.lastScore.allRated,
-            'case_id':    caseNo,
             'try_id':     tryNo,
             'queries':    $scope.queries.avgQuery.lastScore.queries,
           };
 
           $log.info('sending score information to mothership');
-          caseSvc.trackLastScore(lastScoreTracker);
+          caseSvc.trackLastScore(caseNo, lastScoreTracker);
         }
       }
 

--- a/app/assets/javascripts/services/caseSvc.js
+++ b/app/assets/javascripts/services/caseSvc.js
@@ -288,7 +288,7 @@ angular.module('QuepidApp')
         return $http.put(url, data);
       };
 
-      this.trackLastScore = function(scoreData) {
+      this.trackLastScore = function(caseNo, scoreData) {
         var self = this;
 
         if (  angular.isUndefined(scoreData.queries) ||
@@ -300,16 +300,7 @@ angular.module('QuepidApp')
           });
         }
 
-        /*jshint camelcase:false*/
-        var caseNo = scoreData.case_id;
-        /*jshint camelcase:true*/
-
         var url         = '/api/cases/'+ caseNo + '/scores';
-        var dateFormat  = 'yyyy-MM-dd HH:mm:ss Z';
-
-        /*jshint camelcase:false*/
-        scoreData.created_at = $filter('date')(new Date().toUTCString(), dateFormat);
-        /*jshint camelcase:true*/
 
         // Replace null values by an empty string for query scores,
         // in order to normalize values when score is not present:
@@ -319,7 +310,7 @@ angular.module('QuepidApp')
           }
         });
 
-        var data = { 'score': scoreData };
+        var data = { 'case_score': scoreData };
 
         return $http.put(url, data)
           .then(function(response) {

--- a/app/controllers/api/v1/case_scores_controller.rb
+++ b/app/controllers/api/v1/case_scores_controller.rb
@@ -39,13 +39,17 @@ module Api
 
       private
 
+      # There is a weird thing where for some reason our params object has both
+      # a "score" and a "case_score" hash of params, and they are identical, even
+      # though the front end only submits a "score" hash.  Some sort of magic.
+      # this leads to a Unpermitted parameter: queries
       def score_params
-        params.require(:score).permit(
+        params.require(:case_score).permit(
           :score,
           :all_rated,
           :try_id
         ).tap do |whitelisted|
-          whitelisted[:queries] = params[:score][:queries] if params[:score][:queries]
+          whitelisted[:queries] = params[:case_score][:queries] if params[:case_score][:queries]
         end
       end
     end

--- a/spec/javascripts/angular/services/caseSvc_spec.js
+++ b/spec/javascripts/angular/services/caseSvc_spec.js
@@ -436,7 +436,6 @@ describe('Service: caseSvc', function () {
     var scoreData = {
       score:      90,
       all_rated:  false,
-      case_id:    1,
       try_id:     3,
       queries:    {
         174: {
@@ -456,7 +455,7 @@ describe('Service: caseSvc', function () {
     it('tracks the last score successfully', function() {
       $httpBackend.expectPUT('/api/cases/1/scores').respond(200, '');
 
-      caseSvc.trackLastScore(scoreData);
+      caseSvc.trackLastScore(1, scoreData);
       $httpBackend.flush();
     });
 
@@ -465,7 +464,7 @@ describe('Service: caseSvc', function () {
       data.score   = 0;
       data.queries = {};
 
-      caseSvc.trackLastScore(data);
+      caseSvc.trackLastScore(1, data);
 
       $httpBackend.verifyNoOutstandingExpectation();
     });
@@ -476,7 +475,7 @@ describe('Service: caseSvc', function () {
 
       $httpBackend.expectPUT('/api/cases/1/scores').respond(200, '');
 
-      caseSvc.trackLastScore(data);
+      caseSvc.trackLastScore(1, data);
 
       $httpBackend.flush();
       $httpBackend.verifyNoOutstandingExpectation();
@@ -490,7 +489,7 @@ describe('Service: caseSvc', function () {
 
       $httpBackend.expectPUT('/api/cases/1/scores').respond(200, mockResponse);
 
-      caseSvc.trackLastScore(scoreData);
+      caseSvc.trackLastScore(1, scoreData);
       $httpBackend.flush();
       $rootScope.$apply();
 
@@ -518,7 +517,7 @@ describe('Service: caseSvc', function () {
 
       $httpBackend.expectPUT('/api/cases/1/scores').respond(200, mockResponse);
 
-      caseSvc.trackLastScore(scoreData);
+      caseSvc.trackLastScore(1, scoreData);
       $httpBackend.flush();
       $rootScope.$apply();
 

--- a/test/controllers/api/v1/case_scores_controller_test.rb
+++ b/test/controllers/api/v1/case_scores_controller_test.rb
@@ -18,7 +18,7 @@ module Api
 
       describe 'Updates case score' do
         test 'return an error if try id is not specified' do
-          put :update, case_id: acase.id, score: { score: 1 }
+          put :update, case_id: acase.id, case_score: { score: 1 }
 
           assert_response :bad_request
         end

--- a/test/controllers/api/v1/case_scores_controller_test.rb
+++ b/test/controllers/api/v1/case_scores_controller_test.rb
@@ -30,7 +30,7 @@ module Api
             try_id:    first_try.id,
           }
 
-          put :update, case_id: acase.id, score: data
+          put :update, case_id: acase.id, case_score: data
 
           assert_response :no_content
         end
@@ -42,7 +42,7 @@ module Api
             try_id:    first_try.id,
           }
 
-          put :update, case_id: acase.id, score: data
+          put :update, case_id: acase.id, case_score: data
 
           assert_response :ok
 
@@ -69,7 +69,7 @@ module Api
             },
           }
 
-          put :update, case_id: acase.id, score: data
+          put :update, case_id: acase.id, case_score: data
 
           assert_response :ok
 
@@ -87,7 +87,7 @@ module Api
           }
 
           assert_no_difference 'acase.scores.count' do
-            put :update, case_id: acase.id, score: data
+            put :update, case_id: acase.id, case_score: data
 
             assert_response :ok
 
@@ -118,7 +118,7 @@ module Api
           }
 
           assert_difference 'acase.scores.count' do
-            put :update, case_id: acase.id, score: data
+            put :update, case_id: acase.id, case_score: data
 
             assert_response :ok
 


### PR DESCRIPTION


## Description
Front end was sending extra parameters that the backend was droppping.   

Secondly, the json packet of data called `score` was renamed to `case_score` by the Rails layer, leaving a orphan `score` as well, which then was causing more warnings.   

## Motivation and Context
Get rid of logging error message.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manulaly and unit tests

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
