### PR TITLE
Allow team members to copy and send the invite link (outside of email).  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Uglifier for JavaScript appears to not work with ES6, and so using [Terser](https://github.com/ahorek/terser-ruby) instead.  https://github.com/o19s/quepid/pull/329 by @epugh fixes this.
 
+* Add to the Team page the ability to copy the team invitation url to send via other means then Quepid's own email setup.  This is helpful if you don't have email set up, or if you want to share invites with team members via chat tools like Slack.  Also fixed the user flow of registering after someone has sent out an invite for someone.  https://github.com/o19s/quepid/pull/337 by @epugh fixes https://github.com/o19s/quepid/issues/335 and https://github.com/o19s/quepid/issues/326.
+
 ## 6.5.0 - 2021-04-22
 
 ![favicon](https://raw.githubusercontent.com/o19s/quepid/master/app/assets/images/favicon.ico)

--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -20,5 +20,6 @@ angular.module('QuepidApp', [
   'ng-rails-csrf',
   'templates',
   'ngAnimate',
-  'countUp'
+  'countUp',
+  'ngclipboard'
 ]);

--- a/app/assets/javascripts/components/user_listing/user_listing.html
+++ b/app/assets/javascripts/components/user_listing/user_listing.html
@@ -23,7 +23,6 @@
           alt="Accept invite url"
         ></i>
       </a>
-      <span uib-tooltip="Hello!" tooltip-is-open="tooltipIsOpen" tooltip-placement="bottom"></span>
     </span>
 
     <span class="item-actions">

--- a/app/assets/javascripts/components/user_listing/user_listing.html
+++ b/app/assets/javascripts/components/user_listing/user_listing.html
@@ -19,8 +19,8 @@
         <i
           class="glyphicon glyphicon-copy"
           aria-hidden="true"
-          title="Accept invite url"
-          alt="Accept invite url"
+          title="Copy invite url to your clipboard"
+          alt="Copy invite url to your clipboard"
         ></i>
       </a>
     </span>

--- a/app/assets/javascripts/components/user_listing/user_listing.html
+++ b/app/assets/javascripts/components/user_listing/user_listing.html
@@ -14,7 +14,17 @@
 
     {{ ctrl.user.email }}
 
-    <span class="text-muted" ng-if="ctrl.user.pending_invite"> Pending Invitation </span>
+    <span class="text-muted" ng-if="ctrl.user.pending_invite"> Awaiting response to invitation
+      <a class="action-icon" ng-if="ctrl.user.pending_invite" ngclipboard ngclipboard-success="ctrl.confirmCopy()" data-clipboard-text="http://localhost:3000/user/invite/34234234">
+        <i
+          class="glyphicon glyphicon-copy"
+          aria-hidden="true"
+          title="Accept invite url"
+          alt="Accept invite url"
+        ></i>
+      </a>
+      <span uib-tooltip="Hello!" tooltip-is-open="tooltipIsOpen" tooltip-placement="bottom"></span>
+    </span>
 
     <span class="item-actions">
       <remove-member this-member="ctrl.user" this-team="ctrl.team"></remove-member>

--- a/app/assets/javascripts/components/user_listing/user_listing.html
+++ b/app/assets/javascripts/components/user_listing/user_listing.html
@@ -15,7 +15,7 @@
     {{ ctrl.user.email }}
 
     <span class="text-muted" ng-if="ctrl.user.pending_invite"> Awaiting response to invitation
-      <a class="action-icon" ng-if="ctrl.user.pending_invite" ngclipboard ngclipboard-success="ctrl.confirmCopy()" data-clipboard-text="http://localhost:3000/user/invite/34234234">
+      <a class="action-icon" ng-if="ctrl.user.pending_invite" ngclipboard ngclipboard-success="ctrl.confirmCopy()" data-clipboard-text="{{ctrl.user.invite_url}}">
         <i
           class="glyphicon glyphicon-copy"
           aria-hidden="true"

--- a/app/assets/javascripts/components/user_listing/user_listing_controller.js
+++ b/app/assets/javascripts/components/user_listing/user_listing_controller.js
@@ -5,11 +5,16 @@
 angular.module('QuepidApp')
   .controller('UserListingCtrl', [
     '$scope',
-    function ( $scope ) {
+    'flash',
+    function ( $scope, flash ) {
       var ctrl = this;
 
       ctrl.user  = $scope.user;
       ctrl.team  = $scope.team;
+
+      ctrl.confirmCopy = function () {
+        flash.success = "Invite url copied."
+      }
 
     }
   ]);

--- a/app/assets/javascripts/components/user_listing/user_listing_controller.js
+++ b/app/assets/javascripts/components/user_listing/user_listing_controller.js
@@ -13,7 +13,7 @@ angular.module('QuepidApp')
       ctrl.team  = $scope.team;
 
       ctrl.confirmCopy = function () {
-        flash.success = "Invite url copied."
+        flash.success = 'Invite url copied to clipboard.';
       }
 
     }

--- a/app/assets/javascripts/components/user_listing/user_listing_controller.js
+++ b/app/assets/javascripts/components/user_listing/user_listing_controller.js
@@ -14,7 +14,7 @@ angular.module('QuepidApp')
 
       ctrl.confirmCopy = function () {
         flash.success = 'Invite url copied to clipboard.';
-      }
+      };
 
     }
   ]);

