### PR TITLE
harden the logic on parsing csv and move to using "query" instead of"query_text" in all csv export/imports

### DIFF
--- a/app/assets/javascripts/components/export_case/_modal.html
+++ b/app/assets/javascripts/components/export_case/_modal.html
@@ -9,7 +9,7 @@
     <input type="radio" id="information_need" name="exportSelection" value="information_need" ng-model="ctrl.options.which">
     <label for="information_need">Information Need</label>
     <span class="help-block">
-        CSV file with <code>query_id,query_text,information_need</code>, use as a template for uploading Information Need for queries back into Quepid.
+        CSV file with <code>query_id,query,information_need</code>, use as a template for uploading Information Need for queries back into Quepid.
     </span>
   </div>
 

--- a/app/assets/javascripts/components/import_ratings/_modal.html
+++ b/app/assets/javascripts/components/import_ratings/_modal.html
@@ -23,7 +23,7 @@
         <input type="radio" id="csv" name="importSelection" value="csv" ng-model="ctrl.options.which">
         <label for="csv">CSV</label>
         <span class="help-block">
-          The CSV file should have the headers: <code>query,docid,rating</code> and lines:
+          The CSV file should have the headers: <code>query,docid,rating</code> and lines similar to:
           <pre>
 query,docid,rating
 star wars,3574597,3
@@ -86,9 +86,9 @@ star trek,,</pre>
         <input type="radio" id="information_needs" name="importSelection" value="information_needs" ng-model="ctrl.options.which">
         <label for="information_needs">Information Needs CSV</label>
         <span class="help-block">
-          The CSV file should have the headers: <code>query_id, query_text,information_need</code> and lines:
+          The CSV file should have the headers: <code>query_id, query,information_need</code> and lines similar to:
           <pre>
-query_id,query_text,information_need
+query_id,query,information_need
 3574597,star wars,"The original movie"</pre>
         </span>
         <p>Select CSV file to import:</p>

--- a/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
+++ b/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
@@ -202,13 +202,14 @@ angular.module('QuepidApp')
         for (i = 1; i < lines.length; i++) {
           var line = lines[i];
           if (line && line.split(ctrl.csv.separator).length > 3){
-            if (line.match(/"/g) !== undefined && line.match(/"/g).length === 2){
+            var matches = line.match(/"/g);
+            if (matches !== undefined && matches !== null && matches.length === 2){
              // two double quotes means we are okay
             }
             else {
               // check for wrapping in double quotes.
               if (alert === undefined){
-                alert = 'Must have three (or fewer) columns for every line in CSV file: ';
+                alert = 'Must have three (or fewer) columns for every line in CSV file.  Make sure to wrap any queries with <code>,</code> in double quotes.';
                 alert += '<br /><strong>';
               }
               alert += 'line ' + (i + 1) + ': ';
@@ -228,7 +229,7 @@ angular.module('QuepidApp')
         headers     = headers.split(ctrl.information_needs.separator);
 
         var expectedHeaders = [
-          'query_id', 'query_text', 'information_need'
+          'query_id', 'query', 'information_need'
         ];
 
         if (!angular.equals(headers, expectedHeaders)) {
@@ -248,12 +249,13 @@ angular.module('QuepidApp')
         for (i = 1; i < lines.length; i++) {
           var line = lines[i];
           if (line && line.split(ctrl.information_needs.separator).length > 3){
-            if (line.match(/"/g) !== undefined && line.match(/"/g).length >= 2){
+            var matches = line.match(/"/g);
+            if (matches !== undefined && matches !== null && matches.length >= 2){
               // two double quotes (or more) means we are okay, it's not a perfect check
             }
             else {
               if (alert === undefined){
-                alert = 'Must have three (or fewer) columns for every line in CSV file: ';
+                alert = 'Must have three (or fewer) columns for every line in CSV file.  Make sure to wrap any query and information_need with <code>,</code> in double quotes.';
                 alert += '<br /><strong>';
               }
               alert += 'line ' + (i + 1) + ': ';

--- a/app/views/api/v1/export/queries/information_needs/show.csv.erb
+++ b/app/views/api/v1/export/queries/information_needs/show.csv.erb
@@ -1,7 +1,5 @@
+query_id,query,information_need
 <%
-headers = [:query_id, :query_text, :information_need]
-%>
-<%= ::CSV.generate_line(headers).html_safe %><%
 @case.queries.each do |query|
 %><%= ::CSV.generate_line([query.id, query.query_text, query.information_need]).html_safe %><%
 end %>

--- a/spec/javascripts/angular/services/importRatingsSvc_spec.js
+++ b/spec/javascripts/angular/services/importRatingsSvc_spec.js
@@ -121,7 +121,7 @@ describe('Service: importRatingsSvc', function () {
       });
     });
 
-    var mockCsv = 'query_id,query_text,information_need\n'
+    var mockCsv = 'query_id,query,information_need\n'
     mockCsv = mockCsv + '3,tatooine in star wars,Any of the star wars movies mentioning tatooine\n'
 
     var mockCase = {

--- a/test/controllers/api/v1/export/queries/information_needs_controller_test.rb
+++ b/test/controllers/api/v1/export/queries/information_needs_controller_test.rb
@@ -40,7 +40,7 @@ module Api
 
               csv = CSV.parse(response.body, headers: true)
 
-              assert_equal csv[0]['query_text'], 'star wars' # notice csv injection vulnerability
+              assert_equal csv[0]['query'], 'star wars' # notice csv injection vulnerability
               assert_equal csv[0]['information_need'], 'Looking for the original blockbuster movie, followed by the most recent big movies.'
             end
             # rubocop:enable Layout/LineLength

--- a/test/controllers/api/v1/import/queries/information_needs_controller_test.rb
+++ b/test/controllers/api/v1/import/queries/information_needs_controller_test.rb
@@ -50,7 +50,7 @@ module Api
                 acase.queries << query
               end
 
-              csv_text = 'query_id,query_text,information_need\n'
+              csv_text = 'query_id,query,information_need\n'
               queries.each do |q|
                 csv_text = "#{q[:query_id]}, #{q[:query_text]}, #{q[:information_need]}\n"
               end
@@ -83,7 +83,7 @@ module Api
                 acase.queries << query
               end
 
-              csv_text = 'query_id,query_text,information_need\n'
+              csv_text = 'query_id,query,information_need\n'
               queries.each do |q|
                 csv_text = "#{q[:query_id]}, #{q[:query_text]}, #{q[:information_need]}\n"
               end
@@ -139,7 +139,7 @@ module Api
                 information_need: 'Rocky series.',
               }
 
-              csv_text = 'query_id,query_text,information_need\n'
+              csv_text = 'query_id,query,information_need\n'
               queries.each do |q|
                 csv_text = "#{q[:query_id]}, #{q[:query_text]}, #{q[:information_need]}\n"
               end


### PR DESCRIPTION


## Description
used in CSV files `query` everywhere, instead of a mix of `query` and `query_text` ;-).   This is a breaking change!

Also fixes a regex that was blowing up with null....  in the javascript.

## Motivation and Context
Consistency!

## How Has This Been Tested?
tests and by hand

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
