### PR TITLE
Adding nginx reverse proxy using self-signed certificates.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@ RAILS_ENV=development
 MAX_THREADS=2
 WEB_CONCURRENCY=2
 
+# This makes Quepid run only on SSL, including all interactions
+# with search engines.  If FORCE_SSL is false, then Quepid will switch
+# between http and https based on the url of the search engine for the main
+# /case page.
 FORCE_SSL=true
 
 DB_HOST=mysql

--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ RAILS_ENV=development
 MAX_THREADS=2
 WEB_CONCURRENCY=2
 
-FORCE_SSL=false
+FORCE_SSL=true
 
 DB_HOST=mysql
 DB_USERNAME=root

--- a/.env.example
+++ b/.env.example
@@ -9,10 +9,10 @@ MAX_THREADS=2
 WEB_CONCURRENCY=2
 
 # This makes Quepid run only on SSL, including all interactions
-# with search engines.  If FORCE_SSL is false, then Quepid will switch
+# with search engines on SSL.  If FORCE_SSL is false, then Quepid will switch
 # between http and https based on the url of the search engine for the main
 # /case page.
-FORCE_SSL=true
+FORCE_SSL=false
 
 DB_HOST=mysql
 DB_USERNAME=root

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,5 +1,3 @@
 web:    bundle exec puma -C config/puma.rb
 # worker: bundle exec sidekiq -e development -C config/sidekiq.yml -q default
 # For the future webpacker:  ./bin/webpack-dev-server
-
-# web: bundle exec thin start -p 3001 --ssl --ssl-key-file .ssl/localhost.key --ssl-cert-file .ssl/localhost.crt

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
 web:    bundle exec puma -C config/puma.rb
-# worker: bundle exec sidekiq -e development -C config/sidekiq.yml -q default
+worker: bundle exec sidekiq -e development -C config/sidekiq.yml -q default
 # For the future webpacker:  ./bin/webpack-dev-server

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,5 +1,5 @@
 web:    bundle exec puma -C config/puma.rb
-worker: bundle exec sidekiq -e development -C config/sidekiq.yml -q default
+# worker: bundle exec sidekiq -e development -C config/sidekiq.yml -q default
 # For the future webpacker:  ./bin/webpack-dev-server
 
 # web: bundle exec thin start -p 3001 --ssl --ssl-key-file .ssl/localhost.key --ssl-cert-file .ssl/localhost.crt

--- a/README.md
+++ b/README.md
@@ -468,21 +468,7 @@ openssl req -new -newkey rsa:2048 -sha1 -days 365 -nodes -x509 -keyout .ssl/loca
 
 **PS:** It is not necessary to do that again.
 
-What you need to do:
-
-1. Drag `.ssl/localhost.crt` to `System` in `Keychain Access` (this is for OS X)
-2. run (this is for Ubuntu/Docker):
-  * `sudo cp .ssl/localhost.crt /etc/ssl/cert`
-  * `sudo cp .ssl/localhost.key /etc/ssl/private`
-  * `sudo c_rehash`
-3. Add the Thin webserver for testing SSL, `bin/docker r bundle install thin`
-4. In `Procfile.dev` comment the part that uses `puma` and uncomment the part that uses `thin`
-5. In `.env` make sure you add `FORCE_SSL=true`
-6. Restart the server
-7. Go to `https://localhost:3000`
-8. Undo your Thin changes afterwords!
-
-**PS:** Why are we using both `puma` and `thin`? Because I simply could not figure out how to get `puma` to work properly with SSL and did not want to spend any more time on it!
+The `docker-compose.yml` file contains an nginx reverse proxy that uses these certificates. You can access Quepid at https://localhost:8443. (Quepid will still be available over http on port 3000.)
 
 ## I'd like to test OpenID Auth
 

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ openssl req -new -newkey rsa:2048 -sha1 -days 365 -nodes -x509 -keyout .ssl/loca
 
 **PS:** It is not necessary to do that again.
 
-The `docker-compose.yml` file contains an nginx reverse proxy that uses these certificates. You can access Quepid at https://localhost:8443. (Quepid will still be available over http on port 3000.)
+The `docker-compose.yml` file contains an nginx reverse proxy that uses these certificates. You can access Quepid at https://localhost or http://localhost. (Quepid will still be available over http on port 80.)
 
 ## I'd like to test OpenID Auth
 

--- a/app/assets/javascripts/controllers/queryParams.js
+++ b/app/assets/javascripts/controllers/queryParams.js
@@ -27,19 +27,17 @@ angular.module('QuepidApp')
           $scope.showESTemplateWarning = esUrlSvc.isTemplateCall(uri);
         }
 
-        console.log("searchUrl:" + $scope.settings.searchUrl);
+        console.log('searchUrl:' + $scope.settings.searchUrl);
 
