### PR TITLE
Added functionality to send mails over SMTP and start with an operating documentation (#275)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# Learn more about these settings at https://github.com/o19s/quepid/tree/master/docs/operating_documentation.md
+
 PORT=3000
 
 RACK_ENV=development
@@ -37,3 +39,6 @@ SIGNUP_ENABLED=true
 
 # Whether users are only allowed to use communal (admin controlled) scorers to prevent javascript embedding security issues
 COMMUNAL_SCORERS_ONLY=false
+
+# What provider to use to send emails
+EMAIL_PROVIDER=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Invite your friends to join your team on Quepid!  You can now send an email with an invite code to join Quepid and your specific team.   https://github.com/o19s/quepid/pull/259 by @epugh.
 
+* Add support for sending emails via SMTP, or use Postmark, or don't send emails.  https://github.com/o19s/quepid/pull/276 by @gabaur fixes https://github.com/o19s/quepid/issues/275.
+
 ### Improvements
 
 * Upgrade to Rails 5 and Ruby 2.7.2!   We have been stuck on Rails 4.2 for years, and this unlocks a lot of new capabilities.  https://github.com/o19s/quepid/pull/256 by @epugh with inspiration from @worleydl.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Below is information related to developing the Quepid open source project, prima
   - [Seed Data](#seed-data)
 - [Data Map](#data-map)
 - [App Structure](#app-structure)
-- [Legal Pages](#legal-pages)
+- [Operating Documentation](#operating-documentation)
 - [Credits](#credits)
 
 <!-- /MarkdownTOC -->
@@ -495,22 +495,9 @@ Check out the [Data Mapping](docs/data_mapping.md) file for more info about the 
 
 Check out the [App Structure](docs/app_structure.md) file for more info on how Quepid is structured.
 
-# Legal Pages & GDPR
+# Operating Documentation
 
-If you would like to have legal pages linked in the footer of the app, similar to behavior on http://app.quepid.com,
-add the following `ENV` vars:
-
-```
-TC_URL      # terms and condition
-PRIVACY_URL # privacy policy
-COOKIES_URL # cookies policy
-```
-
-To comply with GDPR, and be a good citizen, the hosted version of Quepid asks if they are willing to receive Quepid related updates via email.  This feature isn't useful to private installs, so this controls the display.
-
-```
-EMAIL_MARKETING_MODE=true   # Enables a checkbox on user signup to consent to emails
-```
+Check out the [Operating Documentation](docs/operating_documentation.md) file for more informations how Quepid can be operated and configured for your company.
 
 # Thank You's
 

--- a/app.json
+++ b/app.json
@@ -69,6 +69,9 @@
     },
     "QUEPID_DEFAULT_SCORER": {
       "required": true
+    },
+    "EMAIL_PROVIDER": {
+      "required": true
     }
   },
   "formation": {

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,10 +20,7 @@ module Quepid
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
-    config.action_mailer.delivery_method    = :postmark
-    config.action_mailer.postmark_settings  = {
-      api_token: ENV['POSTMARK_API_TOKEN'],
-    }
+
 
     config.angular_templates.ignore_prefix = %w[templates/ components/]
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,6 @@ module Quepid
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
-
     config.angular_templates.ignore_prefix = %w[templates/ components/]
 
     config.active_job.queue_adapter = :sidekiq

--- a/config/initializers/customize_quepid.rb
+++ b/config/initializers/customize_quepid.rb
@@ -57,4 +57,4 @@ Rails.application.config.communal_scorers_only = bool.deserialize(ENV.fetch('COM
 # You can send emails to users using either the Postmark Saas service by setting this to POSTMARK, or
 # you can send using traditional SMTP server by setting this to SMTP.  Leave it blank and there is
 # no email provider.
-Rails.application.config.email_provider = ENV.fetch('EMAIL_PROVIDER', nil)
+Rails.application.config.email_provider = ENV.fetch('EMAIL_PROVIDER', "")

--- a/config/initializers/customize_quepid.rb
+++ b/config/initializers/customize_quepid.rb
@@ -57,4 +57,4 @@ Rails.application.config.communal_scorers_only = bool.deserialize(ENV.fetch('COM
 # You can send emails to users using either the Postmark Saas service by setting this to POSTMARK, or
 # you can send using traditional SMTP server by setting this to SMTP.  Leave it blank and there is
 # no email provider.
-Rails.application.config.email_provider = ENV.fetch('EMAIL_PROVIDER', "")
+Rails.application.config.email_provider = ENV.fetch('EMAIL_PROVIDER', '')

--- a/config/initializers/customize_quepid.rb
+++ b/config/initializers/customize_quepid.rb
@@ -52,3 +52,9 @@ Rails.application.config.signup_enabled = bool.deserialize(ENV.fetch('SIGNUP_ENA
 # communal scorers only, which are controlled by admins.
 #
 Rails.application.config.communal_scorers_only = bool.deserialize(ENV.fetch('COMMUNAL_SCORERS_ONLY', false))
+
+# == What Email Provider to Use
+# You can send emails to users using either the Postmark Saas service by setting this to POSTMARK, or
+# you can send using traditional SMTP server by setting this to SMTP.  Leave it blank and there is
+# no email provider.
+Rails.application.config.email_provider = ENV.fetch('EMAIL_PROVIDER', nil)

--- a/config/initializers/email_provider.rb
+++ b/config/initializers/email_provider.rb
@@ -14,7 +14,7 @@ if Rails.application.config.email_provider.casecmp?('smtp')
   }
 elsif Rails.application.config.email_provider.casecmp?('postmark')
   Rails.application.config.action_mailer.delivery_method = :postmark
-  Rails.application.config.action_mailer.postmark_settings  = {
+  Rails.application.config.action_mailer.postmark_settings = {
     api_token: ENV['POSTMARK_API_TOKEN'],
   }
 

--- a/config/initializers/email_provider.rb
+++ b/config/initializers/email_provider.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Make mail sending possible over smtp and configurable via env vars.
-if ENV['MAIL_METHOD'].present? && 'smtp'.casecmp(ENV['MAIL_METHOD']).zero?
+# Make email sending possible over smtp and configurable via env vars.
+if Rails.application.config.email_provider.casecmp?('smtp')
   Rails.application.config.action_mailer.delivery_method = :smtp
   Rails.application.config.action_mailer.smtp_settings = {
     address:              ENV['SMTP_HOST'],
@@ -12,4 +12,10 @@ if ENV['MAIL_METHOD'].present? && 'smtp'.casecmp(ENV['MAIL_METHOD']).zero?
     authentication:       ENV['SMTP_AUTHENTICATION_TYPE'],
     enable_starttls_auto: ENV['SMTP_ENABLE_STARTTLS'],
   }
+elsif Rails.application.config.email_provider.casecmp?('postmark')
+  Rails.application.config.action_mailer.delivery_method = :postmark
+  Rails.application.config.action_mailer.postmark_settings  = {
+    api_token: ENV['POSTMARK_API_TOKEN'],
+  }
+
 end

--- a/config/initializers/smtp_mail_provider.rb
+++ b/config/initializers/smtp_mail_provider.rb
@@ -1,0 +1,13 @@
+# Make mail sending possible over smtp and configurable via env vars.
+if ENV['MAIL_METHOD'].present? && ENV['MAIL_METHOD'] === "smtp"
+  Rails.application.config.action_mailer.delivery_method = :smtp
+  Rails.application.config.action_mailer.smtp_settings = {
+    address:              ENV['SMTP_HOST'],
+    port:                 ENV['SMTP_PORT'],
+    domain:               ENV['MAIL_DOMAIN'],
+    user_name:            ENV['SMTP_USERNAME'],
+    password:             ENV['SMTP_PASSWORD'],
+    authentication:       ENV['SMTP_AUTHENTICATION_TYPE'],
+    enable_starttls_auto: ENV['SMTP_ENABLE_STARTTLS']
+  }
+end

--- a/config/initializers/smtp_mail_provider.rb
+++ b/config/initializers/smtp_mail_provider.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 # Make mail sending possible over smtp and configurable via env vars.
-if ENV['MAIL_METHOD'].present? && ENV['MAIL_METHOD'] === "smtp"
+if ENV['MAIL_METHOD'].present? && 'smtp'.casecmp(ENV['MAIL_METHOD']).zero?
   Rails.application.config.action_mailer.delivery_method = :smtp
   Rails.application.config.action_mailer.smtp_settings = {
     address:              ENV['SMTP_HOST'],
@@ -8,6 +10,6 @@ if ENV['MAIL_METHOD'].present? && ENV['MAIL_METHOD'] === "smtp"
     user_name:            ENV['SMTP_USERNAME'],
     password:             ENV['SMTP_PASSWORD'],
     authentication:       ENV['SMTP_AUTHENTICATION_TYPE'],
-    enable_starttls_auto: ENV['SMTP_ENABLE_STARTTLS']
+    enable_starttls_auto: ENV['SMTP_ENABLE_STARTTLS'],
   }
 end

--- a/docs/operating_documentation.md
+++ b/docs/operating_documentation.md
@@ -1,0 +1,62 @@
+# Operating Documentation
+
+This document explains how Quepid can be operated and configured.
+
+# Table of Contents
+
+- [Mail](#mail)
+  - [I. Postmark](#postmark)
+  - [II. SMTP](#smtp)
+- [Legal Pages & GDPR](#legal-pages-&-gdpr)
+
+# Mail
+
+Quepid have to send E-Mails for several reasons, for example for the password reset, or if the `EMAIL_MARKETING_MODE` is enabled. Therefore Quepid has two options to use:
+
+- [Postmark](#postmark) ([https://postmarkapp.com/](https://postmarkapp.com/)) (default)
+- [SMTP](#smtp)
+
+The behavior which option should used, can be controlled by the following `ENV` var:
+```
+MAIL_METHOD  # set to "smtp" to use SMTP or do not set to use Postmark
+```
+
+## Postmark
+
+If you want to use Postmark as your mail delivery service, you have to tell Quepid your [Server API Token](https://postmarkapp.com/support/article/1008-what-are-the-account-and-server-api-tokens). This can be done by setting the following `ENV` var:
+
+```
+POSTMARK_API_TOKEN=XXXXXXXXXXXX  # Your Postmark Server API Token
+```
+
+## SMTP
+
+If you want to use STMP for sending mails, you have to set the `MAIL_METHOD` to `smtp` and set the following `ENV` vars to describe the connection to the smtp sever:
+
+```
+SMTP_HOST                    # smtp server to use for sending
+SMTP_PORT                    # smtp port to use for connection
+MAIL_DOMAIN                  # If you need to specify a HELO domain, you can do set it here
+SMTP_USERNAME                # If your mail server requires authentication, set the username in this setting
+SMTP_PASSWORD                # If your mail server requires authentication, set the password in this setting
+SMTP_AUTHENTICATION_TYPE     # If your mail server requires authentication, you need to specify the authentication type here (plain, login, cram_md5)
+SMTP_ENABLE_STARTTLS         # If STARTTLS is enabled in your server set to true
+```
+
+
+# Legal Pages & GDPR
+
+If you would like to have legal pages linked in the footer of the app, similar to behavior on http://app.quepid.com,
+add the following `ENV` vars:
+
+```
+TC_URL      # terms and condition
+PRIVACY_URL # privacy policy
+COOKIES_URL # cookies policy
+```
+
+To comply with GDPR, and be a good citizen, the hosted version of Quepid asks if they are willing to receive Quepid related updates via email.  This feature isn't useful to private installs, so this controls the display.
+
+```
+EMAIL_MARKETING_MODE=true   # Enables a checkbox on user signup to consent to emails
+```

--- a/docs/operating_documentation.md
+++ b/docs/operating_documentation.md
@@ -11,19 +11,20 @@ This document explains how Quepid can be operated and configured.
 
 # Mail
 
-Quepid have to send E-Mails for several reasons, for example for the password reset, or if the `EMAIL_MARKETING_MODE` is enabled. Therefore Quepid has two options to use:
+Quepid has to send E-Mails for several reasons, for example for the password reset function or to invite a new user.
+Therefore Quepid has two options to use:
 
 - [Postmark](#postmark) ([https://postmarkapp.com/](https://postmarkapp.com/)) (default)
 - [SMTP](#smtp)
 
 The behavior which option should used, can be controlled by the following `ENV` var:
 ```
-MAIL_METHOD  # set to "smtp" to use SMTP or do not set to use Postmark
+EMAIL_PROVIDER  # set to "smtp" to use SMTP, "postmark" to use Postmark, or blank to disable sending emails.
 ```
 
 ## Postmark
 
-If you want to use Postmark as your mail delivery service, you have to tell Quepid your [Server API Token](https://postmarkapp.com/support/article/1008-what-are-the-account-and-server-api-tokens). This can be done by setting the following `ENV` var:
+If you want to use Postmark as your mail delivery service, you have to set the `EMAIL_PROVIDER` to `postmark` and you have to tell Quepid your [Server API Token](https://postmarkapp.com/support/article/1008-what-are-the-account-and-server-api-tokens). This can be done by setting the following `ENV` var:
 
 ```
 POSTMARK_API_TOKEN=XXXXXXXXXXXX  # Your Postmark Server API Token
@@ -31,7 +32,7 @@ POSTMARK_API_TOKEN=XXXXXXXXXXXX  # Your Postmark Server API Token
 
 ## SMTP
 
-If you want to use STMP for sending mails, you have to set the `MAIL_METHOD` to `smtp` and set the following `ENV` vars to describe the connection to the smtp sever:
+If you want to use STMP for sending mails, you have to set the `EMAIL_PROVIDER` to `smtp` and set the following `ENV` vars to describe the connection to the smtp sever:
 
 ```
 SMTP_HOST                    # smtp server to use for sending


### PR DESCRIPTION
## Description
I added a smtp_mail_provider.rb under `config/initializers`, which checks if the env var `MAIL_METHOD` is set and contains the string "smtp". If this is true, the `Rails.application.config.action_mailer.delivery_method` is overwritten to use smtp for sending mails. Further the following env vars are also added for the smtp settings:

- SMTP_HOST => smtp server to use for sending
- SMTP_PORT =>  smtp port to use for connection
- MAIL_DOMAIN => If you need to specify a HELO domain, you can do set it here
- SMTP_USERNAME => If your mail server requires authentication, set the username in this setting
- SMTP_PASSWORD =>  If your mail server requires authentication, set the password in this setting
- SMTP_AUTHENTICATION_TYPE => If your mail server requires authentication, you need to specify the authentication type here (plain, login, cram_md5)
- SMTP_ENABLE_STARTTLS =>If STARTTLS is enabled in your server set to true

I also added the documentation for this feature. Because there is no really operating documentation, I decided to put one under `docs/operating_documentation.md` and moved the other operating stuff I found in the `README.md` to there.

## Motivation and Context
There are two changes of my POV:

1. Added functionality to send mails over SMTP
This was done because of the issue [here](https://github.com/o19s/quepid/issues/275)

2. Started operating documentation
**Motivation:**
My motivation for this was that an operating documentation did not exists and I planned to extend this documentation in the future (adding how to handle SSL, adding k8s deployment files). In my POV this makes sense because members of search teams mostly don't want to run their own Quepid instance on their machines instead of that they wanted to work as team on one Quepid instance (which is already well supported in Quepid). This central Quepid instance must be operated, which should be made as simple as possible.
**Why this change is required:**
This change is required because of the fact, that in the most companies outside there the department which should run Quepid is not the same as the department which is optimizing the search. In many cases, missing documentation on how to operate Quepid can be a blocker or slow down the process, and we want to see Quepid widespread ;)

## How Has This Been Tested?

- I ran all existing tests.
- I build the Docker image locally and configured SMTP over the new env vars and let send me a password reset mail, which worked.

## Types of changes
- [] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [X] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
