### PR TITLE
Review bin/docker commands.  Add a bin/docker console for the Rails console.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,17 +102,17 @@ bin/docker server
 
 It can take up to a minute for the server to respond as it compiles all the front end assets on the first call.
 
-We've created a helper script to run and manage the app through docker that wraps around the `docker-compose` command.
+We've created a helper script to run and manage the app through docker that wraps around the `docker-compose` command.  You will need Ruby installed.
 You can still use `docker-compose` directly, but for the basic stuff you can use the following:
 
-* Building the image: `bin/docker build` or `bin/docker b`
-* Start the vm: `bin/docker start` or `bin/docker t`
-* Stop the vm: `bin/docker stop` or `bin/docker p`
-* Destroy the image: `bin/docker destroy` or `bin/docker d`
 * Start the app: `bin/docker server` or `bin/docker s`
-* Connect to the app container with bash: `bin/docker bash` or `bin/docker c`
+* Connect to the app container with bash: `bin/docker bash` or `bin/docker ba`
+* Connect to the Rails console: `bin/docker console` or `bin/docker c`
 * Run any command: `bin/docker run [COMMAND]` or `bin/docker r [COMMAND]`
+* Run dev mode as daemon: `bin/docker daemon` or `bin/docker q`
+* Destroy the Docker env: `bin/docker destroy` or `bin/docker d`
 * Run unit tests: `bin/docker r bin/rake test:quepid`
+
 
 ## II. Development Log
 

--- a/bin/docker
+++ b/bin/docker
@@ -8,23 +8,19 @@ command, *rest = ARGV
 
 Dir.chdir APP_ROOT do
   case command
-  when 'build', 'b'
-    system 'docker-compose build'
-  when 'bash', 'c'
+  when 'server', 's'
+    system 'docker-compose run --service-ports app foreman s -f Procfile.dev'
+  when 'bash', 'b'
     system 'docker-compose run --rm app bash'
+  when 'console', 'c'
+    system 'docker-compose run --rm app rails console'
+  when 'run', 'r'
+    system "docker-compose run --rm app #{rest.join(' ')}"
   when 'daemon', 'q'
     system 'docker-compose run -d --service-ports app foreman s -f Procfile.dev'
   when 'destroy', 'd'
     system 'docker-compose down'
-  when 'run', 'r'
-    system "docker-compose run --rm app #{rest.join(' ')}"
-  when 'stop', 'p'
-    system 'docker-compose stop'
-  when 'server', 's'
-    system 'docker-compose run --service-ports app foreman s -f Procfile.dev'
-  when 'start', 't'
-    system 'docker-compose start'
   else
-    puts 'Unknown option (build|b, bash|c, daemon|q, destroy|d, run|r, stop|p, server|s, start|t)'
+    puts 'Unknown option (bash|b, console|c, run|r, server|s, daemon|q, destroy|d)'
   end
 end


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

## Description
Inspired by comments with @DmitryKey, I wanted to add a simple way to play with the ActiveRecord objects in Quepid.  So I added a `./bin/docker console` to pop you right into the Rails console.

Then, looking at the `bin/docker` file, I worked through the various commands, removed the build, start, and stop, as they didnt seem to work reliably, and I have never used them!  

I also reordered them from alphabetical into "order to use them in", though that may not have been a good idea...   

## Motivation and Context
Remove docker interactions that I don't understand, under the theory that if I don't get them, well, no one else will ;-)   Happy to leave them if anyone can test them and provide the use case for them.

This is also potentially prepatory for merging the `setup_docker` script into a `docker setup` command instead ;-)

## How Has This Been Tested?
manually playing.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