--- a/app/assets/javascripts/home.js
+++ b/app/assets/javascripts/home.js
@@ -54,6 +54,8 @@
 //= require angular-flash/dist/angular-flash
 //= require angular-animate/angular-animate
 //= require angular-countup/angular-countup
+//= require clipboard/dist/clipboard
+//= require ngclipboard/dist/ngclipboard
 //= require ng-tags-input/build/ng-tags-input
 //= require FileSaver.js/FileSaver
 //= require urijs/src/URI

--- a/app/controllers/api/v1/signups_controller.rb
+++ b/app/controllers/api/v1/signups_controller.rb
@@ -6,11 +6,23 @@ module Api
       skip_before_action :authenticate_api!
       skip_before_action :verify_authenticity_token
 
+      # rubocop:disable Metrics/MethodLength
       def create
         user_params_to_save = user_params
         # Little workaround for the Angular frontend doing password confirmation on the frontend!
         user_params_to_save[:password_confirmation] = user_params_to_save[:password]
-        @user = User.new user_params_to_save
+
+        # Check if we already have an invite out for this user, and if so let's use that
+        if user_params_to_save[:email].blank?
+          @user = User.new user_params_to_save
+        else
+          @user = User.where(email: user_params_to_save[:email]).where.not(invitation_token: nil).first
+          if @user
+            @user.assign_attributes(user_params_to_save)
+          else
+            @user = User.new user_params_to_save
+          end
+        end
 
         if @user.save
           Analytics::Tracker.track_signup_event @user
@@ -19,6 +31,7 @@ module Api
           render json: @user.errors, status: :bad_request
         end
       end
+      # rubocop:enable Metrics/MethodLength
 
       private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -104,8 +104,6 @@ class User < ApplicationRecord
   before_destroy :check_team_ownership_before_removing!, prepend: true
   before_destroy :check_scorer_ownership_before_removing!, prepend: true
 
-
-
   def check_team_ownership_before_removing!
     owned_teams.each do |team|
       if team.members.count > 1
@@ -145,7 +143,7 @@ class User < ApplicationRecord
   before_invitation_created :store_raw_invitation_token
 
   def store_raw_invitation_token
-    self.stored_raw_invitation_token = self.raw_invitation_token
+    self.stored_raw_invitation_token = raw_invitation_token
   end
   # END devise hacks
 
@@ -210,7 +208,5 @@ class User < ApplicationRecord
 
     self[:agreed_time] = Time.zone.now
   end
