### PR TITLE
control signup enablement via config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,6 @@ EMAIL_MARKETING_MODE=false
 
 # Default scorer for new user accounts
 QUEPID_DEFAULT_SCORER=AP@10
+
+# Whether or not signing up via the UI is enabled.
+SIGNUP_ENABLED=true

--- a/app/assets/javascripts/controllers/signup.js
+++ b/app/assets/javascripts/controllers/signup.js
@@ -12,6 +12,7 @@ angular.module('QuepidSecureApp')
       }
 
       $scope.isEmailMarketingMode = configurationSvc.isEmailMarketingMode();
+      $scope.isSignupEnabled = configurationSvc.isSignupEnabled();
 
       $scope.submit = function (agree, emailMarketingAgree, name, email, pass, confirm) {
         $scope.warnAgree    = false;

--- a/app/assets/javascripts/services/configurationSvc.js
+++ b/app/assets/javascripts/services/configurationSvc.js
@@ -6,6 +6,7 @@ angular.module('UtilitiesModule')
     function ConfigurationSvc() {
       var emailMarketingMode;
       var termsAndConditionsUrl;
+      var isSignupEnabled;
 
       this.setEmailMarketingMode = function(val) {
         emailMarketingMode = JSON.parse(val);
@@ -31,6 +32,14 @@ angular.module('UtilitiesModule')
 
       this.getTermsAndConditionsUrl = function () {
         return termsAndConditionsUrl;
+      };
+
+      this.setSignupEnabled = function (val) {
+        isSignupEnabled = JSON.parse(val);
+      };
+
+      this.isSignupEnabled = function() {
+        return isSignupEnabled;
       };
     }
   ]);

--- a/app/assets/templates/views/signup.html
+++ b/app/assets/templates/views/signup.html
@@ -31,11 +31,11 @@
       </div>
     </div>
 
-    <div class="col-md-1 or-block col-sm-2">
+    <div class="col-md-1 or-block col-sm-2" ng-show="isSignupEnabled">
       <h2>OR</h2>
     </div>
 
-    <div class="col-md-3 col-sm-4">
+    <div class="col-md-3 col-sm-4" ng-show="isSignupEnabled">
       <div ng-controller="SignupCtrl">
         <form ng-submit="submit(agree, emailMarketingAgree, name, email, password, confirm)" >
           <h2>Signup to get started!</h2>

--- a/app/views/layouts/secure.html.erb
+++ b/app/views/layouts/secure.html.erb
@@ -38,6 +38,7 @@
         }
         configurationSvc.setEmailMarketingMode('<%= Rails.application.config.email_marketing_mode %>');
         configurationSvc.setTermsAndConditionsUrl('<%= Rails.application.config.terms_and_conditions_url %>');
+        configurationSvc.setSignupEnabled('<%= Rails.application.config.signup_enabled %>');
       });
   </script>
 

--- a/config/initializers/customize_quepid.rb
+++ b/config/initializers/customize_quepid.rb
@@ -39,3 +39,7 @@ Rails.application.config.privacy_url = ENV.fetch('PRIVACY_URL', nil)
 # controls the display.
 #
 Rails.application.config.terms_and_conditions_url = ENV.fetch('TC_URL', nil)
+
+# == Enable signup
+# This parameter controls whether or not signing up via the UI is enabled.
+Rails.application.config.signup_enabled = ENV.fetch('SIGNUP_ENABLED', true)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
       resources :users,   only: %i[index show update] do
         get '/current' => 'current_user#show', on: :collection
       end
-      resources :signups, only: [ :create ]
+      resources :signups, only: [ :create ] if Rails.application.config.signup_enabled
 
       get '/dropdown/cases' => 'cases/dropdown#index'
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -37,6 +37,7 @@ services:
       - COOKIES_URL=
       - EMAIL_MARKETING_MODE=false
       - DEFAULT_QUEPID_SCORER=AP@10
+      - SIGNUP_ENABLED=true
     command: "foreman s -f Procfile"
     ports:
       - 80:3000 # Map to port 80 for outside users.

--- a/spec/javascripts/angular/services/configurationSvc_spec.js
+++ b/spec/javascripts/angular/services/configurationSvc_spec.js
@@ -17,6 +17,13 @@ describe('Service: ConfigurationSvc', function () {
     expect(!!configurationSvc).toBe(true);
   });
 
+  it('reports if signup is enabled', function () {
+    configurationSvc.setSignupEnabled(false);
+    expect(configurationSvc.isSignupEnabled()).toBe(false);
+    configurationSvc.setSignupEnabled(true);
+    expect(configurationSvc.isSignupEnabled()).toBe(true);
+  });
+
   it('reports if terms and conditions url was set', function () {
     configurationSvc.setTermsAndConditionsUrl('https://quepid.com/agreement');
     expect(configurationSvc.hasTermsAndConditions()).toBe(true);


### PR DESCRIPTION
Controls whether or not signing up is permitted.

## Description
Open signup is a potential security risk. This change makes it disable-able (by default it is enabled)
via an environment variable SIGNUP_ENABLED.

## Motivation and Context
To lock down the creation of users to be an administrative function. The administrator
must use the thor script to add users.

## How Has This Been Tested?
1. `bin/docker r bin/rake test:quepid`
1. `bin/docker r bin/rake karma:run`
1. `bin/docker r bundle exec rubocop`
1. SIGNUP_ENABLED not set (in .env)
  navigate to localhost:3000 and verify signup form is present
1. SIGNUP_ENABLED set to false (in .env)
   1. navigate to localhost:3000 and verify signup form is absent
   1. add admin user via `bin/docker r thor user:create -a foo@example.com "Admin" "admin"`, and verify can log in as admin user via UI

## Screenshots or GIFs (if appropriate):
![Screen Shot 2020-11-10 at 12 11 27 PM](https://user-images.githubusercontent.com/1682167/98728122-e5376980-234d-11eb-91ac-007ff9472739.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
   _there is none?_
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
