### PR TITLE
232 stored xss - add new env flag to forbid user scorers and only allow communal scorers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,6 @@ QUEPID_DEFAULT_SCORER=AP@10
 
 # Whether or not signing up via the UI is enabled.
 SIGNUP_ENABLED=true
+
+# Whether users are only allowed to use communal (admin controlled) scorers to prevent javascript embedding security issues
+COMMUNAL_SCORERS_ONLY=false

--- a/app/assets/javascripts/controllers/advancedCtrl.js
+++ b/app/assets/javascripts/controllers/advancedCtrl.js
@@ -8,12 +8,12 @@ angular.module('QuepidApp')
     '$rootScope', '$scope',
     'flash',
     'broadcastSvc',
-    'customScorerSvc',
+    'customScorerSvc', 'configurationSvc',
     function (
       $rootScope, $scope,
       flash,
       broadcastSvc,
-      customScorerSvc
+      customScorerSvc, configurationSvc
     ) {
       // Attributes
       $scope.advanced                 = {};
@@ -30,6 +30,8 @@ angular.module('QuepidApp')
       };
 
       $scope.scorerFilters = { typeFilter: 'communal' };
+
+      $scope.communalScorersOnly = configurationSvc.isCommunalScorersOnly();
 
       // Functions
       $scope.advanced.updateUserScorer    = updateUserScorer;

