### PR TITLE
Migrate from latin to utf8?

### DIFF
--- a/db/migrate/20211012153900_convert_my_sql_latin1_columns_to_utf8.rb
+++ b/db/migrate/20211012153900_convert_my_sql_latin1_columns_to_utf8.rb
@@ -1,0 +1,53 @@
+class ConvertMySqlLatin1ColumnsToUtf8 < ActiveRecord::Migration[6.1]
+  def change
+
+    # no text in these tables
+    # case_metadata
+    # case_scores
+    # snapshot_queries
+    # teams_cases
+    # teams_members
+
+    # has a string or text
+
+    execute("set names utf8")
+
+    # change this hash for your application. This example here is for a
+    # totally original blog application concept.
+    keys = {
+        :curator_variables   => %w{name},
+        :ratings => %w{doc_id},
+        :snapshot_docs => %w{doc_id `explain`},
+        :snapshots => %w{name},
+        :teams => %w{name}
+    }
+
+    conversions = {
+      'C383C2A1'         => 'á', 'C383C2A0'       => 'à', 'C383C2A4'       => 'ä', 'C383C2A2'   => 'â',
+      'C383C2A9'         => 'é', 'C383C2A8'       => 'è', 'C383C2AB'       => 'ë', 'C383C2AA'   => 'ê',
+      'C383C2AD'         => 'í', 'C383C2AC'       => 'ì', 'C383C2AF'       => 'ï', 'C383C2AE'   => 'î',
+      'C383C2B3'         => 'ó', 'C383C2B2'       => 'ò', 'C383C2B6'       => 'ö', 'C383C2B4'   => 'ô',
+      'C383C2BA'         => 'ú', 'C383C2B9'       => 'ù', 'C383C2BC'       => 'ü', 'C383C2BB'   => 'û',
+      'C383C281'         => 'Á', 'C383E282AC'     => 'À', 'C383E2809E'     => 'Ä', 'C383E2809A' => 'Â',
+      'C383E280B0'       => 'É', 'C383CB86'       => 'È', 'C383E280B9'     => 'Ë', 'C383C5A0'   => 'Ê',
+      'C383C28D'         => 'Í', 'C383C592'       => 'Ì', 'C383C28F'       => 'Ï', 'C383C5BD'   => 'Î',
+      'C383E2809C'       => 'Ó', 'C383E28099'     => 'Ò', 'C383E28093'     => 'Ö', 'C383E2809D' => 'Ô',
+      'C383C5A1'         => 'Ú', 'C383E284A2'     => 'Ù', 'C383C593'       => 'Ü', 'C383E280BA' => 'Û',
+      'C385C2B8'         => 'Ÿ', 'C385E2809C'     => 'œ', 'C383C2B8'       => 'ø', 'C383C2BF'   => 'ÿ',
+      'C3A2E282ACC593'   => '“', 'C3A2E282ACC29D' => '”', 'C3A2E282ACCB9C' => '‘',
+      'C3A2E282ACE284A2' => '’', 'C382C2AB'       => '«', 'C382C2BB'       => '»',
+      'C383C2A5'         => 'å', 'C383E280A6'     => 'Å', 'C383C5B8'       => 'ß', 'C383E280A0' => 'Æ',
+      'C383C2A7'         => 'ç', 'C383E280A1'     => 'Ç', 'C383C2B1'       => 'ñ', 'C383E28098' => 'Ñ',
+      'C383C2A3'         => 'ã', 'C383C2B5'       => 'õ', 'C383C692'       => 'Ã', 'C383E280A2' => 'Õ'
+    }
+
+    keys.each { |table, columns|
+      execute "alter table #{table} convert to character set utf8"
+      columns.each { |column|
+        conversions.each { |hex, utf8|
+          execute("update #{table} set #{column} = replace(#{column}, unhex('#{hex}'), '#{utf8}') where cast(#{column} as binary) regexp binary unhex('#{hex}');")
+        }
+      }
+    }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_17_212115) do
+ActiveRecord::Schema.define(version: 2021_10_12_153900) do
 
-  create_table "annotations", id: :integer, charset: "utf8", force: :cascade do |t|
+  create_table "annotations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.text "message"
     t.string "source"
     t.integer "user_id"
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 2021_09_17_212115) do
     t.index ["user_id"], name: "user_id"
   end
 
-  create_table "cases", id: :integer, charset: "utf8", force: :cascade do |t|
+  create_table "cases", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "case_name", limit: 191
     t.integer "last_try_number"
     t.integer "owner_id"
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 2021_09_17_212115) do
     t.index ["owner_id"], name: "user_id"
   end
 
-  create_table "curator_variables", id: :integer, charset: "latin1", force: :cascade do |t|
+  create_table "curator_variables", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "name", limit: 500
     t.float "value"
     t.integer "try_id"
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 2021_09_17_212115) do
     t.index ["try_id"], name: "try_id"
   end
 
-  create_table "permissions", id: :integer, charset: "utf8", force: :cascade do |t|
+  create_table "permissions", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "user_id"
     t.string "model_type", null: false
     t.string "action", null: false
@@ -87,7 +87,7 @@ ActiveRecord::Schema.define(version: 2021_09_17_212115) do
     t.index ["case_id"], name: "case_id"
   end
 
-  create_table "ratings", id: :integer, charset: "latin1", force: :cascade do |t|
+  create_table "ratings", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "doc_id", limit: 500
     t.integer "rating"
     t.integer "query_id"
@@ -111,11 +111,11 @@ ActiveRecord::Schema.define(version: 2021_09_17_212115) do
     t.boolean "communal", default: false
   end
 
-  create_table "snapshot_docs", id: :integer, charset: "latin1", force: :cascade do |t|
+  create_table "snapshot_docs", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "doc_id", limit: 500
     t.integer "position"
     t.integer "snapshot_query_id"
-    t.text "explain", size: :medium
+    t.text "explain", size: :long
     t.boolean "rated_only", default: false
     t.index ["snapshot_query_id"], name: "snapshot_query_id"
   end
@@ -127,7 +127,7 @@ ActiveRecord::Schema.define(version: 2021_09_17_212115) do
     t.index ["snapshot_id"], name: "snapshot_id"
   end
 
-  create_table "snapshots", id: :integer, charset: "latin1", force: :cascade do |t|
+  create_table "snapshots", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "name", limit: 250
     t.datetime "created_at"
     t.integer "case_id"
@@ -135,8 +135,8 @@ ActiveRecord::Schema.define(version: 2021_09_17_212115) do
     t.index ["case_id"], name: "case_id"
   end
 
-  create_table "teams", id: :integer, charset: "latin1", force: :cascade do |t|
-    t.string "name", collation: "utf8_bin"
+  create_table "teams", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+    t.string "name"
     t.integer "owner_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: '3'
 services:
   mysql:
     container_name: quepid_db
+    #image: mysql:8.0.26
     image: mysql:5.6.37
+    command: --default-authentication-plugin=mysql_native_password
     ports:
       - 3306:3306
     environment:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
We have latin for some fields, and utf8 for others in our schema.rb.  

Eventually this will get us.

## How Has This Been Tested?
NO!

We need to put some emoji's in, and then run the migration, and see if things still look good.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