-        console.log("searchUrl:" + $scope.settings.searchUrl != '')
-        console.log("angular.isUndefined:" + angular.isUndefined($scope.settings.searchUrl));
+        console.log('searchUrl:'' + $scope.settings.searchUrl != '');
+        console.log('angular.isUndefined:'' + angular.isUndefined($scope.settings.searchUrl));
         if ($scope.settings.searchEngine != ''){
           // Figure out if we need to redirect based on our search engine's url.
           var quepidStartsWithHttps = $location.protocol() === 'https';
           var searchEngineStartsWithHttps = $scope.settings.searchUrl.startsWith('https');
 
-
-
-          console.log("quepidStartsWithHttps:" + quepidStartsWithHttps);
-          console.log("searchEngineStartsWithHttps:" + searchEngineStartsWithHttps);
+          console.log('quepidStartsWithHttps:' + quepidStartsWithHttps);
+          console.log('searchEngineStartsWithHttps:' + searchEngineStartsWithHttps);
 
           if ((quepidStartsWithHttps.toString() === searchEngineStartsWithHttps.toString())){
             $scope.showTLSChangeWarning = false;
@@ -49,7 +47,7 @@ angular.module('QuepidApp')
             $scope.quepidUrlToSwitchTo = $location.protocol() + '://' + $location.host() + $location.path();
 
             $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo + '?searchUrl=' + $scope.settings.searchUrl;
-            
+
             if (searchEngineStartsWithHttps){
               $scope.protocolToSwitchTo = 'https';
               $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo.replace('http', 'https');
@@ -58,7 +56,6 @@ angular.module('QuepidApp')
               $scope.protocolToSwitchTo = 'http';
               $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo.replace('https', 'http');
             }
-
           }
         }
       };

--- a/app/assets/javascripts/controllers/queryParams.js
+++ b/app/assets/javascripts/controllers/queryParams.js
@@ -30,7 +30,7 @@ angular.module('QuepidApp')
         console.log('searchUrl:' + $scope.settings.searchUrl);
 
         console.log('searchUrl:' + $scope.settings.searchUrl != '');
-        console.log('angular.isUndefined:'' + angular.isUndefined($scope.settings.searchUrl));
+        console.log('angular.isUndefined:' + angular.isUndefined($scope.settings.searchUrl));
         if ($scope.settings.searchEngine != ''){
           // Figure out if we need to redirect based on our search engine's url.
           var quepidStartsWithHttps = $location.protocol() === 'https';

--- a/app/assets/javascripts/controllers/queryParams.js
+++ b/app/assets/javascripts/controllers/queryParams.js
@@ -27,33 +27,44 @@ angular.module('QuepidApp')
           $scope.showESTemplateWarning = esUrlSvc.isTemplateCall(uri);
         }
 
-        // Figure out if we need to redirect.
-        var quepidStartsWithHttps = $location.protocol() === 'https';
-        var searchEngineStartsWithHttps = $scope.settings.searchUrl.startsWith('https');
+        console.log("searchUrl:" + $scope.settings.searchUrl);
 
-        if ((quepidStartsWithHttps.toString() === searchEngineStartsWithHttps.toString())){
-          $scope.showTLSChangeWarning = false;
-        }
-        else {
-          $scope.showTLSChangeWarning = true;
-          $scope.quepidUrlToSwitchTo = $location.absUrl();
+        console.log("searchUrl:" + $scope.settings.searchUrl != '')
+        console.log("angular.isUndefined:" + angular.isUndefined($scope.settings.searchUrl));
+        if ($scope.settings.searchEngine != ''){
+          // Figure out if we need to redirect based on our search engine's url.
+          var quepidStartsWithHttps = $location.protocol() === 'https';
+          var searchEngineStartsWithHttps = $scope.settings.searchUrl.startsWith('https');
 
-          if ($scope.quepidUrlToSwitchTo.endsWith('/')){
-            $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo + '?skip_changing_to_matching_tls=true';
+
+
+          console.log("quepidStartsWithHttps:" + quepidStartsWithHttps);
+          console.log("searchEngineStartsWithHttps:" + searchEngineStartsWithHttps);
+
+          if ((quepidStartsWithHttps.toString() === searchEngineStartsWithHttps.toString())){
+            $scope.showTLSChangeWarning = false;
           }
           else {
-            $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo + '&skip_changing_to_matching_tls=true';
-          }
+            $scope.showTLSChangeWarning = true;
+            $scope.quepidUrlToSwitchTo = $location.absUrl();
 
-          if (searchEngineStartsWithHttps){
-            $scope.protocolToSwitchTo = 'https';
-            $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo.replace('http', 'https');
-          }
-          else {
-            $scope.protocolToSwitchTo = 'http';
-            $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo.replace('https', 'http');
-          }
+            if ($scope.quepidUrlToSwitchTo.endsWith('/')){
+              $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo + '?skip_changing_to_matching_tls=true';
+            }
+            else {
+              $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo + '&skip_changing_to_matching_tls=true';
+            }
 
+            if (searchEngineStartsWithHttps){
+              $scope.protocolToSwitchTo = 'https';
+              $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo.replace('http', 'https');
+            }
+            else {
+              $scope.protocolToSwitchTo = 'http';
+              $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo.replace('https', 'http');
+            }
+
+          }
         }
       };
 

--- a/app/assets/javascripts/controllers/queryParams.js
+++ b/app/assets/javascripts/controllers/queryParams.js
@@ -29,7 +29,7 @@ angular.module('QuepidApp')
 
         console.log('searchUrl:' + $scope.settings.searchUrl);
 
-        console.log('searchUrl:'' + $scope.settings.searchUrl != '');
+        console.log('searchUrl:' + $scope.settings.searchUrl != '');
         console.log('angular.isUndefined:'' + angular.isUndefined($scope.settings.searchUrl));
         if ($scope.settings.searchEngine != ''){
           // Figure out if we need to redirect based on our search engine's url.

--- a/app/assets/javascripts/controllers/queryParams.js
+++ b/app/assets/javascripts/controllers/queryParams.js
@@ -29,7 +29,6 @@ angular.module('QuepidApp')
 
         console.log('searchUrl:' + $scope.settings.searchUrl);
 
-        console.log('searchUrl:' + $scope.settings.searchUrl !== '');
         console.log('angular.isUndefined:' + angular.isUndefined($scope.settings.searchUrl));
         if ($scope.settings.searchEngine !== ''){
           // Figure out if we need to redirect based on our search engine's url.

--- a/app/assets/javascripts/controllers/queryParams.js
+++ b/app/assets/javascripts/controllers/queryParams.js
@@ -46,15 +46,10 @@ angular.module('QuepidApp')
           }
           else {
             $scope.showTLSChangeWarning = true;
-            $scope.quepidUrlToSwitchTo = $location.absUrl();
+            $scope.quepidUrlToSwitchTo = $location.protocol() + '://' + $location.host() + $location.path();
 
-            if ($scope.quepidUrlToSwitchTo.endsWith('/')){
-              $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo + '?skip_changing_to_matching_tls=true';
-            }
-            else {
-              $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo + '&skip_changing_to_matching_tls=true';
-            }
-
+            $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo + '?searchUrl=' + $scope.settings.searchUrl;
+            
             if (searchEngineStartsWithHttps){
               $scope.protocolToSwitchTo = 'https';
               $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo.replace('http', 'https');

--- a/app/assets/javascripts/controllers/queryParams.js
+++ b/app/assets/javascripts/controllers/queryParams.js
@@ -29,9 +29,9 @@ angular.module('QuepidApp')
 
         console.log('searchUrl:' + $scope.settings.searchUrl);
 
-        console.log('searchUrl:' + $scope.settings.searchUrl != '');
+        console.log('searchUrl:' + $scope.settings.searchUrl !== '');
         console.log('angular.isUndefined:' + angular.isUndefined($scope.settings.searchUrl));
-        if ($scope.settings.searchEngine != ''){
+        if ($scope.settings.searchEngine !== ''){
           // Figure out if we need to redirect based on our search engine's url.
           var quepidStartsWithHttps = $location.protocol() === 'https';
           var searchEngineStartsWithHttps = $scope.settings.searchUrl.startsWith('https');

--- a/app/assets/javascripts/controllers/wizardCtrl.js
+++ b/app/assets/javascripts/controllers/wizardCtrl.js
@@ -9,8 +9,8 @@
 // We track this via just seeing how many cases they are involved with.
 angular.module('QuepidApp')
   .controller('WizardCtrl', [
-    '$rootScope', '$scope', '$uibModal', '$timeout',
-    function ($rootScope, $scope, $uibModal, $timeout) {
+    '$rootScope', '$scope', '$uibModal', '$timeout', '$location',
+    function ($rootScope, $scope, $uibModal, $timeout, $location) {
       $scope.wizard = {};
       $scope.wizard.triggerModal = function() {
 
@@ -35,9 +35,12 @@ angular.module('QuepidApp')
       });
 
       // Logic to figure out if we have a valid user who doesn't have
-      // access to any existing cases.
-      // could be replace with a big button "Create your First Case"!
+      // access to any existing case (could be replaced with a big button "Create your First Case"!)
+      // or if the showWizard=true is set on the url.
       function showModal() {
+        if (angular.isDefined($location.search().showWizard) && $location.search().showWizard === 'true') {
+          return true;
+        }
         return angular.isDefined($rootScope.currentUser) &&
           $rootScope.currentUser !== null &&
           (!$rootScope.currentUser.completedCaseWizard && $rootScope.currentUser.casesInvolvedWithCount === 1 && $rootScope.currentUser.teamsInvolvedWithCount === 0) &&

--- a/app/assets/javascripts/controllers/wizardModal.js
+++ b/app/assets/javascripts/controllers/wizardModal.js
@@ -123,16 +123,9 @@ angular.module('QuepidApp')
         }
         else {
           $scope.showTLSChangeWarning = true;
-          // We need to drop the path.
-          //$scope.quepidUrlToSwitchTo = $location.absUrl();
-          // what port is HTTPS on???
-          $scope.quepidUrlToSwitchTo = $location.protocol() + '://' + $location.host() + '?skip_changing_to_matching_tls=true';
-          //if ($scope.quepidUrlToSwitchTo.endsWith('/')){
-          //  $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo + '?skip_changing_to_matching_tls=true';
-          //}
-          //else {
-          //  $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo + '&skip_changing_to_matching_tls=true';
-          //}
+
+          $scope.quepidUrlToSwitchTo = $location.protocol() + '://' + $location.host() + $location.path();
+          $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo + '?searchUrl=' + $scope.pendingWizardSettings.searchUrl;
 
           if (searchEngineStartsWithHttps){
             $scope.protocolToSwitchTo = 'https';

--- a/app/assets/javascripts/controllers/wizardModal.js
+++ b/app/assets/javascripts/controllers/wizardModal.js
@@ -22,6 +22,16 @@ angular.module('QuepidApp')
 
       $scope.pendingWizardSettings = angular.copy(settingsSvc.defaults.solr);
 
+      // if we have restarted the wizard, then grab the searchUrl and caseName from
+      // the params and override the default values.
+      // We should pass this stuff in externally, not do it here.
+      if (angular.isDefined($location.search().searchUrl)){
+        $scope.pendingWizardSettings.searchUrl = $location.search().searchUrl
+      }
+      if (angular.isDefined($location.search().caseName)){
+        $scope.pendingWizardSettings.caseName = $location.search().caseName
+      }
+
       $scope.wizardSettingsModel.settingsId = function() {
         return settingsSvc.settingsId();
       };
@@ -125,7 +135,7 @@ angular.module('QuepidApp')
           $scope.showTLSChangeWarning = true;
 
           $scope.quepidUrlToSwitchTo = $location.protocol() + '://' + $location.host() + $location.path();
-          $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo + '?searchUrl=' + $scope.pendingWizardSettings.searchUrl;
+          $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo + '?searchUrl=' + $scope.pendingWizardSettings.searchUrl + '&showWizard=true&caseName=' + $scope.pendingWizardSettings.caseName;
 
           if (searchEngineStartsWithHttps){
             $scope.protocolToSwitchTo = 'https';

--- a/app/assets/javascripts/controllers/wizardModal.js
+++ b/app/assets/javascripts/controllers/wizardModal.js
@@ -26,10 +26,10 @@ angular.module('QuepidApp')
       // the params and override the default values.
       // We should pass this stuff in externally, not do it here.
       if (angular.isDefined($location.search().searchUrl)){
-        $scope.pendingWizardSettings.searchUrl = $location.search().searchUrl
+        $scope.pendingWizardSettings.searchUrl = $location.search().searchUrl;
       }
       if (angular.isDefined($location.search().caseName)){
-        $scope.pendingWizardSettings.caseName = $location.search().caseName
+        $scope.pendingWizardSettings.caseName = $location.search().caseName;
       }
 
       $scope.wizardSettingsModel.settingsId = function() {
@@ -147,7 +147,7 @@ angular.module('QuepidApp')
           }
 
         }
-      };
+      }
 
       function setupDefaults(validator) {
         $scope.validating   = false;

--- a/app/assets/javascripts/controllers/wizardModal.js
+++ b/app/assets/javascripts/controllers/wizardModal.js
@@ -44,6 +44,7 @@ angular.module('QuepidApp')
       $scope.setupDefaults  = setupDefaults;
       $scope.submit         = submit;
       $scope.reset          = reset;
+      $scope.checkTLSForSearchEngineUrl = checkTLSForSearchEngineUrl;
       $scope.reset();
       $scope.searchFields   = [];
 
@@ -55,6 +56,8 @@ angular.module('QuepidApp')
       function reset() {
         $scope.validating = false;
         $scope.urlValid = $scope.urlInvalid = false;
+        $scope.checkTLSForSearchEngineUrl();
+
       }
 
       function submit() {
@@ -80,13 +83,9 @@ angular.module('QuepidApp')
 
         // This logic maybe should live in Splainer Search if we wanted to support Splainer.io as well?
 
-        // Copied from controllers/queryParams.js
-        // It's a bit awkward, as we have two validates!  validateSearchEngineUrl, which flips some flags,
-        // and then the SettingsValidatorFactory.
-
         $scope.showTLSChangeWarning = false;
 
-        $scope.validateSearchEngineUrl();
+        $scope.checkTLSForSearchEngineUrl();
 
         // exit early if we have the TLS issue, this really should be part of the below logic.
         // validator.validateTLS().then.validateURL().then....
@@ -109,7 +108,8 @@ angular.module('QuepidApp')
         });
       }
 
-      $scope.validateSearchEngineUrl  = function() {
+      // Copied validateSearchEngineUrl from controllers/queryParams.js and renamed it checkTLSForSearchEngineUrl
+      function checkTLSForSearchEngineUrl () {
 
         // Figure out if we need to redirect.
         var quepidStartsWithHttps = $location.protocol() === 'https';

--- a/app/assets/templates/views/devQueryParams.html
+++ b/app/assets/templates/views/devQueryParams.html
@@ -109,7 +109,7 @@
 
             <span ng-show="showTLSChangeWarning">
               You have specified a search engine url that is on a different protocol ( <code>{{protocolToSwitchTo}}</code> ) than Quepid is currently on,
-              so you need to reload Quepid on that protocol first, and then update the URL here.  This is to comply with browser security issues.
+              so you need to reload Quepid on that protocol.  This is to comply with browser security issues.
             </span>
           </div>
         </div>

--- a/app/assets/templates/views/devQueryParams.html
+++ b/app/assets/templates/views/devQueryParams.html
@@ -109,7 +109,7 @@
 
             <span ng-show="showTLSChangeWarning">
               You have specified a search engine url that is on a different protocol ( <code>{{protocolToSwitchTo}}</code> ) than Quepid is currently on,
-              so you need to reload Quepid on that protocol first, and then update the protocol here.  This is to comply with browser security issues.
+              so you need to reload Quepid on that protocol first, and then update the URL here.  This is to comply with browser security issues.
             </span>
           </div>
         </div>

--- a/app/assets/templates/views/devQueryParams.html
+++ b/app/assets/templates/views/devQueryParams.html
@@ -196,13 +196,14 @@
   </div> <!-- end #queryParamsCanvas -->
 </div> <!-- end #queryParamsArea -->
 
-<span ng-show="showTLSChangeWarning">
-  <a href="{{quepidUrlToSwitchTo}}" class="btn btn-primary form-control">
-    <span class="glyphicon glyphicon-refresh"></span> Reload Quepid in <code>{{protocolToSwitchTo}}</code> TLS Protocol
-  </a>
-</span>
+<span ng-show="qp.curTab == 'developer' || qp.curTab == 'engineSettings' || qp.curTab == 'curator'">
+  <span ng-show="showTLSChangeWarning">
+    <a href="{{quepidUrlToSwitchTo}}" class="btn btn-primary form-control">
+      <span class="glyphicon glyphicon-refresh"></span> Reload Quepid in <code>{{protocolToSwitchTo}}</code> TLS Protocol
+    </a>
+  </span>
 
-<span ng-show="!showTLSChangeWarning" id="query-sandbox-action" ng-click="settings.submit()" class="btn btn-primary form-control"
-      ng-show="qp.curTab == 'developer' || qp.curTab == 'engineSettings' || qp.curTab == 'curator'">
-    Rerun My Searches!
+  <span ng-show="!showTLSChangeWarning" id="query-sandbox-action" ng-click="settings.submit()" class="btn btn-primary form-control">
+      Rerun My Searches!
+  </span>
 </span>

--- a/app/assets/templates/views/wizardModal.html
+++ b/app/assets/templates/views/wizardModal.html
@@ -46,7 +46,7 @@
           <div ng-show="showTLSChangeWarning" class="alert alert-warning">
             <span>
             You have specified a search engine url that is on a different protocol ( <code>{{protocolToSwitchTo}}</code> ) than Quepid is currently on,
-            so you need to reload Quepid on that protocol first, and then update the protocol here.  This is to comply with browser security issues.
+            so you need to reload Quepid on that protocol first, and then continue the Wizard.  This is to comply with browser security issues.
             </span>
           </div>
           <div ng-if="urlInvalid && !showTLSChangeWarning" class="alert alert-danger">Sorry, we're not getting any search results from your <span ng-show="pendingWizardSettings.searchEngine === 'es'">Elasticsearch</span><span ng-show="pendingWizardSettings.searchEngine === 'solr'">Solr</span>.

--- a/app/assets/templates/views/wizardModal.html
+++ b/app/assets/templates/views/wizardModal.html
@@ -75,6 +75,7 @@ curl -X POST -H 'Content-type:application/json' -d '{
 
               </li>
               <li>If Solr responds, check if you have an ad blocker blocking your queries.</li>
+              <li>Chrome does not accept self signed certificates on Solr, try Firefox.</li>
               <li>See the <a target="_blank" href="https://github.com/o19s/quepid/wiki/Troubleshooting-Solr-and-Quepid">Troubleshooting Solr and Quepid</a> wiki page for more help!</li>
             </ul>
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -66,6 +66,13 @@ class HomeController < ApplicationController
 
     search_engine_starts_with_https = @try.present? ? @try.search_url.starts_with?('https') : false
 
+    puts "@try.present? #{@try.present?}"
+    if @try.present?
+      puts "@try.search_url: #{@try.search_url}"
+    end
+    puts "search_engine_starts_with_https: #{search_engine_starts_with_https}"
+    puts "request.ssl? #{request.ssl?}"
+
     if search_engine_starts_with_https && !request.ssl? # redirect to SSL
       original_url = request.original_url
       original_url.gsub!(%r{http://}, 'https://')

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,7 +3,7 @@
 class HomeController < ApplicationController
   before_action :set_case_or_bootstrap
 
-  before_action :redirect_to_correct_tls unless Rails.application.config.force_ssl
+  before_action :redirect_to_correct_tls # force a match to the URL of the search engine
 
   def index
     # return unless current_user
@@ -46,12 +46,25 @@ class HomeController < ApplicationController
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
   def redirect_to_correct_tls
-    bool = ActiveRecord::Type::Boolean.new
-    skip_changing_to_matching_tls = bool.deserialize(params[:skip_changing_to_matching_tls]) || false
 
-    return true if true == skip_changing_to_matching_tls
+    puts "In redirect_to_correct_tls"
+
+
+    bool = ActiveRecord::Type::Boolean.new
+    #$skip_changing_to_matching_tls = bool.deserialize(params[:skip_changing_to_matching_tls]) || false
+
+    #return true if true == skip_changing_to_matching_tls
 
     return true if @case.blank? # shortcut if we don't have an @case.
+
+    puts "DO we have a try?  #{@try.present?}"
+    puts "Alternatively, do we have a searchUrl? #{params[:searchUrl]}"
+    puts params
+
+    if @try.present? && params[:searchUrl]
+      @try.search_url = params[:searchUrl]
+      @try.save
+    end
 
     search_engine_starts_with_https = @try.present? ? @try.search_url.starts_with?('https') : false
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -72,9 +72,7 @@ class HomeController < ApplicationController
     search_engine_starts_with_https = @try.present? ? @try.search_url.starts_with?('https') : false
 
     puts "@try.present? #{@try.present?}"
-    if @try.present?
-      puts "@try.search_url: #{@try.search_url}"
-    end
+    puts "@try.search_url: #{@try.search_url}" if @try.present?
     puts "search_engine_starts_with_https: #{search_engine_starts_with_https}"
     puts "request.ssl? #{request.ssl?}"
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -46,14 +46,12 @@ class HomeController < ApplicationController
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
   def redirect_to_correct_tls
+    puts 'In redirect_to_correct_tls'
 
-    puts "In redirect_to_correct_tls"
+    # bool = ActiveRecord::Type::Boolean.new
+    # $skip_changing_to_matching_tls = bool.deserialize(params[:skip_changing_to_matching_tls]) || false
 
-
-    bool = ActiveRecord::Type::Boolean.new
-    #$skip_changing_to_matching_tls = bool.deserialize(params[:skip_changing_to_matching_tls]) || false
-
-    #return true if true == skip_changing_to_matching_tls
+    # return true if true == skip_changing_to_matching_tls
 
     return true if @case.blank? # shortcut if we don't have an @case.
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -46,7 +46,7 @@ class HomeController < ApplicationController
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
   def redirect_to_correct_tls
-    puts 'In redirect_to_correct_tls'
+    # puts 'In redirect_to_correct_tls'
 
     # bool = ActiveRecord::Type::Boolean.new
     # $skip_changing_to_matching_tls = bool.deserialize(params[:skip_changing_to_matching_tls]) || false
@@ -55,9 +55,9 @@ class HomeController < ApplicationController
 
     return true if @case.blank? # shortcut if we don't have an @case.
 
-    puts "DO we have a try?  #{@try.present?}"
-    puts "Alternatively, do we have a searchUrl? #{params[:searchUrl]}"
-    puts params
+    # puts "DO we have a try?  #{@try.present?}"
+    # puts "Alternatively, do we have a searchUrl? #{params[:searchUrl]}"
+    # puts params
 
     if @case.present? && params[:caseName]
       @case.case_name = params[:caseName]
@@ -71,10 +71,10 @@ class HomeController < ApplicationController
 
     search_engine_starts_with_https = @try.present? ? @try.search_url.starts_with?('https') : false
 
-    puts "@try.present? #{@try.present?}"
-    puts "@try.search_url: #{@try.search_url}" if @try.present?
-    puts "search_engine_starts_with_https: #{search_engine_starts_with_https}"
-    puts "request.ssl? #{request.ssl?}"
+    # puts "@try.present? #{@try.present?}"
+    # puts "@try.search_url: #{@try.search_url}" if @try.present?
+    # puts "search_engine_starts_with_https: #{search_engine_starts_with_https}"
+    # puts "request.ssl? #{request.ssl?}"
 
     if search_engine_starts_with_https && !request.ssl? # redirect to SSL
       original_url = request.original_url

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -59,6 +59,11 @@ class HomeController < ApplicationController
     puts "Alternatively, do we have a searchUrl? #{params[:searchUrl]}"
     puts params
 
+    if @case.present? && params[:caseName]
+      @case.case_name = params[:caseName]
+      @case.save
+    end
+
     if @try.present? && params[:searchUrl]
       @try.search_url = params[:searchUrl]
       @try.save

--- a/bin/docker
+++ b/bin/docker
@@ -10,7 +10,7 @@ command, *rest = ARGV
 Dir.chdir APP_ROOT do
   case command
   when 'server', 's'
-    system 'docker-compose run -d --service-ports nginx'
+    system 'docker-compose up -d nginx'
     system 'docker-compose run --service-ports app foreman s -f Procfile.dev'
   when 'bash', 'b'
     system 'docker-compose run --rm app bash'

--- a/bin/docker
+++ b/bin/docker
@@ -10,6 +10,7 @@ command, *rest = ARGV
 Dir.chdir APP_ROOT do
   case command
   when 'server', 's'
+    system 'docker-compose run -d --service-ports nginx'
     system 'docker-compose run --service-ports app foreman s -f Procfile.dev'
   when 'bash', 'b'
     system 'docker-compose run --rm app bash'

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,8 +39,8 @@ module Quepid
       hsts: false,
       redirect: {
         exclude: -> request {
-          # request.path =~ /api/ or request.path =~ /assets/ or request.path =~ /case/ or request.path == '/'
-          request.path =~ /api/ or request.path =~ /assets/ or request.path =~ /case/
+          request.path =~ /api/ or request.path =~ /assets/ or request.path =~ /case/ or request.path == '/'
+          #request.path =~ /api/ or request.path =~ /assets/ or request.path =~ /case/
         },
       },
     }

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,23 +31,21 @@ module Quepid
     # == SSL Specific Settings
     # Note, if true then this will allow Quepid to ONLY talk to HTTPS based search engines.
     config.force_ssl = true if 'true' == ENV['FORCE_SSL']
-    # rubocop:disable Style/YodaCondition
     # rubocop:disable Style/StabbyLambdaParentheses
-    # rubocop:disable Layout/LineLength
     # rubocop:disable Layout/SpaceInLambdaLiteral
+    # rubocop:disable Layout/HashAlignment
     config.ssl_options = {
       secure_cookies: false,
       hsts: false,
       redirect: {
         exclude: -> request {
-          #request.path =~ /api/ or request.path =~ /assets/ or request.path =~ /case/ or request.path == '/'
+          # request.path =~ /api/ or request.path =~ /assets/ or request.path =~ /case/ or request.path == '/'
           request.path =~ /api/ or request.path =~ /assets/ or request.path =~ /case/
-        }
-      }
+        },
+      },
     }
-    # rubocop:enable Style/YodaCondition
     # rubocop:enable Style/StabbyLambdaParentheses
-    # rubocop:enable Layout/LineLength
     # rubocop:enable Layout/SpaceInLambdaLiteral
+    # rubocop:enable Layout/HashAlignment
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module Quepid
     config.active_job.queue_adapter = :sidekiq
 
     # == SSL Specific Settings
-    # Note, uf true then this will allow Quepid to ONLY talk to HTTPS based search engines.
+    # Note, if true then this will allow Quepid to ONLY talk to HTTPS based search engines.
     config.force_ssl = true if 'true' == ENV['FORCE_SSL']
     # rubocop:disable Style/YodaCondition
     # rubocop:disable Style/StabbyLambdaParentheses

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,15 @@ module Quepid
     # rubocop:disable Style/StabbyLambdaParentheses
     # rubocop:disable Layout/LineLength
     # rubocop:disable Layout/SpaceInLambdaLiteral
-    config.ssl_options = { secure_cookies: false, hsts: false, redirect: { exclude: -> request { request.path =~ /api/ or request.path =~ /assets/ or request.path =~ /case/ or request.path == '/' } } }
+    config.ssl_options = {
+      secure_cookies: false,
+      hsts: false,
+      redirect: {
+        exclude: -> request {
+          request.path =~ /api/ or request.path =~ /assets/ or request.path =~ /case/ or request.path == '/'
+        }
+      }
+    }
     # rubocop:enable Style/YodaCondition
     # rubocop:enable Style/StabbyLambdaParentheses
     # rubocop:enable Layout/LineLength

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,8 @@ module Quepid
       hsts: false,
       redirect: {
         exclude: -> request {
-          request.path =~ /api/ or request.path =~ /assets/ or request.path =~ /case/ or request.path == '/'
+          #request.path =~ /api/ or request.path =~ /assets/ or request.path =~ /case/ or request.path == '/'
+          request.path =~ /api/ or request.path =~ /assets/ or request.path =~ /case/
         }
       }
     }

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,6 @@ module Quepid
       redirect: {
         exclude: -> request {
           request.path =~ /api/ or request.path =~ /assets/ or request.path =~ /case/ or request.path == '/'
-          #request.path =~ /api/ or request.path =~ /assets/ or request.path =~ /case/
         },
       },
     }

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,7 +39,7 @@ module Quepid
       hsts: false,
       redirect: {
         exclude: -> request {
-          request.path =~ /api/ or request.path =~ /assets/ or request.path =~ /case/ or request.path == '/'
+          request.path =~ /api/ or request.path =~ /assets/ or request.path =~ /case/ or '/' == request.path
         },
       },
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,10 +58,10 @@ services:
     image: nginx:1.21.4
     container_name: quepid_nginx
     ports:
-      - "8443:8443"
+      - "443:8443"
+      - "80:80"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ./.ssl/:/etc/nginx/certs
     links:
       - app
-  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,6 @@
 version: '3'
 
 services:
-
-  nginx:
-    image: nginx:1.21.4
-    container_name: nginx
-    ports:
-      - "8443:8443"
-    volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./.ssl/:/etc/nginx/certs
-
-  mysql:
-    container_name: quepid_db
-    image: mysql:5.6.37
-    ports:
-      - 3306:3306
-    environment:
-      - MYSQL_ROOT_PASSWORD=password
-
-  redis:
-    container_name: quepid_redis
-    image: redis:6.0.5
-    ports:
-      - 6379:6379
-
   app:
     container_name: quepid_app
     build:
@@ -44,14 +20,30 @@ services:
       - mysql
       - redis
       - keycloak
+      - nginx
     depends_on:
       - mysql
       - redis
       - keycloak
+      - nginx
+      
+  mysql:
+    container_name: quepid_db
+    image: mysql:5.6.37
+    ports:
+      - 3306:3306
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+
+  redis:
+    container_name: quepid_redis
+    image: redis:6.0.5
+    ports:
+      - 6379:6379
 
   keycloak:
     image: quay.io/keycloak/keycloak:13.0.0
-    container_name: keycloak
+    container_name: quepid_keycloak
     hostname: keycloak
     command: ["-b", "0.0.0.0", "-Dkeycloak.migration.action=import", "-Dkeycloak.migration.provider=dir", "-Dkeycloak.migration.dir=/opt/jboss/keycloak/realm-config", "-Dkeycloak.migration.strategy=OVERWRITE_EXISTING", "-Djboss.socket.binding.port-offset=1000", "-Dkeycloak.profile.feature.upload_scripts=enabled"]
     ports:
@@ -63,3 +55,12 @@ services:
       DB_VENDOR: h2
     volumes:
       - ./keycloak/realm-config:/opt/jboss/keycloak/realm-config
+
+  nginx:
+    image: nginx:1.21.4
+    container_name: quepid_nginx
+    ports:
+      - "8443:8443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./.ssl/:/etc/nginx/certs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,16 @@
 version: '3'
+
 services:
+
+  nginx:
+    image: nginx:latest
+    container_name: nginx
+    ports:
+      - "8443:8443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./.ssl/:/etc/nginx/certs
+
   mysql:
     container_name: quepid_db
     image: mysql:5.6.37

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   nginx:
-    image: nginx:latest
+    image: nginx:1.21.4
     container_name: nginx
     ports:
       - "8443:8443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,13 +20,11 @@ services:
       - mysql
       - redis
       - keycloak
-      - nginx
     depends_on:
       - mysql
       - redis
       - keycloak
-      - nginx
-      
+
   mysql:
     container_name: quepid_db
     image: mysql:5.6.37
@@ -64,3 +62,6 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ./.ssl/:/etc/nginx/certs
+    links:
+      - app
+  

--- a/keycloak/realm-config/quepid-realm.json
+++ b/keycloak/realm-config/quepid-realm.json
@@ -441,8 +441,18 @@
   "webAuthnPolicyPasswordlessCreateTimeout": 0,
   "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
   "webAuthnPolicyPasswordlessAcceptableAaguids": [],
-  "clientProfiles": {},
-  "clientPolicies": {},
+  "clientProfiles": {
+    "profiles": []
+  },
+  "clientPolicies": {
+    "policies": [
+      {
+        "name": "builtin-default-policy",
+        "builtin": true,
+        "enable": false
+      }
+    ]
+  },
   "scopeMappings": [
     {
       "clientScope": "offline_access",
@@ -635,17 +645,17 @@
       "clientId": "quepid",
       "name": "Quepid",
       "description": "Show your queries some love!",
-      "rootUrl": "http://localhost:3000",
-      "adminUrl": "http://localhost:3000",
+      "rootUrl": "http://localhost",
+      "adminUrl": "http://localhost",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "http://localhost:3000/*"
+        "http://localhost/*"
       ],
       "webOrigins": [
-        "http://localhost:3000"
+        "http://localhost:"
       ],
       "notBefore": 0,
       "bearerOnly": false,
@@ -980,6 +990,7 @@
           "consentRequired": false,
           "config": {
             "multivalued": "true",
+            "userinfo.token.claim": "true",
             "user.attribute": "foo",
             "id.token.claim": "true",
             "access.token.claim": "true",
@@ -1361,14 +1372,14 @@
         "subComponents": {},
         "config": {
           "allowed-protocol-mapper-types": [
-            "oidc-usermodel-property-mapper",
-            "oidc-sha256-pairwise-sub-mapper",
             "oidc-address-mapper",
-            "saml-role-list-mapper",
             "oidc-usermodel-attribute-mapper",
-            "saml-user-attribute-mapper",
+            "saml-role-list-mapper",
             "saml-user-property-mapper",
-            "oidc-full-name-mapper"
+            "oidc-usermodel-property-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-full-name-mapper",
+            "oidc-sha256-pairwise-sub-mapper"
           ]
         }
       },
@@ -1380,14 +1391,14 @@
         "subComponents": {},
         "config": {
           "allowed-protocol-mapper-types": [
-            "saml-role-list-mapper",
-            "oidc-full-name-mapper",
-            "oidc-usermodel-attribute-mapper",
-            "oidc-address-mapper",
             "oidc-sha256-pairwise-sub-mapper",
-            "saml-user-property-mapper",
+            "oidc-usermodel-attribute-mapper",
             "saml-user-attribute-mapper",
-            "oidc-usermodel-property-mapper"
+            "saml-role-list-mapper",
+            "saml-user-property-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-address-mapper",
+            "oidc-full-name-mapper"
           ]
         }
       },
@@ -1463,7 +1474,7 @@
   "supportedLocales": [],
   "authenticationFlows": [
     {
-      "id": "ca82d824-aff4-4d7a-aa05-0a56ab61d63e",
+      "id": "1c514f54-2cfb-4989-8999-4b4f0c77a01e",
       "alias": "Account verification options",
       "description": "Method with which to verity the existing account",
       "providerId": "basic-flow",
@@ -1489,7 +1500,7 @@
       ]
     },
     {
-      "id": "7d7fdd22-7568-45e3-ba37-8310c4b13ad2",
+      "id": "36dfd43d-14b7-49c2-99ec-1b1c0fa9d3a5",
       "alias": "Authentication Options",
       "description": "Authentication options.",
       "providerId": "basic-flow",
@@ -1523,7 +1534,7 @@
       ]
     },
     {
-      "id": "e9649b65-e7af-4484-a51a-7831a530309b",
+      "id": "d7075686-3eaa-4e2a-8e1e-ffecbaaef33c",
       "alias": "Browser - Conditional OTP",
       "description": "Flow to determine if the OTP is required for the authentication",
       "providerId": "basic-flow",
@@ -1549,7 +1560,7 @@
       ]
     },
     {
-      "id": "94b78b33-05b0-452c-8394-76e6e0319466",
+      "id": "47e0e868-f37a-429f-98b7-2a20677685aa",
       "alias": "Direct Grant - Conditional OTP",
       "description": "Flow to determine if the OTP is required for the authentication",
       "providerId": "basic-flow",
@@ -1575,7 +1586,7 @@
       ]
     },
     {
-      "id": "cc4bb886-4f9f-4540-94b4-6e0b551c222b",
+      "id": "4c681c5b-71ba-47be-a127-e5d9599c3bec",
       "alias": "First broker login - Conditional OTP",
       "description": "Flow to determine if the OTP is required for the authentication",
       "providerId": "basic-flow",
@@ -1601,7 +1612,7 @@
       ]
     },
     {
-      "id": "c6693d44-6ab1-4d82-9ac1-de118a43583b",
+      "id": "42b62607-3c45-4315-81f0-6f54bec5daf9",
       "alias": "Handle Existing Account",
       "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
       "providerId": "basic-flow",
@@ -1627,7 +1638,7 @@
       ]
     },
     {
-      "id": "5d319ecf-2859-4212-81f9-1e9ca8c2ecfa",
+      "id": "55685e93-8a5e-4e5f-9393-9f19953553af",
       "alias": "Reset - Conditional OTP",
       "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
       "providerId": "basic-flow",
@@ -1653,7 +1664,7 @@
       ]
     },
     {
-      "id": "4fe6a496-4588-457b-90d5-f703b42736c0",
+      "id": "4fe9ec93-32bc-4044-b790-eb08d2a54760",
       "alias": "User creation or linking",
       "description": "Flow for the existing/non-existing user alternatives",
       "providerId": "basic-flow",
@@ -1680,7 +1691,7 @@
       ]
     },
     {
-      "id": "00d47232-bc72-4ab0-8125-377d68f705f1",
+      "id": "9e01d583-c419-4031-bae8-7c57afe617a5",
       "alias": "Verify Existing Account by Re-authentication",
       "description": "Reauthentication of existing account",
       "providerId": "basic-flow",
@@ -1706,7 +1717,7 @@
       ]
     },
     {
-      "id": "62d2de38-002b-4f05-b494-dd9c837c7e5a",
+      "id": "bbcdfa4d-a628-41e2-bb6f-274f1ccdca3f",
       "alias": "browser",
       "description": "browser based authentication",
       "providerId": "basic-flow",
@@ -1748,7 +1759,7 @@
       ]
     },
     {
-      "id": "1e30a820-de39-41d2-a1b6-a31eec26273a",
+      "id": "2867685d-bf3e-4760-977d-1581a097e1a3",
       "alias": "clients",
       "description": "Base authentication for clients",
       "providerId": "client-flow",
@@ -1790,7 +1801,7 @@
       ]
     },
     {
-      "id": "6d8bac3b-8cc3-4baa-9d7e-a909c5268631",
+      "id": "ac7a367c-1506-4441-8c8e-c1826936e4ca",
       "alias": "direct grant",
       "description": "OpenID Connect Resource Owner Grant",
       "providerId": "basic-flow",
@@ -1824,7 +1835,7 @@
       ]
     },
     {
-      "id": "b9a07e31-70ad-42f9-b83e-ef2992c57bf5",
+      "id": "b236fec2-e5cd-4014-9827-7b03cfcd8933",
       "alias": "docker auth",
       "description": "Used by Docker clients to authenticate against the IDP",
       "providerId": "basic-flow",
@@ -1842,7 +1853,7 @@
       ]
     },
     {
-      "id": "a4080dd9-113b-4772-87af-06d4233f5ced",
+      "id": "fd968fe7-65f0-4efa-bba5-a3d0a7c2c4c6",
       "alias": "first broker login",
       "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
       "providerId": "basic-flow",
@@ -1869,7 +1880,7 @@
       ]
     },
     {
-      "id": "5b053f79-bf58-4808-a965-7e3dec74a6e0",
+      "id": "34d0cbc8-09b7-411e-ba27-0eb88eab0b30",
       "alias": "forms",
       "description": "Username, password, otp and other auth forms.",
       "providerId": "basic-flow",
@@ -1895,7 +1906,7 @@
       ]
     },
     {
-      "id": "4c8279e2-b55e-4f74-9628-bc7bb5dbbef9",
+      "id": "2df020de-5f3c-4d82-90e8-a5ac779d955f",
       "alias": "http challenge",
       "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
       "providerId": "basic-flow",
@@ -1921,7 +1932,7 @@
       ]
     },
     {
-      "id": "4e1d2e2b-13c9-4817-8b46-301f3a6b13d0",
+      "id": "65ec5880-8726-48fa-afe2-effd954888a3",
       "alias": "registration",
       "description": "registration flow",
       "providerId": "basic-flow",
@@ -1940,7 +1951,7 @@
       ]
     },
     {
-      "id": "955bbee1-0d2d-406d-ad38-011a5ff7797c",
+      "id": "67924e92-a42a-4183-8579-bc5ac738e9ea",
       "alias": "registration form",
       "description": "registration form",
       "providerId": "form-flow",
@@ -1982,7 +1993,7 @@
       ]
     },
     {
-      "id": "58292eb6-34fc-4959-a0ca-da9c1f5452b3",
+      "id": "28143783-b779-4b66-b18f-ceccc09c5a6b",
       "alias": "reset credentials",
       "description": "Reset credentials for a user if they forgot their password or something",
       "providerId": "basic-flow",
@@ -2024,7 +2035,7 @@
       ]
     },
     {
-      "id": "00e5f99f-6e57-4f44-8032-d404723e76c1",
+      "id": "41d3f7c5-2e2b-4b3b-8246-25c6f2e00e31",
       "alias": "saml ecp",
       "description": "SAML ECP Profile Authentication Flow",
       "providerId": "basic-flow",
@@ -2044,14 +2055,14 @@
   ],
   "authenticatorConfig": [
     {
-      "id": "562664c0-e954-469b-b19e-7bc0a87a85cf",
+      "id": "c9fbb561-0d60-4d9d-9e40-3de74eb29120",
       "alias": "create unique user config",
       "config": {
         "require.password.update.after.registration": "false"
       }
     },
     {
-      "id": "f63e4390-7189-4560-9332-ef92c9d4a4d9",
+      "id": "db06e2bf-adbc-4904-88d2-6da3e69a1ab9",
       "alias": "review profile config",
       "config": {
         "update.profile.on.first.login": "missing"
@@ -2134,8 +2145,8 @@
     "cibaExpiresIn": "120",
     "cibaAuthRequestedUserHint": "login_hint",
     "oauth2DeviceCodeLifespan": "600",
-    "oauth2DevicePollingInterval": "5",
     "clientOfflineSessionMaxLifespan": "0",
+    "oauth2DevicePollingInterval": "5",
     "clientSessionIdleTimeout": "0",
     "clientSessionMaxLifespan": "0",
     "clientOfflineSessionIdleTimeout": "0",

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,7 @@ events { worker_connections 1024; }
 http {
 
   server {
+    listen 80;
     listen 8443 ssl;
     ssl_certificate /etc/nginx/certs/localhost.crt;
     ssl_certificate_key /etc/nginx/certs/localhost.key;

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,20 @@
+worker_processes 1;
+events { worker_connections 1024; }
+
+http {
+
+  server {
+    listen 8443 ssl;
+    ssl_certificate /etc/nginx/certs/localhost.crt;
+    ssl_certificate_key /etc/nginx/certs/localhost.key;
+    location / {
+       proxy_pass         http://172.17.0.1:3000;
+       proxy_redirect     off;
+       proxy_set_header   Host $host;
+       proxy_set_header   X-Real-IP $remote_addr;
+       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+       proxy_set_header   X-Forwarded-Host $server_name;
+    }
+  }
+
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -7,13 +7,15 @@ http {
     listen 8443 ssl;
     ssl_certificate /etc/nginx/certs/localhost.crt;
     ssl_certificate_key /etc/nginx/certs/localhost.key;
+    ssl_protocols       TLSv1.2;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+    access_log off;
+
     location / {
-       proxy_pass         http://172.17.0.1:3000;
-       proxy_redirect     off;
-       proxy_set_header   Host $host;
-       proxy_set_header   X-Real-IP $remote_addr;
-       proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-       proxy_set_header   X-Forwarded-Host $server_name;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_pass http://172.17.0.1:3000/;
     }
   }
 

--- a/spec/javascripts/angular/controllers/queryParams_spec.js
+++ b/spec/javascripts/angular/controllers/queryParams_spec.js
@@ -84,7 +84,7 @@ describe('Controller: QueryparamsCtrl', function () {
     scope.settings.searchUrl = 'https://example.com'
     scope.qp.toggleTab();
     expect(scope.showTLSChangeWarning).toBeTruthy();
-    expect(scope.quepidUrlToSwitchTo).toEqual('https://server/?skip_changing_to_matching_tls=true')
+    expect(scope.quepidUrlToSwitchTo).toEqual('https://server/?searchUrl=https://example.com')
     scope.settings.searchUrl = 'http://example.com'
     scope.qp.toggleTab();
     expect(scope.showTLSChangeWarning).toBeFalsy();

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class HomeControllerTest < ActionController::TestCase
   TRY_INFO        = /bootstrapTryNo.*?(\d*);/.freeze
   CASE_INFO       = /bootstrapCaseNo.*?(\d*);/.freeze
-  
+
   before do
     @controller = HomeController.new
   end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -5,8 +5,7 @@ require 'test_helper'
 class HomeControllerTest < ActionController::TestCase
   TRY_INFO        = /bootstrapTryNo.*?(\d*);/.freeze
   CASE_INFO       = /bootstrapCaseNo.*?(\d*);/.freeze
-  CASE_INFO       = /bootstrapCaseNo.*?(\d*);/.freeze
-
+  
   before do
     @controller = HomeController.new
   end


### PR DESCRIPTION
Adding nginx reverse proxy to docker-compose using self-signed certificates.

## Description
Adds an nginx container to the `docker-compose.yml` file that provides https access to Quepid via https://localhost;8443.

## Motivation and Context
To provide easier access developing over https.

## How Has This Been Tested?
Following the Quepid docker instructions.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
