### PR TITLE
Cleanups for the invite user flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 6.5.1 - ??
 
+### Bugs
+
+* Now that we've had the team invitations feature out for a while, we've found places where we make assumptions that aren't correct.  This fixes the Admin panel's user page, and makes on the Teams page the messaging around pending invites.  https://github.com/o19s/quepid/pull/339 by @epugh.
+
 ### Improvements
 
 * Uglifier for JavaScript appears to not work with ES6, and so using [Terser](https://github.com/ahorek/terser-ruby) instead.  https://github.com/o19s/quepid/pull/329 by @epugh fixes this.

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -29,6 +29,12 @@
       </p>
     </div>
   </div>
+  <div class="form-group">
+    <label class="col-sm-2 control-label">Created by Invite?</label>
+    <div class="col-sm-10">
+      <p class="form-control-static"><%= @user.created_by_invite? %></p>
+    </div>
+  </div>
 
   <div class="form-group">
     <label class="col-sm-2 control-label">Email Marketing</label>
@@ -63,7 +69,9 @@
 
 <div class="clearfix">
   <h2>Pulse</h2>
-
+  <% unless @user.agreed_time %>
+  <div class="alert alert-info" role="alert">This user hasn't accepted the invite to join Quepid, therefore no usage data is available.</div>
+  <% else %>
   <h3>Cases viewed</h3>
   <div
     id="cases-viewed"
@@ -113,6 +121,8 @@
     data-url="<%= "/admin/users/#{@user.id}/pulse.json?data=queries-created" %>"
   >
   </div>
+
+  <% end %>
 </div>
 
 <hr />

--- a/app/views/api/v1/team_members/_member.json.jbuilder
+++ b/app/views/api/v1/team_members/_member.json.jbuilder
@@ -4,7 +4,7 @@ json.id member.id
 json.display_name   member.display_name
 json.email          member.email
 json.avatar_url     member.avatar_url(:big)
-json.pending_invite member.created_by_invite? && !member.invitation_accepted?
+json.pending_invite member.created_by_invite? && !member.invitation_accepted? && member.password.blank?
 if member.created_by_invite? && !member.invitation_accepted?
   json.invite_url accept_invitation_url(member, invitation_token: member.stored_raw_invitation_token)
 end

--- a/test/controllers/api/v1/team_members_controller_test.rb
+++ b/test/controllers/api/v1/team_members_controller_test.rb
@@ -144,6 +144,51 @@ module Api
           assert_includes ids, member1.id
           assert_includes ids, member2.id
         end
+
+        describe 'pending invite logic' do
+          test 'outstanding invite returns pending invite' do
+            post :invite, params: { team_id: team.id, id: 'invitee@mail.com' }
+            assert_response :ok
+            invitee = User.find_by(email: 'invitee@mail.com')
+
+            get :index, params: { team_id: team.id }
+
+            assert_response :ok
+            members = JSON.parse(response.body)['members']
+            member = members.find { |m| m['id'].to_i == invitee.id }
+            assert member['pending_invite']
+          end
+
+          test "accepted invite doesn't return pending invite" do
+            post :invite, params: { team_id: team.id, id: 'invitee@mail.com' }
+            assert_response :ok
+            invitee = User.find_by(email: 'invitee@mail.com')
+            User.accept_invitation!(invitation_token: invitee.stored_raw_invitation_token, password: 'ad97nwj3o2',
+name: 'John Doe')
+            assert_response :ok
+
+            get :index, params: { team_id: team.id }
+
+            assert_response :ok
+            members = JSON.parse(response.body)['members']
+            member = members.find { |m| m['id'].to_i == invitee.id }
+            assert_not member['pending_invite']
+          end
+
+          test "pending invite, that is ignored and account directly created doesn't return pending invite" do
+            post :invite, params: { team_id: team.id, id: 'invitee@mail.com' }
+            assert_response :ok
+            invitee = User.find_by(email: 'invitee@mail.com')
+            invitee.update(password: 'temppassword', name: 'john doe') # don't accept invite, just signup directly.
+
+            get :index, params: { team_id: team.id }
+
+            assert_response :ok
+            members = JSON.parse(response.body)['members']
+            member = members.find { |m| m['id'].to_i == invitee.id }
+            assert_not member['pending_invite']
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description


This fixes the admin user detail page which assumed that users had agreed to T&C, but that might not apply for invited users who haven't joined.

This also makes the logic aorund pending_invite in the front end better.

## Motivation and Context
Now that we have the ability to invite someone, we're finding some places where assumpitons we made don't apply.

## How Has This Been Tested?
manually and tests

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
