### PR TITLE
Support the clear Queries option for RRE format imports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.5.8-node-browsers-legacy
+      - image: circleci/ruby:2.5.8-node-browsers
         environment: # environment variables for primary container
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3

--- a/app/assets/javascripts/components/import_ratings/_modal.html
+++ b/app/assets/javascripts/components/import_ratings/_modal.html
@@ -16,7 +16,7 @@
   </p>
   <div class="checkbox">
     <label>
-      <input type="checkbox" ng-model='ctrl.csv.clearQueries'> Clear existing queries?
+      <input type="checkbox" ng-model='ctrl.clearQueries'> Clear existing queries?
       <span class="glyphicon glyphicon-question-sign" aria-hidden="true" data-placement="right" data-toggle="tooltip"  title="Select to clear all the existing queries on a case, this is typical when you manage your queries and ratings per case outside Quepid"></span>
     </label>
   </div>
@@ -76,6 +76,6 @@
   <i class="fa fa-spinner fa-spin" aria-hidden="true" ng-show="ctrl.loading"></i>
 
   <button class="btn btn-default float-left" ng-click="ctrl.cancel()">Cancel</button>
-  <button class="btn btn-primary" ng-click="ctrl.ok()" ng-disabled="ctrl.options.which === 'undefined'">Import</button>
+  <button class="btn btn-primary" ng-click="ctrl.ok()" ng-disabled="ctrl.options.which === 'undefined' || ctrl.import.alert !== undefined">Import</button>
 
 </div>

--- a/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
+++ b/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
@@ -12,8 +12,8 @@ angular.module('QuepidApp')
       ctrl.theCase      = theCase;
       ctrl.loading      = false;
       ctrl.import       = {};
+      ctrl.clearQueries = false;
       ctrl.csv          = {
-        clearQueries:     false,
         content:          null,
         header:           true,
         separator:        ',',
@@ -33,18 +33,23 @@ angular.module('QuepidApp')
       $scope.$watch('ctrl.csv.content', function(newVal, oldVal) {
         if (newVal !== oldVal) {
           ctrl.options.which = 'csv';
+          ctrl.checkCVSHeaders();
         }
       },true);
 
+      // doesn't appear to work.
       $scope.$watch('ctrl.rre.content', function(newVal, oldVal) {
         if (newVal !== oldVal) {
           ctrl.options.which = 'rre';
         }
       },true);
 
+      // doesn't appear to work.
       $scope.$watch('ctrl.rre', function(newVal, oldVal) {
         if (newVal !== oldVal) {
-          ctrl.options.which = 'rre';
+          if (oldVal.content !== newVal.content) {
+            ctrl.options.which = 'rre';
+          }
         }
       },true);
 
@@ -66,22 +71,7 @@ angular.module('QuepidApp')
 
       ctrl.ok = function () {
         if ( ctrl.options.which === 'csv' ) {
-          ctrl.import.alert = undefined;
-          var headers = ctrl.csv.content.split('\n')[0];
-          headers     = headers.split(ctrl.csv.separator);
-
-          var expectedHeaders = [
-            'query', 'docid', 'rating'
-          ];
-
-          if (!angular.equals(headers, expectedHeaders)) {
-            var alert = 'Headers mismatch! Please make sure you have the correct headers in you file (check for correct spelling and capitalization): ';
-            alert += '<br /><strong>';
-            alert += expectedHeaders.join(',');
-            alert += '</strong>';
-
-            ctrl.import.alert = alert;
-          }
+          ctrl.checkCVSHeaders();
         }
 
         // check if any alerts defined.
@@ -92,7 +82,7 @@ angular.module('QuepidApp')
             importRatingsSvc.importCSVFormat(
               ctrl.theCase,
               ctrl.csv.result,
-              ctrl.csv.clearQueries
+              ctrl.clearQueries
             ).then(function() {
                 ctrl.loading = false;
                 $uibModalInstance.close();
@@ -108,7 +98,8 @@ angular.module('QuepidApp')
           else if (ctrl.options.which === 'rre' ) {
             importRatingsSvc.importRREFormat(
               ctrl.theCase,
-              ctrl.rre.content
+              ctrl.rre.content,
+              ctrl.clearQueries
             ).then(function() {
                 ctrl.loading = false;
                 $uibModalInstance.close();
@@ -126,6 +117,25 @@ angular.module('QuepidApp')
 
       ctrl.cancel = function () {
         $uibModalInstance.dismiss('cancel');
+      };
+
+      ctrl.checkCVSHeaders = function() {
+        ctrl.import.alert = undefined;
+        var headers = ctrl.csv.content.split('\n')[0];
+        headers     = headers.split(ctrl.csv.separator);
+
+        var expectedHeaders = [
+          'query', 'docid', 'rating'
+        ];
+
+        if (!angular.equals(headers, expectedHeaders)) {
+          var alert = 'Headers mismatch! Please make sure you have the correct headers in you file (check for correct spelling and capitalization): ';
+          alert += '<br /><strong>';
+          alert += expectedHeaders.join(',');
+          alert += '</strong>';
+
+          ctrl.import.alert = alert;
+        }
       };
     }
   ]);


### PR DESCRIPTION
It turns out that the clear queries wasn supported byt he RRE importer, even thoguh it should have been, so improve it to support that.  also make the import button smarter about if alerts happened

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
