### PR TITLE
Renaming a Case on the Teams Listing Page doesn't work

### DIFF
--- a/app/assets/javascripts/components/case_listing/case_listing_controller.js
+++ b/app/assets/javascripts/components/case_listing/case_listing_controller.js
@@ -58,7 +58,6 @@ angular.module('QuepidApp')
         ctrl.clickToEdit.clicked = false;
         if (ctrl.clickToEdit.oldVal !== ctrl.clickToEdit.currVal) {
           ctrl.clickToEdit.oldVal = ctrl.clickToEdit.currVal;
-          //ctrl.thisCase.rename(ctrl.clickToEdit.currVal);
           caseSvc.renameCase(ctrl.thisCase, ctrl.clickToEdit.currVal);
         }
       }

--- a/app/assets/javascripts/components/case_listing/case_listing_controller.js
+++ b/app/assets/javascripts/components/case_listing/case_listing_controller.js
@@ -6,9 +6,11 @@ angular.module('QuepidApp')
   .controller('CaseListingCtrl', [
     '$scope',
     'caseTryNavSvc',
+    'caseSvc',
     function (
       $scope,
-      caseTryNavSvc
+      caseTryNavSvc,
+      caseSvc
     ) {
       var ctrl = this;
 
@@ -26,6 +28,13 @@ angular.module('QuepidApp')
 
       // we may get bound to different cases on moves, reset the state
       $scope.$watch('thisCase', function() {
+        ctrl.thisCase            = $scope.thisCase;
+        ctrl.clickToEdit.currVal = ctrl.thisCase.caseName.slice(0);
+        ctrl.clickToEdit.clicked = false;
+      });
+
+      // we may get bound to different cases on moves, reset the state
+      $scope.$watch('caseRenamed', function() {
         ctrl.thisCase            = $scope.thisCase;
         ctrl.clickToEdit.currVal = ctrl.thisCase.caseName.slice(0);
         ctrl.clickToEdit.clicked = false;
@@ -49,7 +58,8 @@ angular.module('QuepidApp')
         ctrl.clickToEdit.clicked = false;
         if (ctrl.clickToEdit.oldVal !== ctrl.clickToEdit.currVal) {
           ctrl.clickToEdit.oldVal = ctrl.clickToEdit.currVal;
-          ctrl.thisCase.rename(ctrl.clickToEdit.currVal);
+          //ctrl.thisCase.rename(ctrl.clickToEdit.currVal);
+          caseSvc.renameCase(ctrl.thisCase, ctrl.clickToEdit.currVal);
         }
       }
     }

--- a/app/assets/javascripts/components/case_listing/case_listing_controller.js
+++ b/app/assets/javascripts/components/case_listing/case_listing_controller.js
@@ -27,18 +27,18 @@ angular.module('QuepidApp')
       ctrl.submit     = submit;
 
       // we may get bound to different cases on moves, reset the state
-      $scope.$watch('thisCase', function() {
-        ctrl.thisCase            = $scope.thisCase;
-        ctrl.clickToEdit.currVal = ctrl.thisCase.caseName.slice(0);
-        ctrl.clickToEdit.clicked = false;
-      });
+      //$scope.$watch('thisCase', function() {
+      //  ctrl.thisCase            = $scope.thisCase;
+      //  ctrl.clickToEdit.currVal = ctrl.thisCase.caseName.slice(0);
+      //  ctrl.clickToEdit.clicked = false;
+      //});
 
       // we may get bound to different cases on moves, reset the state
-      $scope.$watch('caseRenamed', function() {
-        ctrl.thisCase            = $scope.thisCase;
-        ctrl.clickToEdit.currVal = ctrl.thisCase.caseName.slice(0);
-        ctrl.clickToEdit.clicked = false;
-      });
+      //$scope.$watch('caseRenamed', function() {
+      //  ctrl.thisCase            = $scope.thisCase;
+      //  ctrl.clickToEdit.currVal = ctrl.thisCase.caseName.slice(0);
+      //  ctrl.clickToEdit.clicked = false;
+      //});
 
       function rename() {
         ctrl.clickToEdit.clicked = true;

--- a/app/assets/javascripts/components/case_listing/case_listing_controller.js
+++ b/app/assets/javascripts/components/case_listing/case_listing_controller.js
@@ -26,20 +26,6 @@ angular.module('QuepidApp')
       ctrl.rename     = rename;
       ctrl.submit     = submit;
 
-      // we may get bound to different cases on moves, reset the state
-      //$scope.$watch('thisCase', function() {
-      //  ctrl.thisCase            = $scope.thisCase;
-      //  ctrl.clickToEdit.currVal = ctrl.thisCase.caseName.slice(0);
-      //  ctrl.clickToEdit.clicked = false;
-      //});
-
-      // we may get bound to different cases on moves, reset the state
-      //$scope.$watch('caseRenamed', function() {
-      //  ctrl.thisCase            = $scope.thisCase;
-      //  ctrl.clickToEdit.currVal = ctrl.thisCase.caseName.slice(0);
-      //  ctrl.clickToEdit.clicked = false;
-      //});
-
       function rename() {
         ctrl.clickToEdit.clicked = true;
       }

--- a/app/assets/javascripts/components/change_team_owner/change_team_owner_controller.js
+++ b/app/assets/javascripts/components/change_team_owner/change_team_owner_controller.js
@@ -17,8 +17,6 @@ angular.module('QuepidApp')
         id: null,
       };
 
-      console.log(ctrl.team);
-
       $scope.$watch('ctrl.team', function() {
         ctrl.owner.id = ctrl.team.id;
       });

--- a/app/assets/javascripts/controllers/wizardModal.js
+++ b/app/assets/javascripts/controllers/wizardModal.js
@@ -237,7 +237,7 @@ angular.module('QuepidApp')
 
             //Change Case Name (Separate from Dev settings)
             if(typeof($scope.pendingWizardSettings.caseName) !=='undefined' && $scope.pendingWizardSettings.caseName !== ''){
-              caseSvc.renameCase(caseSvc.getSelectedCase(), $scope.pendingWizardSettings.caseName)
+              caseSvc.renameCase(caseSvc.getSelectedCase(), $scope.pendingWizardSettings.caseName);
             }
             var length = $scope.pendingWizardSettings.newQueries.length;
             var query = null;

--- a/app/assets/javascripts/controllers/wizardModal.js
+++ b/app/assets/javascripts/controllers/wizardModal.js
@@ -236,8 +236,8 @@ angular.module('QuepidApp')
             queriesSvc.changeSettings(caseTryNavSvc.getCaseNo(), latestSettings);
 
             //Change Case Name (Separate from Dev settings)
-            if(typeof($scope.pendingWizardSettings.caseName)!=='undefined'&&$scope.pendingWizardSettings.caseName!==''){
-              caseSvc.getSelectedCase().rename($scope.pendingWizardSettings.caseName);
+            if(typeof($scope.pendingWizardSettings.caseName) !=='undefined' && $scope.pendingWizardSettings.caseName !== ''){
+              caseSvc.renameCase(caseSvc.getSelectedCase(), $scope.pendingWizardSettings.caseName)
             }
             var length = $scope.pendingWizardSettings.newQueries.length;
             var query = null;

--- a/app/assets/javascripts/services/caseSvc.js
+++ b/app/assets/javascripts/services/caseSvc.js
@@ -62,24 +62,6 @@ angular.module('QuepidApp')
           return names.join(', ');
         };
 
-        theCase.rename = function(newName) {
-          if (newName.length > 0) {
-            // HTTP PUT /api/cases/<int:caseId>
-            var url  = '/api/cases/' + theCase.caseNo;
-            var data = {
-              case_name: newName
-            };
-
-            return $http.put(url, data)
-              .then(function() {
-                theCase.caseName = newName;
-                broadcastSvc.send('caseRenamed', theCase);
-              }, function() {
-                caseTryNavSvc.notFound();
-              });
-          }
-        };
-
         theCase.fetchCaseScore = function() {
           // HTTP GET /api/cases/<int:caseId>/scores
           var url = '/api/cases/' + theCase.caseNo + '/scores';
@@ -386,7 +368,8 @@ angular.module('QuepidApp')
       }
 
       /*
-       * rename the case.  Similar method on theCase object itself!
+       * rename the case.  This could be refactored into a more
+       * general "update" method.
        */
       function renameCase(theCase, newName) {
         if (newName.length > 0) {

--- a/app/assets/javascripts/services/caseSvc.js
+++ b/app/assets/javascripts/services/caseSvc.js
@@ -33,6 +33,7 @@ angular.module('QuepidApp')
       svc.listContainsCase  = listContainsCase;
       svc.refetchCaseLists  = refetchCaseLists;
       svc.saveDefaultScorer = saveDefaultScorer;
+      svc.renameCase        = renameCase;
 
       // an individual case, ie
       // a search problem to be solved
@@ -195,6 +196,7 @@ angular.module('QuepidApp')
             caseTryNavSvc.notFound();
           });
       };
+
 
       this.deleteCase = function(caseToDelete) {
         var that        = this;
@@ -382,6 +384,28 @@ angular.module('QuepidApp')
             return response;
           });
       }
