### PR TITLE
Issue 231: Fixing CSV Injection

### DIFF
--- a/app/assets/javascripts/services/caseCSVSvc.js
+++ b/app/assets/javascripts/services/caseCSVSvc.js
@@ -357,6 +357,10 @@
               data = textDelimiter + data + textDelimiter;
             }
 
+            if (data.startsWith('=') || data.startsWith('@') || data.startsWith('+') || data.startsWith('-')) {
+              data = ' ' + data;
+            }
+
             return data;
           }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,10 +43,9 @@ module ApplicationHelper
 
   def make_csv_safe str
     if %w[- = + @].include?(str[0])
-      " " + str
+      ' ' + str
     else
       str
     end
   end
-
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,4 +40,13 @@ module ApplicationHelper
     nil
   end
   # rubocop:enable Metrics/MethodLength
+
+  def make_csv_safe str
+    if %w[- = + @].include?(str[0])
+      " " + str
+    else
+      str
+    end
+  end
+
 end

--- a/app/views/api/v1/export/ratings/show.basic.csv.erb
+++ b/app/views/api/v1/export/ratings/show.basic.csv.erb
@@ -4,6 +4,6 @@ headers = ['query','docid','rating']
 <%= ::CSV.generate_line(headers).html_safe %><%
 @case.queries.each do |query|
   query.ratings.each do |rating|
-%><%= ::CSV.generate_line([query.query_text,rating.doc_id, rating.rating]).html_safe %><%
+%><%= ::CSV.generate_line([make_csv_safe(query.query_text),rating.doc_id, rating.rating]).html_safe %><%
   end
 end %>

--- a/app/views/api/v1/export/ratings/show.basic_snapshot.csv.erb
+++ b/app/views/api/v1/export/ratings/show.basic_snapshot.csv.erb
@@ -5,6 +5,6 @@ headers = ['query','docid','rating']
 @snapshot.snapshot_queries.each do |snapshot_query|
   snapshot_query.snapshot_docs.each do |snapshot_doc|
     rating = Rating.find_by_query_id_and_doc_id(snapshot_query.query.id,snapshot_doc.doc_id)
-%><%= ::CSV.generate_line([snapshot_query.query.query_text, snapshot_doc.doc_id, rating.nil? ? nil : rating.rating]).html_safe %><%
+%><%= ::CSV.generate_line([make_csv_safe(snapshot_query.query.query_text), snapshot_doc.doc_id, rating.nil? ? nil : rating.rating]).html_safe %><%
   end
 end %>

--- a/spec/javascripts/angular/services/caseCSVSvc_spec.js
+++ b/spec/javascripts/angular/services/caseCSVSvc_spec.js
@@ -134,5 +134,50 @@ describe('Service: caseCSVSvc', function () {
 
       expect(result).toEqual(expectedResult);
     });
+
+    it('escapes a value that starts with =', function () {
+      var newMockCase = angular.copy(mockCase);
+      newMockCase.caseName = '=Test Case';
+
+      var result = caseCSVSvc.stringify(newMockCase);
+
+      var expectedResult = 'Test Team, =Test Case,8,dog,30,2015-07-14 16:08:55,,This dog looks like a great dog.\r\nTest Team, =Test Case,8,cat,0,2015-07-14 16:08:55,,Is this ""really"" a ""cat""?\r\nTest Team, =Test Case,8,foo,,2015-07-14 16:08:55,,chil\'laxin\r\n';
+
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('escapes a value that starts with @', function () {
+      var newMockCase = angular.copy(mockCase);
+      newMockCase.caseName = '@Test Case';
+
+      var result = caseCSVSvc.stringify(newMockCase);
+
+      var expectedResult = 'Test Team, @Test Case,8,dog,30,2015-07-14 16:08:55,,This dog looks like a great dog.\r\nTest Team, @Test Case,8,cat,0,2015-07-14 16:08:55,,Is this ""really"" a ""cat""?\r\nTest Team, @Test Case,8,foo,,2015-07-14 16:08:55,,chil\'laxin\r\n';;
+
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('escapes a value that starts with +', function () {
+      var newMockCase = angular.copy(mockCase);
+      newMockCase.caseName = '+Test Case';
+
+      var result = caseCSVSvc.stringify(newMockCase);
+
+      var expectedResult = 'Test Team, +Test Case,8,dog,30,2015-07-14 16:08:55,,This dog looks like a great dog.\r\nTest Team, +Test Case,8,cat,0,2015-07-14 16:08:55,,Is this ""really"" a ""cat""?\r\nTest Team, +Test Case,8,foo,,2015-07-14 16:08:55,,chil\'laxin\r\n';;
+
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('escapes a value that starts with -', function () {
+      var newMockCase = angular.copy(mockCase);
+      newMockCase.caseName = '-Test Case';
+
+      var result = caseCSVSvc.stringify(newMockCase);
+
+      var expectedResult = 'Test Team, -Test Case,8,dog,30,2015-07-14 16:08:55,,This dog looks like a great dog.\r\nTest Team, -Test Case,8,cat,0,2015-07-14 16:08:55,,Is this ""really"" a ""cat""?\r\nTest Team, -Test Case,8,foo,,2015-07-14 16:08:55,,chil\'laxin\r\n';;
+
+      expect(result).toEqual(expectedResult);
+    });
+
   });
 });

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,23 +1,25 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ApplicationHelperTest < ActionView::TestCase
   test 'adds space when cell begins with =' do
-    assert_equal " =abc", make_csv_safe("=abc")
+    assert_equal ' =abc', make_csv_safe('=abc')
   end
 
   test 'adds space when cell begins with +' do
-    assert_equal " +abc", make_csv_safe("+abc")
+    assert_equal ' +abc', make_csv_safe('+abc')
   end
 
   test 'adds space when cell begins with -' do
-    assert_equal " -abc", make_csv_safe("-abc")
+    assert_equal ' -abc', make_csv_safe('-abc')
   end
 
   test 'adds space when cell begins with @' do
-    assert_equal " @abc", make_csv_safe("@abc")
+    assert_equal ' @abc', make_csv_safe('@abc')
   end
 
   test 'other strings unchanged' do
-    assert_equal "ab=@c", make_csv_safe("ab=@c")
+    assert_equal 'ab=@c', make_csv_safe('ab=@c')
   end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class ApplicationHelperTest < ActionView::TestCase
+  test 'adds space when cell begins with =' do
+    assert_equal " =abc", make_csv_safe("=abc")
+  end
+
+  test 'adds space when cell begins with +' do
+    assert_equal " +abc", make_csv_safe("+abc")
+  end
+
+  test 'adds space when cell begins with -' do
+    assert_equal " -abc", make_csv_safe("-abc")
+  end
+
+  test 'adds space when cell begins with @' do
+    assert_equal " @abc", make_csv_safe("@abc")
+  end
+
+  test 'other strings unchanged' do
+    assert_equal "ab=@c", make_csv_safe("ab=@c")
+  end
+end


### PR DESCRIPTION
## Description
A CSV injection vulnerability exists in Quepid. If a query contains a CSV injection payload, and a user exports and opens the case containing the query, they may be exploited. Possible attacks include code execution, data theft or phishing. 

Fix includes adding a space before the query fields that start with one of the offending characters. This will make excel and other programs treat the cell as a string.

## Motivation and Context
This change is required to improve the security of the product.
Issue #231 

## How Has This Been Tested?
Added unit tests
Manually exported different files on local server

## Screenshots or GIFs (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