--- a/app/assets/javascripts/controllers/scorer.js
+++ b/app/assets/javascripts/controllers/scorer.js
@@ -6,11 +6,11 @@ angular.module('QuepidApp')
   .controller('ScorerCtrl', [
     '$scope', '$location', '$uibModalInstance', '$log',
     'parent', 'customScorerSvc', 'caseSvc', 'queriesSvc',
-    'ScorerFactory',
+    'ScorerFactory', 'configurationSvc',
     function (
       $scope, $location, $uibModalInstance, $log,
       parent, customScorerSvc, caseSvc, queriesSvc,
-      ScorerFactory
+      ScorerFactory, configurationSvc
     ) {
 
       $scope.activeScorer       = parent.currentScorer || {};
@@ -25,6 +25,7 @@ angular.module('QuepidApp')
       $scope.updateButtonLabel  = updateButtonLabel;
       $scope.scorerSelector     = parent.scorerSelector;
       $scope.okButtonLabel      = 'Select Scorer';
+      $scope.communalScorersOnly = configurationSvc.isCommunalScorersOnly();
 
       if ($scope.activeScorer.scorerId && ($scope.activeScorer.scorerId !== 'default')) {
         $scope.activeScorer.scorerId = parseInt($scope.activeScorer.scorerId);

--- a/app/assets/javascripts/services/configurationSvc.js
+++ b/app/assets/javascripts/services/configurationSvc.js
@@ -7,6 +7,7 @@ angular.module('UtilitiesModule')
       var emailMarketingMode;
       var termsAndConditionsUrl;
       var isSignupEnabled;
+      var communalScorersOnly;
 
       this.setEmailMarketingMode = function(val) {
         emailMarketingMode = JSON.parse(val);
@@ -40,6 +41,14 @@ angular.module('UtilitiesModule')
 
       this.isSignupEnabled = function() {
         return isSignupEnabled;
+      };
+
+      this.setCommunalScorersOnly = function(val) {
+        communalScorersOnly = JSON.parse(val);
+      };
+
+      this.isCommunalScorersOnly = function() {
+        return communalScorersOnly;
       };
     }
   ]);

--- a/app/assets/templates/views/advanced/index.html
+++ b/app/assets/templates/views/advanced/index.html
@@ -28,12 +28,12 @@
 
     <div class="row">
       <div class='col-md-4'>
-        <div class="btn-group">
+        <div class="btn-group" ng-show="!communalScorersOnly">
           <new-scorer button-text="'Add New'"></new-scorer>
         </div>
       </div>
 
-      <div class='col-md-4'>
+      <div class='col-md-4' ng-show="!communalScorersOnly">
         View
         &nbsp;&nbsp;&nbsp;
         <div class="btn-group">

--- a/app/assets/templates/views/pick_scorer.html
+++ b/app/assets/templates/views/pick_scorer.html
@@ -14,7 +14,7 @@
       </li>
     </ul>
 
-    <h4>Or select from your own custom scorers:</h4>
+    <div ng-show="!communalScorersOnly"><h4>Or select from your own custom scorers:</h4></div>
     <ul class="list-group">
       <li class="list-group-item"
       ng-repeat="scorer in scorers track by scorer.scorerId"
@@ -27,7 +27,7 @@
 </div>
 
 <div class="modal-footer">
-  <button class="btn btn-primary pull-left" ng-click="gotoAdvanced()">
+  <button class="btn btn-primary pull-left" ng-click="gotoAdvanced()" ng-show="!communalScorersOnly">
     <i class="glyphicon glyphicon-plus" style="color: #FFF"></i>
     Create New Scorer
   </button>

--- a/app/controllers/api/v1/scorers_controller.rb
+++ b/app/controllers/api/v1/scorers_controller.rb
@@ -8,7 +8,7 @@ module Api
       before_action :check_communal_scorers_only, only: %i[create update destroy]
 
       def index
-        @user_scorers = current_user.scorers.all unless 'true' == Rails.application.config.communal_scorers_only
+        @user_scorers = current_user.scorers.all unless Rails.application.config.communal_scorers_only
         @communal_scorers = Scorer.communal
 
         respond_with @user_scorers, @communal_scorers
@@ -212,7 +212,7 @@ module Api
       end
 
       def check_communal_scorers_only
-        return unless 'true' == Rails.application.config.communal_scorers_only
+        return unless Rails.application.config.communal_scorers_only
 
         render(
           json:   { error: 'Communal Scorers Only!' },

--- a/app/controllers/api/v1/scorers_controller.rb
+++ b/app/controllers/api/v1/scorers_controller.rb
@@ -5,9 +5,12 @@ module Api
   module V1
     class ScorersController < Api::ApiController
       before_action :set_scorer, only: %i[show update destroy]
+      before_action :check_communal_scorers_only, only: %i[create update, destroy]
 
       def index
-        @user_scorers     = current_user.scorers.all
+        if not Rails.application.config.communal_scorers_only == 'true'
+          @user_scorers     = current_user.scorers.all
+        end
         @communal_scorers = Scorer.communal
 
         respond_with @user_scorers, @communal_scorers
@@ -208,6 +211,10 @@ module Api
         # rubocop:enable Style/IfUnlessModifier
 
         render json: { error: 'Not Found!' }, status: :not_found unless @scorer
+      end
+
+      def check_communal_scorers_only
+        render json: { error: 'Communal Scorers Only!' }, status: :forbidden if Rails.application.config.communal_scorers_only == 'true'
       end
     end
   end

--- a/app/controllers/api/v1/scorers_controller.rb
+++ b/app/controllers/api/v1/scorers_controller.rb
@@ -5,7 +5,7 @@ module Api
   module V1
     class ScorersController < Api::ApiController
       before_action :set_scorer, only: %i[show update destroy]
-      before_action :check_communal_scorers_only, only: %i[create update, destroy]
+      before_action :check_communal_scorers_only, only: %i[create update destroy]
 
       def index
         if not Rails.application.config.communal_scorers_only == 'true'

--- a/app/controllers/api/v1/scorers_controller.rb
+++ b/app/controllers/api/v1/scorers_controller.rb
@@ -8,9 +8,7 @@ module Api
       before_action :check_communal_scorers_only, only: %i[create update destroy]
 
       def index
-        if not Rails.application.config.communal_scorers_only == 'true'
-          @user_scorers     = current_user.scorers.all
-        end
+        @user_scorers = current_user.scorers.all unless 'true' == Rails.application.config.communal_scorers_only
         @communal_scorers = Scorer.communal
 
         respond_with @user_scorers, @communal_scorers
@@ -214,7 +212,12 @@ module Api
       end
 
       def check_communal_scorers_only
-        render json: { error: 'Communal Scorers Only!' }, status: :forbidden if Rails.application.config.communal_scorers_only == 'true'
+        return unless 'true' == Rails.application.config.communal_scorers_only
+
+        render(
+          json:   { error: 'Communal Scorers Only!' },
+          status: :forbidden
+        )
       end
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,11 +34,13 @@
   <script>
     angular.module('QuepidApp')
       .run([
-        'secureRedirectSvc', 'bootstrapSvc',
-        function(secureRedirectSvc, bootstrapSvc) {
+        'secureRedirectSvc', 'bootstrapSvc', 'configurationSvc',
+        function(secureRedirectSvc, bootstrapSvc, configurationSvc) {
           var appDebug      = '<%= Rails.env == 'development' ? 'true' : 'false' %>';
           var debugPort     = '<%= request.port %>';
           var triggerWizard = <%= @triggerWizard || false %>;
+
+          configurationSvc.setCommunalScorersOnly('<%= Rails.application.config.communal_scorers_only %>');
 
           if (appDebug === 'true') {
             secureRedirectSvc.debugServer(debugPort);

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -32,11 +32,13 @@
   <script>
     angular.module('QuepidApp')
       .run([
-        'secureRedirectSvc', 'bootstrapSvc',
-        function(secureRedirectSvc, bootstrapSvc) {
+        'secureRedirectSvc', 'bootstrapSvc', 'configurationSvc',
+        function(secureRedirectSvc, bootstrapSvc, configurationSvc) {
           var appDebug      = '<%= Rails.env == 'development' ? 'true' : 'false' %>';
           var debugPort     = '<%= request.port %>';
           var triggerWizard = <%= @triggerWizard %>;
+
+          configurationSvc.setCommunalScorersOnly('<%= Rails.application.config.communal_scorers_only %>');
 
           if (appDebug === 'true') {
             secureRedirectSvc.debugServer(debugPort);

--- a/config/initializers/customize_quepid.rb
+++ b/config/initializers/customize_quepid.rb
@@ -49,4 +49,6 @@ Rails.application.config.signup_enabled = ENV.fetch('SIGNUP_ENABLED', true)
 # security flaw as malicious javascript could be entered. This setting restricts users to
 # communal scorers only, which are controlled by admins.
 #
-Rails.application.config.communal_scorers_only = ENV.fetch('COMMUNAL_SCORERS_ONLY', 'false')
+Rails.application.config.communal_scorers_only = ENV.fetch('COMMUNAL_SCORERS_ONLY', false)
+Rails.application.config.communal_scorers_only = true if 'true' == Rails.application.config.communal_scorers_only
+Rails.application.config.communal_scorers_only = false if 'false' == Rails.application.config.communal_scorers_only

--- a/config/initializers/customize_quepid.rb
+++ b/config/initializers/customize_quepid.rb
@@ -43,3 +43,10 @@ Rails.application.config.terms_and_conditions_url = ENV.fetch('TC_URL', nil)
 # == Enable signup
 # This parameter controls whether or not signing up via the UI is enabled.
 Rails.application.config.signup_enabled = ENV.fetch('SIGNUP_ENABLED', true)
+
+# == Communal Scorers Only
+# Users can normally create custom scorers which run embedded javascript, this is a potential
+# security flaw as malicious javascript could be entered. This setting restricts users to
+# communal scorers only, which are controlled by admins.
+#
+Rails.application.config.communal_scorers_only = ENV.fetch('COMMUNAL_SCORERS_ONLY', 'false')

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,6 +38,7 @@ services:
       - EMAIL_MARKETING_MODE=false
       - DEFAULT_QUEPID_SCORER=AP@10
       - SIGNUP_ENABLED=true
+      - COMMUNAL_SCORERS_ONLY=false
     command: "foreman s -f Procfile"
     ports:
       - 80:3000 # Map to port 80 for outside users.

--- a/spec/javascripts/angular/services/configurationSvc_spec.js
+++ b/spec/javascripts/angular/services/configurationSvc_spec.js
@@ -38,4 +38,11 @@ describe('Service: ConfigurationSvc', function () {
 
   });
 
+  it('reports if communcal scorers only is set', function () {
+    configurationSvc.setCommunalScorersOnly(false);
+    expect(configurationSvc.isCommunalScorersOnly()).toBe(false);
+    configurationSvc.setCommunalScorersOnly(true);
+    expect(configurationSvc.isCommunalScorersOnly()).toBe(true);
+  });
+
 });

--- a/test/controllers/api/v1/scorers_controller_test.rb
+++ b/test/controllers/api/v1/scorers_controller_test.rb
@@ -9,7 +9,7 @@ module Api
 
       before do
         @controller = Api::V1::ScorersController.new
-        Rails.application.config.communal_scorers_only = 'false'
+        Rails.application.config.communal_scorers_only = false
 
         login_user user
       end
@@ -193,7 +193,7 @@ module Api
         end
 
         test 'respects communal_Scorers_only environment setting' do
-          Rails.application.config.communal_scorers_only = 'true'
+          Rails.application.config.communal_scorers_only = true
 
           post :create
 
@@ -287,7 +287,7 @@ module Api
         end
 
         test 'respects communal_Scorers_only environment setting' do
-          Rails.application.config.communal_scorers_only = 'true'
+          Rails.application.config.communal_scorers_only = true
 
           put :update, id: owned_scorer.id, scorer: { name: 'new name' }
 
@@ -419,7 +419,7 @@ module Api
           end
 
           test 'respects communal_Scorers_only environment setting' do
-            Rails.application.config.communal_scorers_only = 'true'
+            Rails.application.config.communal_scorers_only = true
 
             delete :destroy, id: owned_scorer.id
 
@@ -633,7 +633,7 @@ module Api
         end
 
         test 'respects communal_Scorers_only environment setting' do
-          Rails.application.config.communal_scorers_only = 'true'
+          Rails.application.config.communal_scorers_only = true
 
           get :index
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a new config flag that if set to true only allows communal scorers (edited by admins) to be used. It enforces this at the service and UI layers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is to fix a security hole where malicious users could insert malicious javascript into scorers.
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/o19s/quepid/issues/232

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1 - added tests to the scorers_controller_tests.rb class
2 - manually tested with local quepid instance to ensure gui behaved correctly with and without flag set

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
