### PR TITLE
Add docs how to run Quepid behind a load balancer

### DIFF
--- a/docs/operating_documentation.md
+++ b/docs/operating_documentation.md
@@ -2,14 +2,68 @@
 
 This document explains how Quepid can be operated and configured.
 
-# Table of Contents
-
+- [Running behind a load balancer](#loadbalancer)
 - [Mail](#mail)
 - [OAuth](#OAuth)
 - [Legal Pages & GDPR](#legal-pages-&-gdpr)
 - [Heathcheck Endpoint](#healthcheck)
 
-# Mail
+## Running behind a load balancer
+
+> ⚠️ _Quepid will run in TLS (`https`) or plain `http` mode depending on the
+> protocol of the target search engine_. Requests to the search engine
+> are issued by the client. Most browsers deny plain http requests
+> (to the search engine) originating from a TLS secured Quepid.
+
+(1) To run behind a TLS secured load balancer, acquire a valid TLS certificate
+from e.g. [Let's Encrypt](https://letsencrypt.org/) or create a self-signed
+certificate:
+
+```bash
+# create self-signed certificate
+$ openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+    -subj "localhost" \
+    -keyout /etc/ssl/certs/quepid.key \
+    -out /etc/ssl/certs/quepid.crt
+
+# join private key and certificate into PEM format
+$ cat /etc/ssl/certs/quepid.crt /etc/ssl/certs/quepid.key \
+    > /etc/ssl/certs/quepid.pem
+```
+
+(2) Configure your favorite load balancer (or reverse proxy), in this
+case [Nginx](http://nginx.org/)
+
+```nginx
+server {
+    listen              80;
+    listen              443 ssl;
+    ssl_certificate     /etc/ssl/certs/quepid.pem;
+    ssl_certificate_key /etc/ssl/certs/quepid.pem;
+    ssl_protocols       TLSv1.2;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+    access_log off;
+
+    location / {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_pass http://localhost:3000/;
+    }
+}
+```
+
+(3) Configure Quepid with the domain visible to the user.
+
+```
+QUEPID_DOMAIN=https://localhost  # Set this to the domain visible to the user
+FORCE_SSL=true                   # Enable this to use https only connections
+```
+
+> ⚠️ Setting `FORCE_SSL=true` will prevent you from testing search engines
+> that are not TLS enabled (`https`)!
+
+## Mail
 
 Quepid has to send E-Mails for several reasons, for example for the password reset function or to invite a new user.
 Therefore Quepid has two options to use:
@@ -49,7 +103,7 @@ SMTP_AUTHENTICATION_TYPE     # If your mail server requires authentication, you 
 SMTP_ENABLE_STARTTLS         # If STARTTLS is enabled in your server set to true
 ```
 
-# OAuth
+## OAuth
 Quepid uses [OmniAuth](https://github.com/intridea/omniauth) for authenticating users against other resources besides it's own email/password database.   OmniAuth provides an easy way to authenticate against dozens of outside services. The only ones that are packaged with Quepid are Google and Keycloak, but it's fairly easy to add new ones.
 
 Learn more about setting up Google oAuth at https://support.google.com/cloud/answer/6158849?hl=en.
@@ -60,9 +114,9 @@ The OmniAuth providers are defined in `config/initializers/devise.rb`. A list of
 
 The existence of `GOOGLE_CLIENT_ID` or `KEYCLOAK_REALM` enables the respective sign in option.
 
-## Keycloak Setup Details
+### Keycloak Setup Details
 
-Quepid has a basic Keycloak config file in `/keycloak/realm-config/quepid-realm.json` that is used for development purposes.  
+Quepid has a basic Keycloak config file in `/keycloak/realm-config/quepid-realm.json` that is used for development purposes.
 
 We have a Realm called `Quepid`, and it includes a Client called `quepid`.  The client is where the specific configuration for how Quepid interacts with Keycloak via oAuth is set up.
 
@@ -70,7 +124,7 @@ We *assume* that the client definition in Keycloak will be named `quepid`, you c
 
 
 
-# Legal Pages & GDPR
+## Legal Pages & GDPR
 
 If you would like to have legal pages linked in the footer of the app, similar to behavior on http://app.quepid.com,
 add the following `ENV` vars:
@@ -87,7 +141,7 @@ To comply with GDPR, and be a good citizen, the hosted version of Quepid asks if
 EMAIL_MARKETING_MODE=true   # Enables a checkbox on user signup to consent to emails
 ```
 
-# User Tracking
+## User Tracking
 
 We currently only support Google Analytics, and you enable it by setting the following `ENV` var:
 
@@ -96,6 +150,6 @@ QUEPID_GA=XXXXXXXXXXXX  # Your Google Analytics Key
 ```
 
 
-# Healthcheck
+## Healthcheck
 
 Want to monitor if Quepid is behaving?  Just monitor `/healthcheck`, and you will get 200 status codes from a healthy Quepid, and 503 if not.  The JSON output is `{"code":200,"status":{"database":"OK","migrations":"OK"}}`.


### PR DESCRIPTION
This PR add documentation on how to run Quepid behind a TLS secured load balancer. This is linked to the upcoming fixes by @epugh.