### PR TITLE
patch up nDCG logic for less than 10 result to fix #234

### DIFF
--- a/db/scorers/ndcg@10.js
+++ b/db/scorers/ndcg@10.js
@@ -1,9 +1,18 @@
 var k = 10 // @Rank
+var missing_rating = 0; // pessimistic assumption
 
-var ideal = topRatings(k)
+var ideal = topRatings(k) // could return less than k if less than k docs have ratings
+var missing_pad = Array(k - ideal.length).fill(missing_rating);
+ideal = ideal.concat(missing_pad);
 
-k = ideal.length < k ? ideal.length : k
-var scores = Array(k).fill(0);
+var scores = Array(k);
+eachDoc(function (doc, i) {
+  if (hasDocRating(i)) {
+    scores[i] = (docRating(i));
+  } else {
+      scores[i] = missing_rating;
+  }
+}, k)
 
 function DCG(vals, k) {
   var dcg = 0;
@@ -15,17 +24,11 @@ function DCG(vals, k) {
   return dcg;
 }
 
-function nDCG(vals, k) {
-  var ideal = topRatings(k)
+function nDCG(vals, ideal, k) {
   var n = DCG(vals, k);
   var d = DCG(ideal, k);
   return d ? (n / d) : 0;
 }
 
-eachDoc(function (doc, i) {
-  if (hasDocRating(i)) {
-    scores[i] = (docRating(i));
-  }
-}, k)
+setScore(nDCG(scores, ideal, k));
 
-setScore(nDCG(scores, k));


### PR DESCRIPTION
The way we handled scenarios with less than 10 docs was poor so this is a remedy to that.

To address this, we now assume unrated documents get a value defined has `missing_rating` in the code (set to 0) in the default scorerer. So in situations with less than 10 docs rated, we fill/pad out the score array and the ideal score array to a length of 10 with 0's as the fill.

We discussed dropping unrated documents for a condensed list of results to be evaluated by nDCG, for nDCG', but I think this would lead to visual confusions as people use Quepid. Consider the scenarios only position 10 is rated (no other docs are rated) would that be intuitive to see that get a nDCG value of 1? I think the pessimistic default will encourage people to fill in missing ratings.