### PR TITLE
Harden export import cycle for queries no docs

### DIFF
--- a/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
+++ b/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
@@ -167,9 +167,9 @@ angular.module('QuepidApp')
         var alert;
         for (i = 1; i < lines.length; i++) {
           var line = lines[i];
-          if (line && line.split(ctrl.csv.separator).length !== 3){
+          if (line && line.split(ctrl.csv.separator).length > 3){
             if (alert === undefined){
-              alert = 'Must have three columns for every line in CSV file: ';
+              alert = 'Must have three (or fewer) columns for every line in CSV file: ';
               alert += '<br /><strong>';
             }
             alert += 'line ' + (i + 1) + ': ';

--- a/app/controllers/api/v1/import/ratings_controller.rb
+++ b/app/controllers/api/v1/import/ratings_controller.rb
@@ -21,15 +21,24 @@ module Api
             rre_json = JSON.parse(params[:rre_json])
             rre_json['queries'].each do |rre_query|
               query_text = rre_query['placeholders']['$query']
-              rre_query['relevant_documents'].each do |rating_value, doc_ids|
-                doc_ids.each do |doc_id|
-                  rating = {
-                    query_text: query_text,
-                    doc_id:     doc_id,
-                    rating:     rating_value,
-                  }
-                  ratings << rating
+              if rre_query['relevant_documents'] # deal with if a query had no rated docs.
+                rre_query['relevant_documents'].each do |rating_value, doc_ids|
+                  doc_ids.each do |doc_id|
+                    rating = {
+                      query_text: query_text,
+                      doc_id:     doc_id,
+                      rating:     rating_value,
+                    }
+                    ratings << rating
+                  end
                 end
+              else
+                rating = {
+                  query_text: query_text,
+                  doc_id:     nil,
+                  rating:     nil,
+                }
+                ratings << rating
               end
             end
           elsif 'ltr' == file_format

--- a/app/controllers/api/v1/import/ratings_controller.rb
+++ b/app/controllers/api/v1/import/ratings_controller.rb
@@ -9,6 +9,7 @@ module Api
 
         # rubocop:disable Metrics/MethodLength
         # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/PerceivedComplexity
         def create
           file_format = params[:file_format]
           file_format = 'hash' unless params[:file_format]
@@ -77,6 +78,7 @@ module Api
           end
           # rubocop:enable Lint/RescueException
         end
+        # rubocop:enable Metrics/PerceivedComplexity
 
         def rating_from_ltr_line ltr_line
           # Pattern: 3 qid:1 # 1370 star trek

--- a/app/services/ratings_importer.rb
+++ b/app/services/ratings_importer.rb
@@ -33,6 +33,7 @@ class RatingsImporter
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/CyclomaticComplexity
   def import
     if @options[:clear_existing]
       print_step 'Clearing all ratings'
@@ -108,7 +109,7 @@ class RatingsImporter
       doc_id      = row[:doc_id]
       rating      = row[:rating]
 
-      unless doc_id.blank? # filter out creating ratings where we have no document
+      if doc_id.present? # filter out creating ratings where we have no document
         print_step "Importing rating: #{rating} for query: #{query_text} and doc: #{doc_id}"
 
         query   = @queries[query_text]
@@ -142,6 +143,7 @@ class RatingsImporter
   # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private
 

--- a/app/services/ratings_importer.rb
+++ b/app/services/ratings_importer.rb
@@ -108,16 +108,18 @@ class RatingsImporter
       doc_id      = row[:doc_id]
       rating      = row[:rating]
 
-      print_step "Importing rating: #{rating} for query: #{query_text} and doc: #{doc_id}"
+      unless doc_id.blank? # filter out creating ratings where we have no document
+        print_step "Importing rating: #{rating} for query: #{query_text} and doc: #{doc_id}"
 
-      query   = @queries[query_text]
-      exists  = query.ratings.where(doc_id: doc_id).first
+        query   = @queries[query_text]
+        exists  = query.ratings.where(doc_id: doc_id).first
 
-      if exists.present? && @options[:force]
-        exists.rating = rating
-        ratings_to_update << exists
-      elsif exists.blank?
-        ratings_to_import << query.ratings.build(doc_id: doc_id, rating: rating)
+        if exists.present? && @options[:force]
+          exists.rating = rating
+          ratings_to_update << exists
+        elsif exists.blank?
+          ratings_to_import << query.ratings.build(doc_id: doc_id, rating: rating)
+        end
       end
     end
 

--- a/app/services/ratings_importer.rb
+++ b/app/services/ratings_importer.rb
@@ -109,7 +109,7 @@ class RatingsImporter
       doc_id      = row[:doc_id]
       rating      = row[:rating]
 
-      if doc_id.present? # filter out creating ratings where we have no document
+      if doc_id.present? and rating.present? # Only create ratings for document and rating pairs, queries are always created.
         print_step "Importing rating: #{rating} for query: #{query_text} and doc: #{doc_id}"
 
         query   = @queries[query_text]

--- a/app/services/ratings_importer.rb
+++ b/app/services/ratings_importer.rb
@@ -109,7 +109,7 @@ class RatingsImporter
       doc_id      = row[:doc_id]
       rating      = row[:rating]
 
-      if doc_id.present? and rating.present? # Only create ratings for document and rating pairs, queries are always created.
+      if doc_id.present? && rating.present? # queries are always created.
         print_step "Importing rating: #{rating} for query: #{query_text} and doc: #{doc_id}"
 
         query   = @queries[query_text]

--- a/app/views/api/v1/export/ratings/show.basic.csv.erb
+++ b/app/views/api/v1/export/ratings/show.basic.csv.erb
@@ -3,7 +3,11 @@ headers = ['query','docid','rating']
 %>
 <%= ::CSV.generate_line(headers).html_safe %><%
 @case.queries.each do |query|
-  query.ratings.each do |rating|
+  if query.ratings.empty?
+%><%= ::CSV.generate_line([make_csv_safe(query.query_text)]).html_safe %><%
+  else
+    query.ratings.each do |rating|
 %><%= ::CSV.generate_line([make_csv_safe(query.query_text),rating.doc_id, rating.rating]).html_safe %><%
+    end
   end
 end %>

--- a/app/views/api/v1/export/ratings/show.basic_snapshot.csv.erb
+++ b/app/views/api/v1/export/ratings/show.basic_snapshot.csv.erb
@@ -3,6 +3,9 @@ headers = ['query','docid','rating']
 %>
 <%= ::CSV.generate_line(headers).html_safe %><%
 @snapshot.snapshot_queries.each do |snapshot_query|
+  if snapshot_query.ratings.empty?
+%><%= ::CSV.generate_line([make_csv_safe(snapshot_query.query.query_text)]).html_safe %><%  
+  else
   snapshot_query.snapshot_docs.each do |snapshot_doc|
     rating = Rating.find_by_query_id_and_doc_id(snapshot_query.query.id,snapshot_doc.doc_id)
 %><%= ::CSV.generate_line([make_csv_safe(snapshot_query.query.query_text), snapshot_doc.doc_id, rating.nil? ? nil : rating.rating]).html_safe %><%

--- a/app/views/api/v1/export/ratings/show.basic_snapshot.csv.erb
+++ b/app/views/api/v1/export/ratings/show.basic_snapshot.csv.erb
@@ -3,11 +3,12 @@ headers = ['query','docid','rating']
 %>
 <%= ::CSV.generate_line(headers).html_safe %><%
 @snapshot.snapshot_queries.each do |snapshot_query|
-  if snapshot_query.ratings.empty?
-%><%= ::CSV.generate_line([make_csv_safe(snapshot_query.query.query_text)]).html_safe %><%  
+  if snapshot_query.snapshot_docs.empty?
+%><%= ::CSV.generate_line([make_csv_safe(snapshot_query.query.query_text)]).html_safe %><%
   else
   snapshot_query.snapshot_docs.each do |snapshot_doc|
     rating = Rating.find_by_query_id_and_doc_id(snapshot_query.query.id,snapshot_doc.doc_id)
 %><%= ::CSV.generate_line([make_csv_safe(snapshot_query.query.query_text), snapshot_doc.doc_id, rating.nil? ? nil : rating.rating]).html_safe %><%
+    end
   end
 end %>

--- a/test/controllers/api/v1/export/ratings_controller_test.rb
+++ b/test/controllers/api/v1/export/ratings_controller_test.rb
@@ -70,16 +70,14 @@ module Api
             the_case.queries << query
             the_case.save!
 
-
             get :show, case_id: the_case.id, format: :csv, file_format: 'basic'
             assert_response :ok
             csv = CSV.parse(response.body, headers: true)
 
-            assert_equal csv[0]['query'],                               " =cmd" # notice dealing with command injection vulnerability
             assert_nil csv[0]['rating']
+            assert_equal csv[0]['query'],                               ' =cmd' # notice dealing with command injection vulnerability
             assert_equal csv[1]['query'],                               the_case.queries[0].query_text
             assert_equal csv[1]['rating'],                              the_case.queries[0].ratings[0].rating.to_s
-
           end
         end
 

--- a/test/controllers/api/v1/export/ratings_controller_test.rb
+++ b/test/controllers/api/v1/export/ratings_controller_test.rb
@@ -38,6 +38,11 @@ module Api
           let(:the_case) { cases(:one) }
 
           test 'returns case info' do
+            # add a query with no docs or ratings
+            query = Query.new query_text: '=cmd', case_id: the_case.id
+            the_case.queries << query
+            the_case.save!
+
             get :show, case_id: the_case.id, file_format: 'rre'
             assert_response :ok
 
@@ -47,6 +52,8 @@ module Api
             assert_equal body['index'],                                 the_case.tries.latest.index_name_from_search_url
             assert_equal body['queries'].size,                          the_case.queries.size
             assert_equal body['queries'][0]['placeholders']['$query'],  the_case.queries[0].query_text
+            assert_equal body['queries'][2]['placeholders']['$query'],  the_case.queries[2].query_text
+            assert_nil body['queries'][2]['relevant_documents']
           end
         end
 
@@ -54,17 +61,25 @@ module Api
           let(:the_case) { cases(:one) }
 
           test 'returns case w/ queries and ratings info' do
-            # fixme, there must be a better approach.  We need a case with ratings to make this work
-            @rating = the_case.queries[0].ratings.find_or_create_by doc_id: '999a'
-            @rating.rating = 99
-            @rating.save!
+            rating = the_case.queries[0].ratings.find_or_create_by doc_id: '999a'
+            rating.rating = 99
+            rating.save!
+
+            # add a query with no docs or ratings
+            query = Query.new query_text: '=cmd', case_id: the_case.id
+            the_case.queries << query
+            the_case.save!
+
 
             get :show, case_id: the_case.id, format: :csv, file_format: 'basic'
             assert_response :ok
             csv = CSV.parse(response.body, headers: true)
 
-            assert_equal csv[0]['query'],                               the_case.queries[0].query_text
-            assert_equal csv[0]['rating'],                              the_case.queries[0].ratings[0].rating.to_s
+            assert_equal csv[0]['query'],                               " =cmd" # notice dealing with command injection vulnerability
+            assert_nil csv[0]['rating']
+            assert_equal csv[1]['query'],                               the_case.queries[0].query_text
+            assert_equal csv[1]['rating'],                              the_case.queries[0].ratings[0].rating.to_s
+
           end
         end
 

--- a/test/controllers/api/v1/export/ratings_controller_test.rb
+++ b/test/controllers/api/v1/export/ratings_controller_test.rb
@@ -75,7 +75,7 @@ module Api
             csv = CSV.parse(response.body, headers: true)
 
             assert_nil csv[0]['rating']
-            assert_equal csv[0]['query'],                               ' =cmd' # notice dealing with command injection vulnerability
+            assert_equal csv[0]['query'],                               ' =cmd' # notice csv injection vulnerability
             assert_equal csv[1]['query'],                               the_case.queries[0].query_text
             assert_equal csv[1]['rating'],                              the_case.queries[0].ratings[0].rating.to_s
           end

--- a/test/services/ratings_importer_test.rb
+++ b/test/services/ratings_importer_test.rb
@@ -50,5 +50,30 @@ class RatingsImporterTest < ActiveSupport::TestCase
       assert_not_nil(rating)
       assert_equal 'Mexican Food', rating.query.query_text
     end
+
+    test 'includes queries with no ratings and no docs' do
+      ratings = [
+        { query_text: 'Mexican Food', doc_id: '720784-021190', rating: '5' },
+        { query_text: 'Mexican Food', doc_id: '', rating: '' },
+        { query_text: 'Chinese Food', doc_id: nil, rating: nil }
+      ]
+
+      assert_empty(owned_case.queries)
+
+      ratings_importer = RatingsImporter.new owned_case, ratings, options
+      ratings_importer.import
+      rating = Rating.find_by(doc_id: '720784-021190')
+
+      assert_not_nil(rating)
+      assert_equal 'Mexican Food', rating.query.query_text
+
+      assert_equal 2, owned_case.queries.size
+      query = Query.find_by(case_id: owned_case.id, query_text: 'Chinese Food')
+      assert_empty (query.ratings)
+
+      query = Query.find_by(case_id: owned_case.id, query_text: 'Mexican Food')
+      assert_equal 1, query.ratings.size
+
+    end
   end
 end

--- a/test/services/ratings_importer_test.rb
+++ b/test/services/ratings_importer_test.rb
@@ -58,22 +58,21 @@ class RatingsImporterTest < ActiveSupport::TestCase
         { query_text: 'Chinese Food', doc_id: nil, rating: nil }
       ]
 
-      assert_empty(owned_case.queries)
+      assert_empty owned_case.queries
 
       ratings_importer = RatingsImporter.new owned_case, ratings, options
       ratings_importer.import
       rating = Rating.find_by(doc_id: '720784-021190')
 
-      assert_not_nil(rating)
+      assert_not_nil rating
       assert_equal 'Mexican Food', rating.query.query_text
 
       assert_equal 2, owned_case.queries.size
       query = Query.find_by(case_id: owned_case.id, query_text: 'Chinese Food')
-      assert_empty (query.ratings)
+      assert_empty query.ratings
 
       query = Query.find_by(case_id: owned_case.id, query_text: 'Mexican Food')
       assert_equal 1, query.ratings.size
-
     end
   end
 end

--- a/test/services/ratings_importer_test.rb
+++ b/test/services/ratings_importer_test.rb
@@ -28,7 +28,7 @@ class RatingsImporterTest < ActiveSupport::TestCase
       assert_equal 'Mexican Food', rating.query.query_text
     end
 
-    test 'includes queries with no ratings' do
+    test 'includes queries with no ratings as queries but no ratings' do
       ratings = [
         { query_text: 'Mexican Food', doc_id: '720784-021190', rating: '5' },
         { query_text: 'Mexican Food', doc_id: '843075-031090', rating: '' },
@@ -37,21 +37,21 @@ class RatingsImporterTest < ActiveSupport::TestCase
 
       ratings_importer = RatingsImporter.new owned_case, ratings, options
       ratings_importer.import
-      rating = Rating.find_by(doc_id: '843075-031090')
 
-      assert_not_nil(rating)
+      rating = Rating.find_by(doc_id: '720784-021190')
+      assert_not_nil rating
       assert_equal 'Mexican Food', rating.query.query_text
 
       rating = Rating.find_by(doc_id: '843075-031090')
-      assert_not_nil(rating)
-      assert_equal 'Mexican Food', rating.query.query_text
-
+      assert_nil rating
       rating = Rating.find_by(doc_id: '748785-005680')
-      assert_not_nil(rating)
-      assert_equal 'Mexican Food', rating.query.query_text
+      assert_nil rating
+      query = Query.find_by(case_id: owned_case.id, query_text: 'Mexican Food')
+      assert_not_nil query
+
     end
 
-    test 'includes queries with no ratings and no docs' do
+    test 'includes queries with no ratings and no docs as queries but no ratings' do
       ratings = [
         { query_text: 'Mexican Food', doc_id: '720784-021190', rating: '5' },
         { query_text: 'Mexican Food', doc_id: '', rating: '' },
@@ -74,5 +74,23 @@ class RatingsImporterTest < ActiveSupport::TestCase
       query = Query.find_by(case_id: owned_case.id, query_text: 'Mexican Food')
       assert_equal 1, query.ratings.size
     end
+  end
+
+  test 'handles when a doc id does not exist in our index, it is still inserted' do
+    ratings = [
+      { query_text: 'Swedish Food',   doc_id: ' 720784-021190', rating: nil },
+      { query_text: 'Swedish Food',   doc_id: 'NON_EXISTANT_DOC_ID', rating: '6' },
+
+    ]
+
+    ratings_importer = RatingsImporter.new owned_case, ratings, options
+    ratings_importer.import
+    rating = Rating.find_by(doc_id: '720784-021190')
+    assert_nil(rating)
+
+    rating = Rating.find_by(doc_id: 'NON_EXISTANT_DOC_ID')
+    assert_not_nil(rating)
+    assert_equal 'Swedish Food', rating.query.query_text
+
   end
 end

--- a/test/services/ratings_importer_test.rb
+++ b/test/services/ratings_importer_test.rb
@@ -48,7 +48,6 @@ class RatingsImporterTest < ActiveSupport::TestCase
       assert_nil rating
       query = Query.find_by(case_id: owned_case.id, query_text: 'Mexican Food')
       assert_not_nil query
-
     end
 
     test 'includes queries with no ratings and no docs as queries but no ratings' do
@@ -79,8 +78,7 @@ class RatingsImporterTest < ActiveSupport::TestCase
   test 'handles when a doc id does not exist in our index, it is still inserted' do
     ratings = [
       { query_text: 'Swedish Food',   doc_id: ' 720784-021190', rating: nil },
-      { query_text: 'Swedish Food',   doc_id: 'NON_EXISTANT_DOC_ID', rating: '6' },
-
+      { query_text: 'Swedish Food',   doc_id: 'NON_EXISTANT_DOC_ID', rating: '6' }
     ]
 
     ratings_importer = RatingsImporter.new owned_case, ratings, options
@@ -91,6 +89,5 @@ class RatingsImporterTest < ActiveSupport::TestCase
     rating = Rating.find_by(doc_id: 'NON_EXISTANT_DOC_ID')
     assert_not_nil(rating)
     assert_equal 'Swedish Food', rating.query.query_text
-
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
turns out that the import export cycle is a bit fragile.  Lets make it more robust, and only create ratings in our db if we have both doc and rating pairs.  We also used to not create queries that didn't have docs or rating, and now we proeprly do.  plus we properly export empty queries.

## Motivation and Context
Solves #244 hopefully, though we don't have a smoking gun to prove it!

## How Has This Been Tested?
unit tests and manually

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
