### PR TITLE
preserve search engine type when swapping protocol

### DIFF
--- a/app/assets/javascripts/controllers/queryParams.js
+++ b/app/assets/javascripts/controllers/queryParams.js
@@ -27,16 +27,10 @@ angular.module('QuepidApp')
           $scope.showESTemplateWarning = esUrlSvc.isTemplateCall(uri);
         }
 
-        console.log('searchUrl:' + $scope.settings.searchUrl);
-
-        console.log('angular.isUndefined:' + angular.isUndefined($scope.settings.searchUrl));
         if ($scope.settings.searchEngine !== ''){
           // Figure out if we need to redirect based on our search engine's url.
           var quepidStartsWithHttps = $location.protocol() === 'https';
           var searchEngineStartsWithHttps = $scope.settings.searchUrl.startsWith('https');
-
-          console.log('quepidStartsWithHttps:' + quepidStartsWithHttps);
-          console.log('searchEngineStartsWithHttps:' + searchEngineStartsWithHttps);
 
           if ((quepidStartsWithHttps.toString() === searchEngineStartsWithHttps.toString())){
             $scope.showTLSChangeWarning = false;

--- a/app/assets/javascripts/controllers/wizardModal.js
+++ b/app/assets/javascripts/controllers/wizardModal.js
@@ -22,9 +22,12 @@ angular.module('QuepidApp')
 
       $scope.pendingWizardSettings = angular.copy(settingsSvc.defaults.solr);
 
-      // if we have restarted the wizard, then grab the searchUrl and caseName from
-      // the params and override the default values.
+      // if we have restarted the wizard, then grab the searchUrl, searchEngine,
+      // and caseName from the params and override the default values.
       // We should pass this stuff in externally, not do it here.
+      if (angular.isDefined($location.search().searchEngine)){
+        $scope.pendingWizardSettings.searchEngine = $location.search().searchEngine;
+      }
       if (angular.isDefined($location.search().searchUrl)){
         $scope.pendingWizardSettings.searchUrl = $location.search().searchUrl;
       }
@@ -121,12 +124,9 @@ angular.module('QuepidApp')
       // Copied validateSearchEngineUrl from controllers/queryParams.js and renamed it checkTLSForSearchEngineUrl
       function checkTLSForSearchEngineUrl () {
 
-        // Figure out if we need to redirect.
+        // Figure out if we need to reload Quepid on a different http/https port to match search engine.
         var quepidStartsWithHttps = $location.protocol() === 'https';
-        //
-        //var searchEngineStartsWithHttps = $scope.settings.searchUrl.startsWith('https');
         var searchEngineStartsWithHttps = $scope.pendingWizardSettings.searchUrl.startsWith('https');
-
 
         if ((quepidStartsWithHttps.toString() === searchEngineStartsWithHttps.toString())){
           $scope.showTLSChangeWarning = false;
@@ -135,7 +135,7 @@ angular.module('QuepidApp')
           $scope.showTLSChangeWarning = true;
 
           $scope.quepidUrlToSwitchTo = $location.protocol() + '://' + $location.host() + $location.path();
-          $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo + '?searchUrl=' + $scope.pendingWizardSettings.searchUrl + '&showWizard=true&caseName=' + $scope.pendingWizardSettings.caseName;
+          $scope.quepidUrlToSwitchTo = $scope.quepidUrlToSwitchTo + '?searchEngine=' + $scope.pendingWizardSettings.searchEngine + '&searchUrl=' + $scope.pendingWizardSettings.searchUrl + '&showWizard=true&caseName=' + $scope.pendingWizardSettings.caseName;
 
           if (searchEngineStartsWithHttps){
             $scope.protocolToSwitchTo = 'https';

--- a/app/assets/stylesheets/bootstrap-add.css
+++ b/app/assets/stylesheets/bootstrap-add.css
@@ -181,7 +181,7 @@ header .navbar-nav > li > a {
 	font-family: 'allerregular';
 }
 
-.navbar-secpndary .navbar-nav > li > a {
+.navbar-secondary .navbar-nav > li > a {
 	color: #FFF;
 }
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -37,44 +37,29 @@ class HomeController < ApplicationController
   # Similarily we may have only HTTPS set up for Quepid, and therefore need to stay on HTTPS,
   # so this method is only conditionally called if force_ssl is false.
   #
-  # The skip_changing_to_matching_tls lets us override this behavior, which we have to do when
-  # you edit the search engine url in the front end.  We need to change first, then come back
-  # and ask the person to reapply the change.
-
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
   def redirect_to_correct_tls
-    # puts 'In redirect_to_correct_tls'
-
-    # bool = ActiveRecord::Type::Boolean.new
-    # $skip_changing_to_matching_tls = bool.deserialize(params[:skip_changing_to_matching_tls]) || false
-
-    # return true if true == skip_changing_to_matching_tls
-
     return true if @case.blank? # shortcut if we don't have an @case.
-
-    # puts "DO we have a try?  #{@try.present?}"
-    # puts "Alternatively, do we have a searchUrl? #{params[:searchUrl]}"
-    # puts params
 
     if @case.present? && params[:caseName]
       @case.case_name = params[:caseName]
       @case.save
     end
 
-    if @try.present? && params[:searchUrl]
-      @try.search_url = params[:searchUrl]
+    if @try.present?
+      if params[:searchEngine].present?
+        @try.search_engine = params[:searchEngine]
+      end
+      if params[:searchUrl].present?
+        @try.search_url = params[:searchUrl]
+      end
       @try.save
     end
 
     search_engine_starts_with_https = @try.present? ? @try.search_url.starts_with?('https') : false
-
-    # puts "@try.present? #{@try.present?}"
-    # puts "@try.search_url: #{@try.search_url}" if @try.present?
-    # puts "search_engine_starts_with_https: #{search_engine_starts_with_https}"
-    # puts "request.ssl? #{request.ssl?}"
 
     if search_engine_starts_with_https && !request.ssl? # redirect to SSL
       original_url = request.original_url

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -50,12 +50,8 @@ class HomeController < ApplicationController
     end
 
     if @try.present?
-      if params[:searchEngine].present?
-        @try.search_engine = params[:searchEngine]
-      end
-      if params[:searchUrl].present?
-        @try.search_url = params[:searchUrl]
-      end
+      @try.search_engine = params[:searchEngine] if params[:searchEngine].present?
+      @try.search_url = params[:searchUrl] if params[:searchUrl].present?
       @try.save
     end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
we were defaulting to always picking solr, which obviously didn't work if you picked ES!

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
