### PR TITLE
add teams owner controller tests and add check for ownership before a…

### DIFF
--- a/app/controllers/api/v1/team_owners_controller.rb
+++ b/app/controllers/api/v1/team_owners_controller.rb
@@ -8,7 +8,7 @@ module Api
 
       def update
         previous_owner = @team.owner
-        @team.members << previous_owner unless @team.members.exists?(previous_owner)
+        @team.members << previous_owner unless @team.members.exists?(previous_owner.id)
 
         if @team.update(owner_id: params[:id])
           respond_with @team

--- a/app/controllers/api/v1/team_owners_controller.rb
+++ b/app/controllers/api/v1/team_owners_controller.rb
@@ -4,6 +4,7 @@ module Api
   module V1
     class TeamOwnersController < Api::ApiController
       before_action :set_team, only: [ :update ]
+      before_action :check_team_owner, only: [ :update ]
 
       def update
         previous_owner = @team.owner

--- a/test/controllers/api/v1/team_owners_controller_test.rb
+++ b/test/controllers/api/v1/team_owners_controller_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Api
+  module V1
+    class TeamOwnersControllerTest < ActionController::TestCase
+      let(:owner) { users(:team_owner) }
+      let(:member1) { users(:team_member_1) }
+      let(:owned_team) { teams(:team_owner_team) }
+
+      before do
+        @controller = Api::V1::TeamOwnersController.new
+      end
+
+      describe 'Updating a teams owner' do
+        test 'user successfully updates an owned teams owner' do
+          login_user owner
+
+          put :update, team_id: owned_team.id, id: member1.id
+          assert_response :ok
+
+          assert_equal owner.owned_teams.count, 0
+          assert_equal member1.owned_teams.count, 1
+        end
+
+        test 'user cannot update a non-owned teams owner' do
+          login_user member1
+
+          put :update, team_id: owned_team.id, id: member1.id
+          assert_response :forbidden
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
…llowing it to change

## Description
Added a new class so that the existing team_owners_controller would have test coverage, and then added 2 tests, one for the happy path and one for the security hole I am trying to fix

## Motivation and Context
https://github.com/o19s/quepid/issues/230
security hole, currently any team member can make themselves the owner

## How Has This Been Tested?
ran rake tests including the new test to cover the issue, ran tests before code change and after to ensure correctness.

## Screenshots or GIFs (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
