### PR TITLE
Another strong params issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
 
 * Thanks to @DmitryKey for spotting that we were not tracking scorers for cases (bug introduced when we added the Show Only Ratings feature).  https://github.com/o19s/quepid/pull/303 by @epugh and @worleydl fixes both https://github.com/o19s/quepid/issues/306 AND https://github.com/o19s/quepid/issues/289.  A twofer!
 
+* Thanks to @DmitryKey for spotting that we were not properly storing the Elasticsearch choice.  https://github.com/o19s/quepid/pull/310 by @epugh fixes https://github.com/o19s/quepid/issues/309.
+
 ## 6.4.1 - 2021-01-14
 
 In the 6.4.0 release, the correct splainer-search NPM package was missed in the production Docker image.

--- a/app/controllers/api/v1/clone/tries_controller.rb
+++ b/app/controllers/api/v1/clone/tries_controller.rb
@@ -45,10 +45,6 @@ module Api
           render json: { message: 'Try not found!' }, status: :not_found unless @try
         end
 
-        def update_try_params
-          params.require(:try).permit(:name)
-        end
-
         def try_params
           params.require(:try).permit(
             :name,

--- a/app/controllers/api/v1/tries_controller.rb
+++ b/app/controllers/api/v1/tries_controller.rb
@@ -35,7 +35,7 @@ module Api
       end
 
       def update
-        if @try.update update_try_params
+        if @try.update try_params
           respond_with @try
         else
           render json: @try.errors, status: :bad_request
@@ -54,10 +54,6 @@ module Api
         @try = @case.tries.where(try_number: params[:try_number]).first
 
         render json: { message: 'Try not found!' }, status: :not_found unless @try
-      end
-
-      def update_try_params
-        params.require(:try).permit( :name )
       end
 
       def try_params

--- a/test/controllers/api/v1/tries_controller_test.rb
+++ b/test/controllers/api/v1/tries_controller_test.rb
@@ -138,7 +138,7 @@ module Api
           assert_equal the_try['name'], 'New Name'
         end
 
-        test 'does nothing with params passed except name' do
+        test 'can change other parameters too' do
           old_no = the_try.try_number
           put :update, params: { case_id: the_case.id, try_number: the_try.try_number, try: { query_params: 'New No' } }
 
@@ -154,7 +154,7 @@ module Api
           assert_response :ok
 
           the_try.reload
-          assert_not_equal the_try.field_spec, 'New field_spec'
+          assert_equal the_try.field_spec, 'New field_spec'
         end
       end
 


### PR DESCRIPTION
turns out the old update_try_params being seperate was old school, and so refactor.  fixes another Rails 5 issue.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes #309 

## Motivation and Context
More rails 5 strong parameter fall out.

## How Has This Been Tested?


## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
