### PR TITLE
Redis is ONLY used for Google Analytics!!!!

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
       actionmailer (>= 3.0.0)
       postmark (>= 1.21.3, < 2.0)
     public_suffix (4.0.6)
-    puma (5.4.0)
+    puma (5.6.4)
       nio4r (~> 2.0)
     puma_worker_killer (0.3.1)
       get_process_mem (~> 0.2)

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web:    bundle exec puma -C config/puma.rb
-worker: bundle exec sidekiq -e production -C config/sidekiq.yml -q default
+# Enable the worker if you have Google Analytics set up.
+#worker: bundle exec sidekiq -e production -C config/sidekiq.yml -q default

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -3,8 +3,18 @@
     <h2>
       Admin Panel
     </h2>
-  <%= link_to 'Users', admin_users_path %><br />
-  <%= link_to 'Quepid Communal Scorers', admin_communal_scorers_path %><br />
-  <a href="/admin/jobs">Job Manager</a>
+  <ul>
+  <li><%= link_to 'Users', admin_users_path %>
+  <li><%= link_to 'Quepid Communal Scorers', admin_communal_scorers_path %></li>
+
+  <li><a href="/admin/jobs">Job Manager</a><em>
+  <% if Rails.application.config.google_analytics_enabled %>
+    Google Analytics enabled, so Redis is setup.
+  <% else %>
+    Google Analytics disabled, so Redis not required.
+  <% end %></em>
+
+  </li>
+  </ul>
   </div>
 </div>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,14 +1,18 @@
 # frozen_string_literal: true
 
-Sidekiq::Extensions.enable_delay!
+# Redis and Sidekiq is used only for sending Google Analytics updates, which is
+# primarily used by the app.quepid.com install.  This checks if we need Sidekiq.
+if Rails.application.config.google_analytics_enabled
+  Sidekiq::Extensions.enable_delay!
 
-sidekiq_config = { url:        ENV['REDIS_URL'],
-                   ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
+  sidekiq_config = { url:        ENV['REDIS_URL'],
+                     ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
 
-Sidekiq.configure_server do |config|
-  config.redis = sidekiq_config
-end
+  Sidekiq.configure_server do |config|
+    config.redis = sidekiq_config
+  end
 
-Sidekiq.configure_client do |config|
-  config.redis = sidekiq_config
+  Sidekiq.configure_client do |config|
+    config.redis = sidekiq_config
+  end
 end

--- a/db/migrate/20220407201223_remove_index_from_ancestry_column_in_tries.rb
+++ b/db/migrate/20220407201223_remove_index_from_ancestry_column_in_tries.rb
@@ -1,0 +1,14 @@
+class RemoveIndexFromAncestryColumnInTries < ActiveRecord::Migration[6.1]
+  # we have discovered that we can't have a index on a string column longer then 767 bytes
+  # unless we use special column formatting.   Which we have for app.quepid.com,
+  # but not on our prod setup.
+  # https://dev.mysql.com/doc/refman/8.0/en/innodb-limits.html#:~:text=The%20index%20key%20prefix%20length,REDUNDANT%20or%20COMPACT%20row%20format.
+  # we don't need the index as there is only one page that shows this data...
+  def up
+    remove_index :tries, :ancestry
+  end
+
+  def down
+    add_index :tries, :ancestry
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2022_03_28_153812) do
+ActiveRecord::Schema.define(version: 2022_04_07_201223) do
 
   create_table "annotations", id: :integer, charset: "utf8", force: :cascade do |t|
     t.text "message"
@@ -180,7 +179,6 @@ ActiveRecord::Schema.define(version: 2022_03_28_153812) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "ancestry", limit: 3072
-    t.index ["ancestry"], name: "index_tries_on_ancestry"
     t.index ["case_id"], name: "case_id"
     t.index ["try_number"], name: "ix_queryparam_tryNo"
   end

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,11 +13,13 @@ services:
     volumes:
       - ./volumes/mysql_data:/var/lib/mysql
 
-  redis:
-    container_name: quepid_prod_redis
-    image: redis:6.0.5
-    ports:
-      - 6379:6379
+#  Redis is used to support sending to Google Analytics events.
+#  Enable this if you are running in Docker and have GA setup.
+#  redis:
+#    container_name: quepid_prod_redis
+#    image: redis:6.0.5
+#    ports:
+#      - 6379:6379
 
   app:
     container_name: quepid_prod_app
@@ -39,6 +41,7 @@ services:
       - TC_URL=
       - PRIVACY_URL=
       - COOKIES_URL=
+      - QUEPID_GA=
       - QUEPID_DOMAIN=https://example.com
       - EMAIL_MARKETING_MODE=false
       - QUEPID_DEFAULT_SCORER=AP@10

--- a/docs/operating_documentation.md
+++ b/docs/operating_documentation.md
@@ -6,6 +6,7 @@ This document explains how Quepid can be operated and configured.
 - [Mail](#mail)
 - [OAuth](#OAuth)
 - [Legal Pages & GDPR](#legal-pages-&-gdpr)
+- [User Tracking](#user-tracking)
 - [Heathcheck Endpoint](#healthcheck)
 
 ## Running behind a load balancer

--- a/docs/operating_documentation.md
+++ b/docs/operating_documentation.md
@@ -149,6 +149,10 @@ We currently only support Google Analytics, and you enable it by setting the fol
 QUEPID_GA=XXXXXXXXXXXX  # Your Google Analytics Key
 ```
 
+You will need Redis to support sending events to GA.   In production, uncomment the Redis
+configuration in `docker-compose.yml` to set up a local Redis.  Also uncomment the `worker` in
+the file `Procfile`
+
 
 ## Healthcheck
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Redis is only, today at least, used by Google Analytics.

## Motivation and Context
Some folks can't use redis, and yet we require it..  why?   Dug in and found we need it for GA tracking and thats it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
