### PR TITLE
turn off redis dependencies for app

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ Then check in the updated `package.json` and `yarn.lock` files.
 
 Use `bin/docker r yarn outdated` to see what packages you can update!!!!
 
-## I'd like to use a new Ruby Gem, or update a existing one
+## I'd like to use a new Ruby Gem, or update an existing one
 
 Typically you would simply do:
 
@@ -454,6 +454,40 @@ To understand if you have gems that are out of date run:
 ```
 bin/docker r bundle outdated --groups
 ```
+
+## I'd like to run and test out a local build
+
+Those steps should get you up and running locally
+
+- Make the desired changes to the code
+- From the root dir in the project run the following to build a new docker image:
+```
+docker build -t o19s/quepid -f Dockerfile.prod .
+```
+This could error on first run. Try again if that happens
+
+- Tag a new version of your image. 
+- You can either hard code your version or use a sys var for it (like QUEPID_VERSION=10.0.0) or if you prefer use 'latest'
+```
+docker tag o19s/quepid o19s/quepid:$QUEPID_VERSION
+```
+
+- Bring up the mysql container 
+```
+docker-compose up -d mysql
+```
+- Run the initialization scripts. This can take a few seconds
+```
+docker-compose run --rm app bin/rake db:setup
+```
+- Update your docker-compose.prod.yml file to use your image by updating the image version in the app ```image: o19s/quepid:10.0.0```
+
+- Start up the app either as a Daemon (-d) or as an active container
+```
+docker-compose up [-d]
+```
+- You should be able to access the app through [http://localhost](http://localhost)
+
 
 
 ## I'd like to test SSL

--- a/README.md
+++ b/README.md
@@ -455,9 +455,10 @@ To understand if you have gems that are out of date run:
 bin/docker r bundle outdated --groups
 ```
 
-## I'd like to run and test out a local build
+## I'd like to run and test out a local PRODUCTION build
 
-Those steps should get you up and running locally
+Those steps should get you up and running locally a production build (versus the developer build)
+of Quepid.
 
 - Make the desired changes to the code
 - From the root dir in the project run the following to build a new docker image:
@@ -466,13 +467,13 @@ docker build -t o19s/quepid -f Dockerfile.prod .
 ```
 This could error on first run. Try again if that happens
 
-- Tag a new version of your image. 
+- Tag a new version of your image.
 - You can either hard code your version or use a sys var for it (like QUEPID_VERSION=10.0.0) or if you prefer use 'latest'
 ```
 docker tag o19s/quepid o19s/quepid:$QUEPID_VERSION
 ```
 
-- Bring up the mysql container 
+- Bring up the mysql container
 ```
 docker-compose up -d mysql
 ```

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -31,7 +31,7 @@ services:
       - RACK_ENV=production
       - RAILS_ENV=production
       - DATABASE_URL=mysql2://root:password@mysql:3306/quepid
-      - REDIS_URL=redis://redis:6379/1
+#      - REDIS_URL=redis://redis:6379/1
       - FORCE_SSL=false
       - MAX_THREADS=2
       - WEB_CONCURRENCY=2
@@ -55,7 +55,7 @@ services:
       - 80:3000 # Map to port 80 for outside users.
     links:
       - mysql
-      - redis
+#      - redis
     depends_on:
       - mysql
-      - redis
+#      - redis


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
removed redis dependency and linkage from the app service setup 

## Motivation and Context
app won't start due to commented out redis dependency

## How Has This Been Tested?
build local image and used tagged version in docker-compose file
ran `docker-compose up` and verified app starts up properly
Signed up on locally running app and created a case

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
