### PR TITLE
WIP: add whitelist for search hosts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,6 @@ QUEPID_DEFAULT_SCORER=AP@10
 
 # Whether or not signing up via the UI is enabled.
 SIGNUP_ENABLED=true
+
+# Whitelist of allowed search hosts
+SEARCH_HOST_WHITELIST=example.com,quepid-elasticsearch.dev.o19s.com

--- a/app/models/try.rb
+++ b/app/models/try.rb
@@ -59,6 +59,9 @@ class Try < ActiveRecord::Base
   # Callbacks
   before_create :set_defaults
 
+  # Validations
+  validates_with ::SearchUrlWhitelistValidator
+
   def args
     if 'solr' == search_engine
       solr_args

--- a/app/validators/search_url_whitelist_validator.rb
+++ b/app/validators/search_url_whitelist_validator.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class SearchUrlWhitelistValidator < ActiveModel::Validator
+  def validate record
+    return true if Rails.application.config.search_host_whitelist.empty?
+    # TODO: extract host name from record.search_url (ignore protocol, port, path and other url components)
+    # TODO: check if host is in Rails.application.config.search_host_whitelist
+    return true
+  end
+end

--- a/config/initializers/customize_quepid.rb
+++ b/config/initializers/customize_quepid.rb
@@ -43,3 +43,7 @@ Rails.application.config.terms_and_conditions_url = ENV.fetch('TC_URL', nil)
 # == Enable signup
 # This parameter controls whether or not signing up via the UI is enabled.
 Rails.application.config.signup_enabled = ENV.fetch('SIGNUP_ENABLED', true)
+
+# == Search host whitelist
+# An array of allowed search hostnames. If empty, all hosts are allowed.
+Rails.application.config.search_host_whitelist = ENV.fetch('SEARCH_HOST_WHITELIST', '').split(',')


### PR DESCRIPTION
This is a WIP, for early feedback.

Add a whitelist configuration to Quepid that restricts which hosts are
allowed to be used as search backends.

TODO: use the list in the JS code as well, to provide user guidance and
ensure they know early on what the list of valid hosts are.
