### PR TITLE
The detailed export of the case doesn't exports the 0 hit queries

### DIFF
--- a/app/assets/javascripts/services/caseCSVSvc.js
+++ b/app/assets/javascripts/services/caseCSVSvc.js
@@ -281,7 +281,7 @@
 
           angular.forEach(queries, function (query) {
             var docs = query.docs;
-            if (docs === 0 ) {
+            if (docs.length === 0 ) {
               var dataString;
               var infoArray = [];
               infoArray.push(stringifyField(aCase.teamNames()));
@@ -381,7 +381,7 @@
             }
           }
           if (typeof data === 'string') {
-            data = data.replace(/"/g, '""'); // Escape double quotes
+            data = data.trim().replace(/"/g, '""'); // Escape double quotes
 
             if (data.indexOf(',') > -1 || data.indexOf('\n') > -1 || data.indexOf('\r') > -1) {
               data = textDelimiter + data + textDelimiter;

--- a/app/assets/javascripts/services/caseCSVSvc.js
+++ b/app/assets/javascripts/services/caseCSVSvc.js
@@ -281,26 +281,37 @@
 
           angular.forEach(queries, function (query) {
             var docs = query.docs;
-
-            angular.forEach(docs, function (doc) {
+            if (docs === 0 ) {
               var dataString;
               var infoArray = [];
-
               infoArray.push(stringifyField(aCase.teamNames()));
               infoArray.push(stringifyField(aCase.caseName));
               infoArray.push(stringifyField(aCase.lastScore.case_id));
               infoArray.push(stringifyField(query.queryText));
-              infoArray.push(stringifyField(doc.id));
-              infoArray.push(stringifyField(doc.title));
-              infoArray.push(stringifyField(doc.getRating()));
-
-              angular.forEach(fields, function(field) {
-                infoArray.push(stringifyField(doc.doc[field]));
-              });
-
               dataString = infoArray.join(',');
               csvContent += dataString + EOL;
-            });
+            }
+            else {
+              angular.forEach(docs, function (doc) {
+                var dataString;
+                var infoArray = [];
+
+                infoArray.push(stringifyField(aCase.teamNames()));
+                infoArray.push(stringifyField(aCase.caseName));
+                infoArray.push(stringifyField(aCase.lastScore.case_id));
+                infoArray.push(stringifyField(query.queryText));
+                infoArray.push(stringifyField(doc.id));
+                infoArray.push(stringifyField(doc.title));
+                infoArray.push(stringifyField(doc.getRating()));
+
+                angular.forEach(fields, function (field) {
+                  infoArray.push(stringifyField(doc.doc[field]));
+                });
+
+                dataString = infoArray.join(',');
+                csvContent += dataString + EOL;
+              });
+            }
           });
 
           return csvContent;


### PR DESCRIPTION
The detailed export of the case doesn't exports the 0 hit queries

## Description
As per the code we add the queries and result set to the csv while we iterate on the resultant docs.
Per made changes , we would still add the queries,irrespective of their result size to the export for analysis and comparison.

## Motivation and Context
Per made changes , we would add the queries,irrespective of their result size to the export for analysis and comparison.
https://github.com/o19s/quepid/issues/501

## How Has This Been Tested?
This feature has been tested with cases including 0 hit examples ensuring we get the query details in the exported csv.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
