### PR TITLE
bump version of splainer to deal with performance issues in looking up a single solr doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 6.10.0 - 2021-12-20??
+
+We've taken a rag and polished up the _Find and Rate Missing Documents_ modal box in this release.
+
+### Improvements
+
+The _Find and Rate Missing Documents_ query interface assumes you use the Lucene query syntax.  Turns out we have a highlighter built in, so enable that for Lucene syntax.  https://github.com/o19s/quepid/pull/453 by @epugh.
+
+Writing your own scorer?   The modal popup window is rather cramped, so let's give the editor room to breathe by making them larger!   https://github.com/o19s/quepid/pull/452 by @epugh.
+
+### Bugs
+
+On the _Find and Rate Missing Documents_ screen the ability to show just the rated documents had an issue that you had to click the button twice, making you think it was broken.  https://github.com/o19s/quepid/issues/454 and https://github.com/o19s/quepid/issues/423 by @epugh are fixed in https://github.com/o19s/quepid/pull/455 by @epugh.
+
+
 ## 6.9.1 - 2021-10-27
 
 ### Improvements

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ng-tags-input": "3.2.0",
     "ngclipboard": "^2.0.0",
     "popper.js": "^1.16.1",
-    "splainer-search": "2.11.0",
+    "splainer-search": "2.12.0",
     "tether-shepherd": "latest",
     "turbolinks": "^5.2.0",
     "vega": "^5.20.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7012,10 +7012,10 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
-splainer-search@2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/splainer-search/-/splainer-search-2.11.0.tgz#3c0dbe258114d5b0b2fa04281106592944443595"
-  integrity sha512-qTkYBPBWu7PrsEW/c55ROatP3MgsM/QQpSX3aSzCx6UXFkbG0VOuYcbENsbBE01c5CfrpGVZVTTqy3qnavaANA==
+splainer-search@2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/splainer-search/-/splainer-search-2.12.0.tgz#e48e25ecefccfb5d14a7eb99afe908db081917ce"
+  integrity sha512-cEL+0//8vXCDFNBTJVRmlngOj30M9S9dSFAG0IrbIoQcvLHDAx3/b7f5NvjD1K+dihW3CB/r8Z+MwcjVa5ERnQ==
   dependencies:
     angular "^1.7.9"
     urijs "^1.19.7"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This fixes #442  by turning off the default parameter to facet on EVERY single field that you might be listing in Quepid when you look up a single doc.

## Motivation and Context
No idea why the facet thing was there...  From the dawn of Quepid...    <-- @softwaredoug  do you have any ideas?

## How Has This Been Tested?
Manually

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
