### PR TITLE
Move "docid" from the URL to a JSON payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Update Javascript references to `application/javascript`.  Pay down some tech debt!  https://github.com/o19s/quepid/pull/223 by @epugh
 
+* Simplify handling doc id's that have periods or slashes in then, and avoid base64 issues by passing that in the JSON payload.  https://github.com/o19s/quepid/pull/233 by @epugh fixes https://github.com/o19s/quepid/issues/228.
+
 ## 6.3.1.2 - 2020-09-16
 
 * Silly cut'n'paste error that should have been caught with more testing before the 6.3.1.1 release, not the day after.  Fixed in commit 2e322b337cc62895847df0ed95ba6a68683dad5f by @epugh.

--- a/app/assets/javascripts/services/ratingsStoreSvc.js
+++ b/app/assets/javascripts/services/ratingsStoreSvc.js
@@ -32,9 +32,11 @@ angular.module('QuepidApp')
 
         this.rateDocument = function(docId, rating) {
           var url   = basePath() + '/ratings';
-          var data  = {
-            doc_id:  docId,
-            rating: rating,
+          var data  = { rating:
+            {
+              doc_id:  docId,
+              rating: rating,
+            }
           };
 
           $http.put(url, data).then(function() {
@@ -63,14 +65,16 @@ angular.module('QuepidApp')
 
         this.resetRating = function(docId) {
           var url   = basePath() + '/ratings';
-          var data  = {
-            doc_id:  docId,
+          var data  = { rating:
+            {
+              doc_id:  docId,
+            }
           };
           $http.delete(url, data).then(function() {
-            delete ratingsDict[docId];        
+            delete ratingsDict[docId];
             markDirty();
           });
-        };        
+        };
 
         this.resetBulkRatings = function(docIds) {
           var url   = basePath() + '/bulk' + '/ratings/delete';

--- a/app/assets/javascripts/services/ratingsStoreSvc.js
+++ b/app/assets/javascripts/services/ratingsStoreSvc.js
@@ -21,17 +21,6 @@ angular.module('QuepidApp')
           return '/api/cases/' + caseNo + '/queries/' + queryId;
         };
 
-        var path      = function(docId) {
-          var id = docId;
-          // For document id's that have either a / or a . character, we need to base64 encode them.
-          // Rails pukes on the . and the webapp pukes on the / in routing things.
-          if ( /\//.test(docId) || /\./.test(docId)) {
-            id = btoa(docId);
-          }
-
-          return  basePath() + '/ratings/' + encodeURIComponent(id);
-        };
-
         var markDirty = function() {
           version++;
           svcVersion++;

--- a/app/assets/javascripts/services/ratingsStoreSvc.js
+++ b/app/assets/javascripts/services/ratingsStoreSvc.js
@@ -42,14 +42,20 @@ angular.module('QuepidApp')
         };
 
         this.rateDocument = function(docId, rating) {
-          $http.put(path(docId), {'rating': rating}).then(function() {
+          var url   = basePath() + '/ratings';
+          var data  = {
+            doc_id:  docId,
+            rating: rating,
+          };
+
+          $http.put(url, data).then(function() {
             ratingsDict[docId] = rating;
+
             markDirty();
           });
         };
 
-        // We do not encode doc ids with the bulk because they are in the payload
-        // instead of in the URL, so the / and . issues don't crop up.
+        // This takes a single rating and applies it to a list of docIds
         this.rateBulkDocuments = function(docIds, rating) {
           var url   = basePath() + '/bulk' + '/ratings';
           var data  = {
@@ -67,11 +73,15 @@ angular.module('QuepidApp')
         };
 
         this.resetRating = function(docId) {
-          $http.delete(path(docId)).then(function() {
-            delete ratingsDict[docId];
+          var url   = basePath() + '/ratings';
+          var data  = {
+            doc_id:  docId,
+          };
+          $http.delete(url, data).then(function() {
+            delete ratingsDict[docId];        
             markDirty();
           });
-        };
+        };        
 
         this.resetBulkRatings = function(docIds) {
           var url   = basePath() + '/bulk' + '/ratings/delete';
@@ -96,7 +106,7 @@ angular.module('QuepidApp')
           if (ratingsDict.hasOwnProperty(docId)) {
             var rating = ratingsDict[docId];
             if (angular.isString(rating)) {
-              /* An annoying incosistency upstream is compensated for here:
+              /* An annoying inconsistency upstream is compensated for here:
                * sometimes we're given ratings as strings.
                * The backend bootstraps various features with ratings as strings
                * so we do a silly thing here and report the strings we store as ints

--- a/app/controllers/api/v1/queries/ratings_controller.rb
+++ b/app/controllers/api/v1/queries/ratings_controller.rb
@@ -4,9 +4,8 @@ module Api
   module V1
     module Queries
       class RatingsController < Api::V1::Queries::ApplicationController
-        #before_action :decode_id
         before_action :set_doc_id, only: %i[update destroy]
-        
+
         def update
           @rating = @query.ratings.find_or_create_by doc_id: @doc_id
 
@@ -26,12 +25,12 @@ module Api
           head :no_content
         end
 
-        #private
+        private
 
         def rating_params
           params.require(:rating).permit(:rating, :doc_id)
         end
-        
+
         def set_doc_id
           @doc_id = rating_params[:doc_id]
         end

--- a/app/controllers/api/v1/queries/ratings_controller.rb
+++ b/app/controllers/api/v1/queries/ratings_controller.rb
@@ -4,10 +4,11 @@ module Api
   module V1
     module Queries
       class RatingsController < Api::V1::Queries::ApplicationController
-        before_action :decode_id
-
+        #before_action :decode_id
+        before_action :set_doc_id, only: %i[update destroy]
+        
         def update
-          @rating = @query.ratings.find_or_create_by doc_id: @id
+          @rating = @query.ratings.find_or_create_by doc_id: @doc_id
 
           if @rating.update rating_params
             Analytics::Tracker.track_rating_created_event current_user, @rating
@@ -18,41 +19,21 @@ module Api
         end
 
         def destroy
-          @rating = @query.ratings.where(doc_id: @id).first
+          @rating = @query.ratings.where(doc_id: @doc_id).first
           @rating.delete
           Analytics::Tracker.track_rating_deleted_event current_user, @rating
 
           head :no_content
         end
 
-        private
+        #private
 
         def rating_params
-          params.permit(:rating)
+          params.require(:rating).permit(:rating, :doc_id)
         end
-
-        def id_base64? id
-          !numeric?(id) &&
-            Base64.strict_encode64(Base64.strict_decode64(id)) == id ||
-            contains_period?(Base64.strict_decode64(id))
-        rescue ArgumentError
-          false
-        end
-
-        def contains_period? string
-          string.include?('.')
-        end
-
-        def numeric? string
-          nil != Float(string)
-        rescue ArgumentError
-          false
-        end
-
-        def decode_id
-          @id = params[:doc_id]
-
-          @id = Base64.strict_decode64(@id) if id_base64? @id
+        
+        def set_doc_id
+          @doc_id = rating_params[:doc_id]
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,7 +83,7 @@ Rails.application.routes.draw do
             resource  :position,  only: [ :update ]
             resource  :scorer,    only: %i[show update destroy]
             resource  :threshold, only: [ :update ]
-            resources :ratings,   only: %i[update destroy], param: :doc_id
+            resource  :ratings,   only: %i[update destroy] # not actually a singular resource, doc_id in json payload
           end
 
           resource :bulk, only: [] do

--- a/spec/javascripts/angular/services/queriesSvc_spec.js
+++ b/spec/javascripts/angular/services/queriesSvc_spec.js
@@ -632,7 +632,7 @@ describe('Service: queriesSvc', function () {
     queriesSvc.persistQuery(newQ);
     $httpBackend.flush();
 
-    $httpBackend.expectPUT('/api/cases/2/queries/3/ratings/doc1').respond(200);
+    $httpBackend.expectPUT('/api/cases/2/queries/3/ratings').respond(200, {doc_id: 'doc1', rating: 10});
     newQ.docs[0].rate('10');
     $httpBackend.flush();
     $httpBackend.verifyNoOutstandingExpectation();
@@ -690,7 +690,7 @@ describe('Service: queriesSvc', function () {
 
       testQuery = queriesSvc.queries['0'];
       testDoc = testQuery.docs[0];
-      $httpBackend.expectPUT('/api/cases/2/queries/' + testQuery.queryId + '/ratings/' + testDoc.id).respond(200, '');
+      $httpBackend.expectPUT('/api/cases/2/queries/' + testQuery.queryId + '/ratings').respond(200, {doc_id: testDoc.id, rating: 10});
       versionBeforeRate = queriesSvc.version();
       testDoc.rate(10);
       $httpBackend.flush();
@@ -721,7 +721,8 @@ describe('Service: queriesSvc', function () {
 
     var testQuery = queriesSvc.queries['0'];
     var testDoc = testQuery.docs[0];
-    $httpBackend.expectPUT('/api/cases/3/queries/' + testQuery.queryId + '/ratings/' + testDoc.id).respond(200, '');
+    $httpBackend.expectPUT('/api/cases/3/queries/' + testQuery.queryId + '/ratings').respond(200, {doc_id: testDoc.id, rating: 10});
+    //$httpBackend.expectPUT('/api/cases/3/queries/' + testQuery.queryId + '/ratings/' + testDoc.id).respond(200, '');
     testDoc.rate(10);
     var score = testQuery.score();
     expect(score.score).toBeGreaterThan(0);

--- a/spec/javascripts/angular/services/ratingsStoreSvc_spec.js
+++ b/spec/javascripts/angular/services/ratingsStoreSvc_spec.js
@@ -20,7 +20,7 @@ describe('Service: Ratingsstoresvc', function () {
 
   it('should rate documents', function () {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {});
-    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings/doc1').respond(200, {});
+    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {});
     ratingsStore.rateDocument('doc1', 10);
     $httpBackend.flush();
     expect(ratingsStore.getRating('doc1')).toBe(10);
@@ -40,48 +40,45 @@ describe('Service: Ratingsstoresvc', function () {
     $httpBackend.verifyNoOutstandingExpectation();
   });
 
-  it('should urlencode when POSTIng rating', function() {
+  it('should handle slashes in the doc id', function() {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {});
-    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings/ZmlsZTovL2Zvby9iYXI%3D').respond(200, {});
+    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {});
     ratingsStore.rateDocument('file://foo/bar', 10);
     $httpBackend.flush();
     expect(ratingsStore.getRating('file://foo/bar')).toBe(10);
     $httpBackend.verifyNoOutstandingExpectation();
   });
-  it('should base 64 and urlencode when POSTIng rating w id is URL', function() {
+  it('should handle a URL as the doc id', function() {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {});
-    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings/aHR0cDovL3d3dy5leGFtcGxlLmNvbS9kb2MvMQ%3D%3D').respond(200, {});
+    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {doc_id: 'http://www.example.com/doc/1', rating: 10});
     ratingsStore.rateDocument('http://www.example.com/doc/1', 10);
     $httpBackend.flush();
     expect(ratingsStore.getRating('http://www.example.com/doc/1')).toBe(10);
 
-    var id = 'aspace-https-archives-yale-edu-repositories-5-archival_objects-2530795';
-    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings/aspace-https-archives-yale-edu-repositories-5-archival_objects-2530795').respond(200, {});
+    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {doc_id: 'aspace-https-archives-yale-edu-repositories-5-archival_objects-2530795', rating: 10});
     ratingsStore.rateDocument('aspace-https-archives-yale-edu-repositories-5-archival_objects-2530795', 10);
     $httpBackend.flush();
     expect(ratingsStore.getRating('aspace-https-archives-yale-edu-repositories-5-archival_objects-2530795')).toBe(10);
 
-    // Base64 encoded value of d2Vic2l0ZTpodHRwOi8vd3d3Lmdvb2dsZS5jb20= is then URL encoded.
-    id = 'website:http://www.google.com';
-    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings/d2Vic2l0ZTpodHRwOi8vd3d3Lmdvb2dsZS5jb20%3D').respond(200, {});
+    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {doc_id: 'website:http://www.google.com', rating: 10});
     ratingsStore.rateDocument('website:http://www.google.com', 10);
     $httpBackend.flush();
     expect(ratingsStore.getRating('website:http://www.google.com')).toBe(10);
 
     $httpBackend.verifyNoOutstandingExpectation();
   });
-  it('should base 64 and urlencode when POSTIng rating w id containing a period', function() {
+  it('should handle a document with a dot in the id', function() {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {});
-    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings/bXlkb2MucGRm').respond(200, {});
+    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {doc_id: 'mydoc.pdf', rating: 10});
     ratingsStore.rateDocument('mydoc.pdf', 10);
     $httpBackend.flush();
     expect(ratingsStore.getRating('mydoc.pdf')).toBe(10);
     $httpBackend.verifyNoOutstandingExpectation();
   });
 
-  it('should urlencode when DELETING rating', function() {
+  it('should handle when DELETING rating', function() {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {});
-    $httpBackend.expectDELETE('/api/cases/0/queries/1/ratings/ZmlsZTovL2Zvby9iYXI%3D').respond(200, {});
+    $httpBackend.expectDELETE('/api/cases/0/queries/1/ratings').respond(200, {doc_id: 'file://foo/bar'});
     ratingsStore.resetRating('file://foo/bar');
     $httpBackend.flush();
     expect(ratingsStore.hasRating('file://foo/bar')).toBe(false);
@@ -90,7 +87,7 @@ describe('Service: Ratingsstoresvc', function () {
 
   it('should alter the value of existing ratings', function() {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {doc1: 10});
-    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings/doc1').respond(200, {});
+    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {});
     ratingsStore.rateDocument('doc1', 5);
     $httpBackend.flush();
     expect(ratingsStore.getRating('doc1')).toBe(5);
@@ -100,7 +97,7 @@ describe('Service: Ratingsstoresvc', function () {
   it('should reset ratings', function() {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {doc1: 10});
     expect(ratingsStore.hasRating('doc1')).toBeTruthy();
-    $httpBackend.expectDELETE('/api/cases/0/queries/1/ratings/doc1').respond(200, {});
+    $httpBackend.expectDELETE('/api/cases/0/queries/1/ratings').respond(200, {});
     ratingsStore.resetRating('doc1');
     $httpBackend.flush();
     expect(ratingsStore.hasRating()).toBe(false);
@@ -142,7 +139,7 @@ describe('Service: Ratingsstoresvc', function () {
 
   it('updates version increment on reset', function() {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {doc1: 10});
-    $httpBackend.expectDELETE('/api/cases/0/queries/1/ratings/doc1').respond(200, {});
+    $httpBackend.expectDELETE('/api/cases/0/queries/1/ratings').respond(200, {doc_id: 'doc1'});
     var origVersion = ratingsStore.version();
     ratingsStore.resetRating('doc1');
     $httpBackend.flush();
@@ -151,7 +148,7 @@ describe('Service: Ratingsstoresvc', function () {
 
   it('updates version increment on rate', function() {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {doc1: 10});
-    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings/doc1').respond(200, {});
+    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {doc_id: 'doc2', rating: 10});
     var origVersion = ratingsStore.version();
     ratingsStore.rateDocument('doc1', '5');
     $httpBackend.flush();
@@ -193,7 +190,7 @@ describe('Rateable Docs', function () {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {doc1: 10});
     var solrDoc = {'id': 'doc2'};
     var rateableSolrDoc = ratingsStore.createRateableDoc(solrDoc);
-    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings/doc2').respond(200, {});
+    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {});
     rateableSolrDoc.rate(5);
     $httpBackend.flush();
     expect(rateableSolrDoc.getRating()).toBe(5);
@@ -204,7 +201,7 @@ describe('Rateable Docs', function () {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {doc1: 10});
     var solrDoc = {'id': 'doc2'};
     var rateableSolrDoc = ratingsStore.createRateableDoc(solrDoc);
-    $httpBackend.expectDELETE('/api/cases/0/queries/1/ratings/doc2').respond(200, {});
+    $httpBackend.expectDELETE('/api/cases/0/queries/1/ratings').respond(200, {doc_id: 'doc2'});
     rateableSolrDoc.resetRating();
     $httpBackend.flush();
     $httpBackend.verifyNoOutstandingExpectation();

--- a/spec/javascripts/angular/services/ratingsStoreSvc_spec.js
+++ b/spec/javascripts/angular/services/ratingsStoreSvc_spec.js
@@ -50,17 +50,17 @@ describe('Service: Ratingsstoresvc', function () {
   });
   it('should handle a URL as the doc id', function() {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {});
-    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {doc_id: 'http://www.example.com/doc/1', rating: 10});
+    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {rating: {doc_id: 'http://www.example.com/doc/1', rating: 10}});
     ratingsStore.rateDocument('http://www.example.com/doc/1', 10);
     $httpBackend.flush();
     expect(ratingsStore.getRating('http://www.example.com/doc/1')).toBe(10);
 
-    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {doc_id: 'aspace-https-archives-yale-edu-repositories-5-archival_objects-2530795', rating: 10});
+    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {rating: {doc_id: 'aspace-https-archives-yale-edu-repositories-5-archival_objects-2530795', rating: 10}});
     ratingsStore.rateDocument('aspace-https-archives-yale-edu-repositories-5-archival_objects-2530795', 10);
     $httpBackend.flush();
     expect(ratingsStore.getRating('aspace-https-archives-yale-edu-repositories-5-archival_objects-2530795')).toBe(10);
 
-    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {doc_id: 'website:http://www.google.com', rating: 10});
+    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {rating: {doc_id: 'website:http://www.google.com', rating: 10}});
     ratingsStore.rateDocument('website:http://www.google.com', 10);
     $httpBackend.flush();
     expect(ratingsStore.getRating('website:http://www.google.com')).toBe(10);
@@ -69,7 +69,7 @@ describe('Service: Ratingsstoresvc', function () {
   });
   it('should handle a document with a dot in the id', function() {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {});
-    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {doc_id: 'mydoc.pdf', rating: 10});
+    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {rating: {doc_id: 'mydoc.pdf', rating: 10}});
     ratingsStore.rateDocument('mydoc.pdf', 10);
     $httpBackend.flush();
     expect(ratingsStore.getRating('mydoc.pdf')).toBe(10);
@@ -78,7 +78,7 @@ describe('Service: Ratingsstoresvc', function () {
 
   it('should handle when DELETING rating', function() {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {});
-    $httpBackend.expectDELETE('/api/cases/0/queries/1/ratings').respond(200, {doc_id: 'file://foo/bar'});
+    $httpBackend.expectDELETE('/api/cases/0/queries/1/ratings').respond(200, {rating: {doc_id: 'file://foo/bar'}});
     ratingsStore.resetRating('file://foo/bar');
     $httpBackend.flush();
     expect(ratingsStore.hasRating('file://foo/bar')).toBe(false);
@@ -139,7 +139,7 @@ describe('Service: Ratingsstoresvc', function () {
 
   it('updates version increment on reset', function() {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {doc1: 10});
-    $httpBackend.expectDELETE('/api/cases/0/queries/1/ratings').respond(200, {doc_id: 'doc1'});
+    $httpBackend.expectDELETE('/api/cases/0/queries/1/ratings').respond(200, {rating: {doc_id: 'doc1'}});
     var origVersion = ratingsStore.version();
     ratingsStore.resetRating('doc1');
     $httpBackend.flush();
@@ -148,7 +148,7 @@ describe('Service: Ratingsstoresvc', function () {
 
   it('updates version increment on rate', function() {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {doc1: 10});
-    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {doc_id: 'doc2', rating: 10});
+    $httpBackend.expectPUT('/api/cases/0/queries/1/ratings').respond(200, {rating: {doc_id: 'doc2', rating: 10}});
     var origVersion = ratingsStore.version();
     ratingsStore.rateDocument('doc1', '5');
     $httpBackend.flush();
@@ -201,7 +201,7 @@ describe('Rateable Docs', function () {
     var ratingsStore = ratingsStoreSvc.createRatingsStore(0, 1, {doc1: 10});
     var solrDoc = {'id': 'doc2'};
     var rateableSolrDoc = ratingsStore.createRateableDoc(solrDoc);
-    $httpBackend.expectDELETE('/api/cases/0/queries/1/ratings').respond(200, {doc_id: 'doc2'});
+    $httpBackend.expectDELETE('/api/cases/0/queries/1/ratings').respond(200, {rating: {doc_id: 'doc2'}});
     rateableSolrDoc.resetRating();
     $httpBackend.flush();
     $httpBackend.verifyNoOutstandingExpectation();

--- a/test/controllers/api/v1/queries/ratings_controller_test.rb
+++ b/test/controllers/api/v1/queries/ratings_controller_test.rb
@@ -19,8 +19,12 @@ module Api
         describe 'Update query rating for doc' do
           test 'creates a new rating with TMDB id (issue 1001)' do
             doc_id = '7555'
+            rating = {
+              doc_id: doc_id,
+              rating: 4
+            }
 
-            put :update, case_id: acase.id, query_id: query.id, doc_id: doc_id, rating: 4
+            put :update, case_id: acase.id, query_id: query.id, rating: rating
 
             assert_response :ok
 
@@ -37,8 +41,13 @@ module Api
 
           test "creates a new rating if it didn't already exist" do
             doc_id = 'x123z'
-
-            put :update, case_id: acase.id, query_id: query.id, doc_id: doc_id, rating: 5
+            
+            rating = {
+              doc_id: doc_id,
+              rating: 5
+            }
+            
+            put :update, case_id: acase.id, query_id: query.id, rating: rating
 
             assert_response :ok
 
@@ -56,8 +65,13 @@ module Api
           test 'updates existing rating for doc' do
             doc_id = 'x123z'
             query.ratings.create(doc_id: doc_id, rating: 1)
-
-            put :update, case_id: acase.id, query_id: query.id, doc_id: doc_id, rating: 5
+            
+            rating = {
+              doc_id: doc_id,
+              rating: 5
+            }
+            
+            put :update, case_id: acase.id, query_id: query.id, rating: rating
 
             assert_response :ok
 
@@ -74,7 +88,10 @@ module Api
 
           test 'works with a url as the id' do
             doc_id     = 'https%3A%2F%2Fexample.com%2Frelative-path'
-            encoded_id = Base64.strict_encode64(doc_id)
+            rating = {
+              doc_id: doc_id,
+              rating: 5
+            }
 
             assert_recognizes(
               {
@@ -83,13 +100,12 @@ module Api
                 action:     'update',
                 case_id:    acase.id.to_s,
                 query_id:   query.id.to_s,
-                doc_id:     encoded_id,
               },
-              path:   "/api/cases/#{acase.id}/queries/#{query.id}/ratings/#{encoded_id}",
+              path:   "/api/cases/#{acase.id}/queries/#{query.id}/ratings",
               method: :put
             )
 
-            put :update, case_id: acase.id, query_id: query.id, doc_id: encoded_id, rating: 5
+            put :update, case_id: acase.id, query_id: query.id, rating: rating
 
             assert_response :ok
 
@@ -104,7 +120,10 @@ module Api
             assert_equal count, 1
 
             doc_id     = 'https://example.com/relative-path2'
-            encoded_id = Base64.strict_encode64(doc_id)
+            rating = {
+              doc_id: doc_id,
+              rating: 6
+            }
 
             assert_recognizes(
               {
@@ -113,13 +132,12 @@ module Api
                 action:     'update',
                 case_id:    acase.id.to_s,
                 query_id:   query.id.to_s,
-                doc_id:     encoded_id,
               },
-              path:   "/api/cases/#{acase.id}/queries/#{query.id}/ratings/#{encoded_id}",
+              path:   "/api/cases/#{acase.id}/queries/#{query.id}/ratings",
               method: :put
             )
 
-            put :update, case_id: acase.id, query_id: query.id, doc_id: encoded_id, rating: 6
+            put :update, case_id: acase.id, query_id: query.id, rating: rating
 
             assert_response :ok
 
@@ -135,6 +153,10 @@ module Api
 
             # test where we have https but it's all dashes, no / or . character.
             doc_id = 'https-example-com-relative-path2'
+            rating = {
+              doc_id: doc_id,
+              rating: 6
+            }            
 
             assert_recognizes(
               {
@@ -142,14 +164,13 @@ module Api
                 controller: 'api/v1/queries/ratings',
                 action:     'update',
                 case_id:    acase.id.to_s,
-                query_id:   query.id.to_s,
-                doc_id:     doc_id,
+                query_id:   query.id.to_s
               },
-              path:   "/api/cases/#{acase.id}/queries/#{query.id}/ratings/#{doc_id}",
+              path:   "/api/cases/#{acase.id}/queries/#{query.id}/ratings",
               method: :put
             )
 
-            put :update, case_id: acase.id, query_id: query.id, doc_id: doc_id, rating: 6
+            put :update, case_id: acase.id, query_id: query.id, rating: rating
 
             assert_response :ok
 
@@ -166,8 +187,12 @@ module Api
 
           test 'works with a document id that contains a period' do
             doc_id = 'mydoc.pdf'
+            rating = {
+              doc_id: doc_id,
+              rating: 5
+            }  
 
-            put :update, case_id: acase.id, query_id: query.id, doc_id: doc_id, rating: 5
+            put :update, case_id: acase.id, query_id: query.id, rating: rating
 
             assert_response :ok
 
@@ -187,9 +212,13 @@ module Api
               expects_any_ga_event_call
 
               doc_id = 'x123z'
+              rating = {
+                doc_id: doc_id,
+                rating: 5
+              }  
 
               perform_enqueued_jobs do
-                put :update, case_id: acase.id, query_id: query.id, doc_id: doc_id, rating: 5
+                put :update, case_id: acase.id, query_id: query.id, rating: rating
 
                 assert_response :ok
               end
@@ -200,9 +229,12 @@ module Api
         describe 'Removes doc rating' do
           test 'deletes rating from query' do
             doc_id = 'x123z'
+            rating = {
+              doc_id: doc_id
+            } 
             query.ratings.create(doc_id: doc_id, rating: 1)
 
-            delete :destroy, case_id: acase.id, query_id: query.id, doc_id: doc_id
+            delete :destroy, case_id: acase.id, query_id: query.id, rating: rating
 
             assert_response :no_content
 
@@ -216,10 +248,13 @@ module Api
               expects_any_ga_event_call
 
               doc_id = 'x123z'
+              rating = {
+                doc_id: doc_id
+              } 
               query.ratings.create(doc_id: doc_id, rating: 1)
 
               perform_enqueued_jobs do
-                delete :destroy, case_id: acase.id, query_id: query.id, doc_id: doc_id
+                delete :destroy, case_id: acase.id, query_id: query.id, rating: rating
 
                 assert_response :no_content
               end

--- a/test/controllers/api/v1/queries/ratings_controller_test.rb
+++ b/test/controllers/api/v1/queries/ratings_controller_test.rb
@@ -21,7 +21,7 @@ module Api
             doc_id = '7555'
             rating = {
               doc_id: doc_id,
-              rating: 4
+              rating: 4,
             }
 
             put :update, case_id: acase.id, query_id: query.id, rating: rating
@@ -41,12 +41,12 @@ module Api
 
           test "creates a new rating if it didn't already exist" do
             doc_id = 'x123z'
-            
+
             rating = {
               doc_id: doc_id,
-              rating: 5
+              rating: 5,
             }
-            
+
             put :update, case_id: acase.id, query_id: query.id, rating: rating
 
             assert_response :ok
@@ -65,12 +65,11 @@ module Api
           test 'updates existing rating for doc' do
             doc_id = 'x123z'
             query.ratings.create(doc_id: doc_id, rating: 1)
-            
+
             rating = {
               doc_id: doc_id,
-              rating: 5
+              rating: 5,
             }
-            
             put :update, case_id: acase.id, query_id: query.id, rating: rating
 
             assert_response :ok
@@ -87,10 +86,10 @@ module Api
           end
 
           test 'works with a url as the id' do
-            doc_id     = 'https%3A%2F%2Fexample.com%2Frelative-path'
+            doc_id = 'https%3A%2F%2Fexample.com%2Frelative-path'
             rating = {
               doc_id: doc_id,
-              rating: 5
+              rating: 5,
             }
 
             assert_recognizes(
@@ -119,10 +118,10 @@ module Api
 
             assert_equal count, 1
 
-            doc_id     = 'https://example.com/relative-path2'
+            doc_id = 'https://example.com/relative-path2'
             rating = {
               doc_id: doc_id,
-              rating: 6
+              rating: 6,
             }
 
             assert_recognizes(
@@ -155,8 +154,8 @@ module Api
             doc_id = 'https-example-com-relative-path2'
             rating = {
               doc_id: doc_id,
-              rating: 6
-            }            
+              rating: 6,
+            }
 
             assert_recognizes(
               {
@@ -164,7 +163,7 @@ module Api
                 controller: 'api/v1/queries/ratings',
                 action:     'update',
                 case_id:    acase.id.to_s,
-                query_id:   query.id.to_s
+                query_id:   query.id.to_s,
               },
               path:   "/api/cases/#{acase.id}/queries/#{query.id}/ratings",
               method: :put
@@ -189,8 +188,8 @@ module Api
             doc_id = 'mydoc.pdf'
             rating = {
               doc_id: doc_id,
-              rating: 5
-            }  
+              rating: 5,
+            }
 
             put :update, case_id: acase.id, query_id: query.id, rating: rating
 
@@ -214,8 +213,8 @@ module Api
               doc_id = 'x123z'
               rating = {
                 doc_id: doc_id,
-                rating: 5
-              }  
+                rating: 5,
+              }
 
               perform_enqueued_jobs do
                 put :update, case_id: acase.id, query_id: query.id, rating: rating
@@ -230,8 +229,8 @@ module Api
           test 'deletes rating from query' do
             doc_id = 'x123z'
             rating = {
-              doc_id: doc_id
-            } 
+              doc_id: doc_id,
+            }
             query.ratings.create(doc_id: doc_id, rating: 1)
 
             delete :destroy, case_id: acase.id, query_id: query.id, rating: rating
@@ -249,8 +248,8 @@ module Api
 
               doc_id = 'x123z'
               rating = {
-                doc_id: doc_id
-              } 
+                doc_id: doc_id,
+              }
               query.ratings.create(doc_id: doc_id, rating: 1)
 
               perform_enqueued_jobs do

--- a/test/integration/api/rating_documents_flow_test.rb
+++ b/test/integration/api/rating_documents_flow_test.rb
@@ -3,46 +3,19 @@
 require 'test_helper'
 
 class RatingDocumentsFlowTest < ActionDispatch::IntegrationTest
-  it 'can rate documents that have various formatted document ids' do
-    # asserts the route for normal doc id's works.
+  
+  it 'can rate documents where the doc_id isnt in the route' do
+
     assert_routing(
       {
         method: 'put',
-        path:   '/api/cases/44/queries/62/ratings/99',
+        path:   '/api/cases/44/queries/62/ratings',
       },
       controller: 'api/v1/queries/ratings',
       action:     'update',
       format:     :json,
       case_id:    '44',
-      'query_id': '62',
-      doc_id:     '99'
-    )
-
-    # make sure using other non numeric identifiers works.
-    assert_routing(
-      {
-        method: 'put',
-        path:   '/api/cases/44/queries/62/ratings/mydoc',
-      },
-      controller: 'api/v1/queries/ratings',
-      action:     'update',
-      format:     :json,
-      case_id:    '44',
-      'query_id': '62',
-      doc_id:     'mydoc'
-    )
-
-    # A period in the doc_id should work, however Rails assumes that post the dot is the format type.
-    # We deal with this by Base64 encoding in the Angular front end and decoding in ratings controller.
-    assert_routing(
-      {
-        method: 'put',
-        path:   '/api/cases/44/queries/62/ratings/mydoc.pdf',
-      },
-      controller: 'api/v1/queries/ratings',
-      action:     'update', 'format': 'pdf',
-      case_id:    '44', 'query_id': '62',
-      doc_id:     'mydoc'
+      query_id:   '62'
     )
   end
 end

--- a/test/integration/api/rating_documents_flow_test.rb
+++ b/test/integration/api/rating_documents_flow_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 
 class RatingDocumentsFlowTest < ActionDispatch::IntegrationTest
-
   it 'can rate documents where the doc_id isnt in the route' do
     assert_routing(
       {

--- a/test/integration/api/rating_documents_flow_test.rb
+++ b/test/integration/api/rating_documents_flow_test.rb
@@ -3,9 +3,8 @@
 require 'test_helper'
 
 class RatingDocumentsFlowTest < ActionDispatch::IntegrationTest
-  
-  it 'can rate documents where the doc_id isnt in the route' do
 
+  it 'can rate documents where the doc_id isnt in the route' do
     assert_routing(
       {
         method: 'put',


### PR DESCRIPTION

## Description
When rating documents, the doc_id is somethign the user controls, and can be any string.  We historically have had it in the URL, which meant things like `.` or `/` caused issues.   For those, we would base64 encode the doc id, and then on the server side do some checks and then if it was base64, then decode it.

However, we have found examples where the docid would erronosnly trigger the "is_base64" logic on the server side.

In digging, I noticed that the bulk rating capablity just passes the doc_id as part of the json payload, avoiding the URL issues.



## Motivation and Context
This refactoring fixes #228 and makes the code work more like other quepid apis.   

## How Has This Been Tested?
manually and unit testing.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
