### PR TITLE
Add Apple Silicon M1 Chip support

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -23,12 +23,11 @@ RUN apt-get update -qq \
 # may not need libgbm
 
 # Node and Yarn
-RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN wget --no-check-certificate -qO - https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 RUN apt-get update -qq && apt-get install -y --no-install-recommends nodejs yarn netcat \
   && rm -rf /var/lib/apt/lists/*
-
 
 # Clean environment
 RUN apt-get clean all

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -14,7 +14,7 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends vim curl ap
   && rm -rf /var/lib/apt/lists/*
 
 # Node and Yarn
-RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN wget --no-check-certificate -qO - https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,7 +5,7 @@ version: '3'
 services:
   mysql:
     container_name: quepid_prod_db
-    image: mysql:5.6.37
+    image: amd64/mysql:5.7.36
     ports:
       - 3306:3306
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   mysql:
     container_name: quepid_db
-    image: mysql:5.6.37
+    image: amd64/mysql:5.7.36
     ports:
       - 3306:3306
     environment:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "angular-ui-bootstrap": "~2.5.0",
     "angular-ui-sortable": "~0.19.0",
     "angular-utils-pagination": "~0.11.1",
-    "angular-wizard": "git://github.com/softwaredoug/angular-wizard.git#0.4.2",
+    "angular-wizard": "https://github.com/softwaredoug/angular-wizard.git#0.4.2",
     "bootstrap": "^5.0.2",
     "d3": "~6.6.2",
     "d3-tip": "~0.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1300,9 +1300,9 @@ angular-utils-pagination@~0.11.1:
   resolved "https://registry.yarnpkg.com/angular-utils-pagination/-/angular-utils-pagination-0.11.1.tgz#efad7c8879beb30ad3d77707f93e3d0ef51f2c66"
   integrity sha1-7618iHm+swrT13cH+T49DvUfLGY=
 
-"angular-wizard@git://github.com/softwaredoug/angular-wizard.git#0.4.2":
+"angular-wizard@https://github.com/softwaredoug/angular-wizard.git#0.4.2":
   version "0.4.2"
-  resolved "git://github.com/softwaredoug/angular-wizard.git#d86e03e77296e60c9115622ab7c81221fad37649"
+  resolved "https://github.com/softwaredoug/angular-wizard.git#d86e03e77296e60c9115622ab7c81221fad37649"
 
 angular@>=1.2.x, angular@^1.2.10, angular@^1.7.9, angular@~1.8.2:
   version "1.8.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The following changes were made:
1) In docker-compose.yml & docker-compose.prod.yml: Changed the
 mysql repository from `mysql` to `amd64/mysql` and took the latest
 5.7 version. That solves the build error on Apple Silicon M1 chips.

2) In Dockerfile.dev & Dockerfile.prod: Changed to a `wget` 
command and disabled certificate checking, since this resulted in an error (see https://github.com/o19s/quepid/issues/430).
For reference, I followed this recommendation on SO: https://stackoverflow.com/a/38039880

## Motivation and Context
This pull request aims to make the build successful on Apple Silicon M1 chips.
See https://github.com/querqy/chorus/issues/86 
and https://github.com/o19s/quepid/issues/430
for additional detail.


## How Has This Been Tested?

On my Apple MacBook Pro with Apple Silicon M1 chip:
I ran through the setup steps to setup the Docker images
and run the app. That was successful.