+
+      /*
+       * rename the case.  Similar method on theCase object itself!
+       */
+      function renameCase(theCase, newName) {
+        if (newName.length > 0) {
+          // HTTP PUT /api/cases/<int:caseId>
+          var url  = '/api/cases/' + theCase.caseNo;
+          var data = {
+            case_name: newName
+          };
+
+          return $http.put(url, data)
+            .then(function() {
+              theCase.caseName = newName;
+              broadcastSvc.send('caseRenamed', theCase);
+            }, function() {
+              caseTryNavSvc.notFound();
+            });
+        }
+      };
+
 
       function get(id, useCache) {
         // http GET /api/cases/<int:caseId>

--- a/app/assets/javascripts/services/caseSvc.js
+++ b/app/assets/javascripts/services/caseSvc.js
@@ -404,7 +404,7 @@ angular.module('QuepidApp')
               caseTryNavSvc.notFound();
             });
         }
-      };
+      }
 
 
       function get(id, useCache) {

--- a/spec/javascripts/angular/services/caseSvc_spec.js
+++ b/spec/javascripts/angular/services/caseSvc_spec.js
@@ -140,7 +140,7 @@ describe('Service: caseSvc', function () {
 
       var newName = 'blah';
       $httpBackend.expectPUT('/api/cases/' + newCase.caseNo).respond(201, {});
-      newCase.rename(newName);
+      caseSvc.renameCase(newCase, newName);
       $httpBackend.flush();
       var sameCase = caseSvc.getSelectedCase();
       expect(sameCase.caseName).toBe(newName);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Digging in, it turns out that for Cases, we have the `case` object itself have methods like `case.rename(newName)`, however in most other objects we have a Service that manipulates our objects.  So ideally we would have `caseSvc.renameCase(case, newCaseName)`.   

This bug occureed because when we load a `Team` object, we get back a list of `cases`, but we don't add the method `rename(newName)` to those cases, it's just some JSON objects wiht out any of the supporting methods.



## Motivation and Context
Lets pay down some tech debt and start chipping away at the `Case` object, moving it to a pure object without all the methods that interact with the API, and put them in the `caseSvc`.



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
