### PR TITLE
fixed isUrl function that check whether the given field is of the url…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 * Running `bin/setup_docker` more than once always had hiccups on dropping MySQL, and needed a `docker-compose -v`, so just make that part of the script. https://github.com/o19s/quepid/pull/208 by @epugh fixes this.
 
+* Making HTTP links clickable wasn't working in some cases.  https://github.com/o19s/quepid/pull/211 by @e-budur fixes https://github.com/o19s/quepid/issues/183.
+
 
 ## 6.3.0 - 2020-09-01
 

--- a/app/assets/javascripts/controllers/searchResult.js
+++ b/app/assets/javascripts/controllers/searchResult.js
@@ -87,7 +87,7 @@ angular.module('QuepidApp')
         return typeof value === 'object';
       };
       $scope.isUrl = function(value) {
-        return ( /^\s+http/.test(value));
+        return ( /^\s*http[s]?:.*/.test(value));
       };
     }
   ]);

--- a/spec/javascripts/angular/controllers/searchResult_spec.js
+++ b/spec/javascripts/angular/controllers/searchResult_spec.js
@@ -1,0 +1,40 @@
+'use strict';
+
+describe('Controller: SearchResultCtrl', function () {
+
+  // load the controller's module
+  beforeEach(module('QuepidTest'));
+
+  var SearchResultCtrl,
+    scope;
+
+  var mockDoc = {
+    subSnippets: function(hlPre, hlPost) {
+      return [];
+    }
+  };
+
+  // Initialize the controller and a mock scope
+  beforeEach(inject(function ($controller, $rootScope) {
+    scope = $rootScope.$new();
+    scope.doc = mockDoc;
+    SearchResultCtrl = $controller('SearchResultCtrl', {
+      $scope: scope
+    });
+
+  }));
+
+  describe('Initial state', function () {
+    it('instantiates the controller properly', function () {
+      expect(SearchResultCtrl).not.toBeUndefined();
+    });
+  });
+
+  it('Check url paths', function () {
+    expect(scope.isUrl("http://amazon.ca")).toBe(true);
+    expect(scope.isUrl("https://amazon.ca")).toBe(true);
+    expect(scope.isUrl("httpx://amazon.ca")).toBe(false);
+    expect(scope.isUrl(" http://amazon.ca")).toBe(true);
+    expect(scope.isUrl(" https://amazon.ca")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

The following part of [this wiki page](https://github.com/o19s/quepid/wiki/Tips-for-working-with-Quepid) says that the fields that contain a value that starts with `http` is supposed to be turned into a link.

> Sometimes you need to look at the original document. If your field value starts with the string http then it will be turned into a link.

However, it looks like the links aren't formatted as expected due to the regex that mismatch URLs that starts with `https` 

So, changed the regex in the corresponding function that checks whether a field is a URL or not.

Fixes #183


## How Has This Been Tested?
I tested the new regex from [https://regex101.com/](https://regex101.com/) with the following URLs.

http://amazon.ca  _works-OK_
https://amazon.ca _works-OK_
httpx://amazon.ca _doesn't work-OK_
[SPACE] http://amazon.ca _works-OK_
[SPACE] https://amazon.ca _works-OK_


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