-
-
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -104,6 +104,8 @@ class User < ApplicationRecord
   before_destroy :check_team_ownership_before_removing!, prepend: true
   before_destroy :check_scorer_ownership_before_removing!, prepend: true
 
+
+
   def check_team_ownership_before_removing!
     owned_teams.each do |team|
       if team.members.count > 1
@@ -136,6 +138,14 @@ class User < ApplicationRecord
 
   def encrypted_password_changed?
     password_changed?
+  end
+
+  # Because we want to be able to send the acceptance invite later,
+  # store the raw invitation token in our own column for reuse later
+  before_invitation_created :store_raw_invitation_token
+
+  def store_raw_invitation_token
+    self.stored_raw_invitation_token = self.raw_invitation_token
   end
   # END devise hacks
 
@@ -200,5 +210,7 @@ class User < ApplicationRecord
 
     self[:agreed_time] = Time.zone.now
   end
+
+
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,7 @@
 #  updated_at             :datetime         not null
 #  default_scorer_id      :integer
 #  email_marketing        :boolean          not null
+#  stored_raw_invitation_token :string
 #
 
 # rubocop:disable Metrics/ClassLength

--- a/app/views/api/v1/team_members/_member.json.jbuilder
+++ b/app/views/api/v1/team_members/_member.json.jbuilder
@@ -5,3 +5,6 @@ json.display_name   member.display_name
 json.email          member.email
 json.avatar_url     member.avatar_url(:big)
 json.pending_invite member.created_by_invite? && !member.invitation_accepted?
+if member.created_by_invite? && !member.invitation_accepted?
+  json.invite_url accept_invitation_url(member, invitation_token: member.invitation_token)
+end

--- a/app/views/api/v1/team_members/_member.json.jbuilder
+++ b/app/views/api/v1/team_members/_member.json.jbuilder
@@ -6,5 +6,5 @@ json.email          member.email
 json.avatar_url     member.avatar_url(:big)
 json.pending_invite member.created_by_invite? && !member.invitation_accepted?
 if member.created_by_invite? && !member.invitation_accepted?
-  json.invite_url accept_invitation_url(member, invitation_token: member.invitation_token)
+  json.invite_url accept_invitation_url(member, invitation_token: member.stored_raw_invitation_token)
 end

--- a/app/views/api/v1/teams/_team.json.jbuilder
+++ b/app/views/api/v1/teams/_team.json.jbuilder
@@ -11,12 +11,8 @@ json.scorers do
   json.array! team.scorers, partial: 'api/v1/scorers/scorer', as: :scorer
 end
 
-json.members team.members do |member|
-  json.id             member.id
-  json.display_name   member.display_name
-  json.email          member.email
-  json.avatar_url     member.avatar_url(:big)
-  json.pending_invite member.created_by_invite? && !member.invitation_accepted?
+json.members do
+  json.array! team.members, partial: 'api/v1/team_members/member', as: :member
 end
 
 if load_cases

--- a/db/migrate/20210505221952_add_stored_raw_invitation_token_to_user.rb
+++ b/db/migrate/20210505221952_add_stored_raw_invitation_token_to_user.rb
@@ -1,0 +1,5 @@
+class AddStoredRawInvitationTokenToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :stored_raw_invitation_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_30_190122) do
+ActiveRecord::Schema.define(version: 2021_05_05_221952) do
 
   create_table "annotations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "message"
@@ -220,6 +220,7 @@ ActiveRecord::Schema.define(version: 2021_03_30_190122) do
     t.integer "invited_by_id"
     t.integer "invitations_count", default: 0
     t.boolean "completed_case_wizard", default: false, null: false
+    t.string "stored_raw_invitation_token"
     t.index ["default_scorer_id"], name: "index_users_on_default_scorer_id"
     t.index ["email"], name: "ix_user_username", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true, length: 191

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "jquery-ui": "~1.12.1",
     "ng-json-explorer": "http://github.com/odra/ng-json-explorer",
     "ng-tags-input": "3.2.0",
