### PR TITLE
Fix refresh of all ratings for queries

### DIFF
--- a/app/assets/javascripts/controllers/searchResults.js
+++ b/app/assets/javascripts/controllers/searchResults.js
@@ -24,8 +24,8 @@ angular.module('QuepidApp')
       $scope.selectedTry  = settingsSvc.applicableSettings();
 
       // Refresh rated-only docs if ratings have changed
-      $rootScope.$on('rating-changed', function() {
-        if (!queriesSvc.showOnlyRated) {
+      $rootScope.$on('rating-changed', function(e, queryId) {
+        if (!queriesSvc.showOnlyRated && $scope.query.queryId == queryId) {
           $scope.query.refreshRatedDocs();
         }
       });

--- a/app/assets/javascripts/controllers/searchResults.js
+++ b/app/assets/javascripts/controllers/searchResults.js
@@ -25,7 +25,7 @@ angular.module('QuepidApp')
 
       // Refresh rated-only docs if ratings have changed
       $rootScope.$on('rating-changed', function(e, queryId) {
-        if (!queriesSvc.showOnlyRated && $scope.query.queryId == queryId) {
+        if (!queriesSvc.showOnlyRated && $scope.query.queryId === queryId) {
           $scope.query.refreshRatedDocs();
         }
       });

--- a/app/assets/javascripts/services/ratingsStoreSvc.js
+++ b/app/assets/javascripts/services/ratingsStoreSvc.js
@@ -26,7 +26,7 @@ angular.module('QuepidApp')
           version++;
           svcVersion++;
 
-          $scope.$emit('rating-changed');
+          $scope.$emit('rating-changed', queryId);
         };
 
         this.setQueryId = function(newQueryId) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We were sending extra requests to the search engine when ratings were made, instead of only doing it for the specific query that was JUST rated.   

## Motivation and Context
putting extra load on the server....   ;-(

## How Has This Been Tested?
manual testing!

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
