### PR TITLE
Make loading teams faster

### DIFF
--- a/app/controllers/api/v1/teams_controller.rb
+++ b/app/controllers/api/v1/teams_controller.rb
@@ -56,7 +56,8 @@ module Api
       end
 
       def case_load
-        @load_cases = 'true' == params[:load_cases]
+        bool = ActiveRecord::Type::Boolean.new
+        @load_cases = bool.type_cast_from_user(params[:load_cases]) || false
       end
     end
   end

--- a/app/views/api/v1/teams/_team.json.jbuilder
+++ b/app/views/api/v1/teams/_team.json.jbuilder
@@ -20,7 +20,7 @@ end
 
 if load_cases
   json.cases do
-    json.array! team.cases, partial: 'api/v1/cases/case', as: :acase, locals: { shallow: true }
+    json.array! team.cases, partial: 'api/v1/cases/case', as: :acase, locals: { shallow: true, no_teams: true, no_tries: true }
   end
 end
 

--- a/app/views/api/v1/teams/_team.json.jbuilder
+++ b/app/views/api/v1/teams/_team.json.jbuilder
@@ -20,7 +20,9 @@ end
 
 if load_cases
   json.cases do
+    # rubocop:disable Metrics/LineLength
     json.array! team.cases, partial: 'api/v1/cases/case', as: :acase, locals: { shallow: true, no_teams: true, no_tries: true }
+    # rubocop:enable Metrics/LineLength
   end
 end
 

--- a/test/controllers/api/v1/teams_controller_test.rb
+++ b/test/controllers/api/v1/teams_controller_test.rb
@@ -179,7 +179,7 @@ module Api
       end
 
       describe 'Listing teams' do
-        test 'returns list of team owned by user' do
+        test 'returns list of teams owned by user' do
           get :index
 
           assert_response :ok
@@ -192,7 +192,7 @@ module Api
           assert_equal teams.first['id'],   the_team.id
         end
 
-        test 'returns list of team shared by user' do
+        test 'returns list of teams shared by user' do
           get :index
 
           assert_response :ok
@@ -203,6 +203,17 @@ module Api
           assert_equal teams.length,        user.teams_im_in.all.length
           assert_equal teams.last['name'],  shared_team.name
           assert_equal teams.last['id'],    shared_team.id
+        end
+
+        test 'returns list of teams and loads case data' do
+          get :index, load_cases: true
+
+          assert_response :ok
+
+          body  = JSON.parse(response.body)
+          teams = body['teams']
+
+          refute_empty(teams.last['cases'])
         end
       end
     end

--- a/test/controllers/api/v1/teams_controller_test.rb
+++ b/test/controllers/api/v1/teams_controller_test.rb
@@ -213,7 +213,7 @@ module Api
           body  = JSON.parse(response.body)
           teams = body['teams']
 
-          refute_empty(teams.last['cases'])
+          assert_not_empty(teams.last['cases'])
         end
       end
     end

--- a/test/fixtures/teams.yml
+++ b/test/fixtures/teams.yml
@@ -41,6 +41,7 @@ shared_team:
   name:     Team shared with Team Finder User
   owner:    :random
   members:  team_finder_user, team_owner, shared_team_member
+  cases:    shared_team_case
 
 team_owner_team:
   name:     Team owned bt Team Owner User


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Today, when I go to share a case or scorer, in app.quepid.com I get a 1.8 MB JSON file back!  in staging it's 1.14 MB!!!


## Motivation and Context
This makes the screen load much faster.  We even tell the user "It'll be fast, I promise" while you stare at the loading wheel!

We don't need all the query or tries data.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
unit test and manulally.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