+    "ngclipboard": "^2.0.0",
     "popper.js": "^1.16.1",
     "splainer-search": "^2.6.9",
     "tether-shepherd": "latest"

--- a/test/controllers/api/v1/signups_controller_test.rb
+++ b/test/controllers/api/v1/signups_controller_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 module Api
   module V1
     class SignupsControllerTest < ActionController::TestCase
+      let(:user) { users(:matt) }
       before do
         @controller = Api::V1::SignupsController.new
       end
@@ -30,6 +31,16 @@ module Api
 
           error = JSON.parse(response.body)
           assert_includes error['email'], I18n.t('errors.messages.taken')
+        end
+
+        test 'user with existing invite is allowed to signup using invite user record' do
+          invitee = User.invite!({ email: 'invitee@mail.com', password: '' }, user)
+          assert invitee.created_by_invite?
+
+          data = { user: { email: invitee.email, password: 'password' } }
+
+          post :create, params: data
+          assert_response :ok
         end
 
         test 'returns an error when the password is not present' do

--- a/test/controllers/api/v1/team_members_controller_test.rb
+++ b/test/controllers/api/v1/team_members_controller_test.rb
@@ -84,6 +84,10 @@ module Api
             assert_response :ok
 
             assert json_response['pending_invite']
+
+            user = User.find_by_email(invitee_email)
+            assert_not_nil user.stored_raw_invitation_token
+            assert_not_equal user.stored_raw_invitation_token, user.invitation_token
           end
         end
       end

--- a/test/controllers/api/v1/team_members_controller_test.rb
+++ b/test/controllers/api/v1/team_members_controller_test.rb
@@ -85,7 +85,7 @@ module Api
 
             assert json_response['pending_invite']
 
-            user = User.find_by_email(invitee_email)
+            user = User.find_by(email: invitee_email)
             assert_not_nil user.stored_raw_invitation_token
             assert_not_equal user.stored_raw_invitation_token, user.invitation_token
           end

--- a/yarn.lock
+++ b/yarn.lock
@@ -276,6 +276,15 @@ cli@~1.0.0:
     exit "0.1.2"
     glob "^7.1.1"
 
+clipboard@^2.0.0:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.8.tgz#ffc6c103dd2967a83005f3f61976aa4655a4cdba"
+  integrity sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 cliui@^7.0.2:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
@@ -656,6 +665,11 @@ delaunator@4:
   resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-4.0.1.tgz#3d779687f57919a7a418f8ab947d3bddb6846957"
   integrity sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==
 
+delegate@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
+  integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
+
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -906,6 +920,13 @@ glob@^7.1.1, glob@^7.1.3, glob@^7.1.6:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  integrity sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=
+  dependencies:
+    delegate "^3.1.2"
 
 graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.6"
@@ -1195,6 +1216,13 @@ ng-tags-input@3.2.0:
   resolved "https://registry.yarnpkg.com/ng-tags-input/-/ng-tags-input-3.2.0.tgz#91282de575130c8ab794797febf0972b0f3bba3e"
   integrity sha1-kSgt5XUTDIq3lHl/6/CXKw87uj4=
 
+ngclipboard@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ngclipboard/-/ngclipboard-2.0.0.tgz#406f6c34d21d78c13faafa7f7df2ae4acd50e75a"
+  integrity sha1-QG9sNNIdeME/qvp/ffKuSs1Q51o=
+  dependencies:
+    clipboard "^2.0.0"
+
 node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
@@ -1404,6 +1432,11 @@ safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
+  integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
+
 setprototypeof@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
@@ -1540,6 +1573,11 @@ through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+tiny-emitter@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
+  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
 tmp@0.2.1:
   version "0.2.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add to the UI a "copy" icon to cut and send via slack or other tools invite links.

## Motivation and Context
Not everyone has email set up.   Sometimes email takes a while and you want to cut n paste a invite link immediately.

Also fixed the flow of someone wanting to signup who already has an invite link outstanding!

## How Has This Been Tested?
unit tests and manual

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
