### PR TITLE
Move the logic for the default ES and Solr server definitions from server AND client side to just client side

### DIFF
--- a/app/assets/javascripts/controllers/queryParamsHistory.js
+++ b/app/assets/javascripts/controllers/queryParamsHistory.js
@@ -8,6 +8,12 @@ angular.module('QuepidApp')
     function($scope, $uibModal, flash, caseTryNavSvc) {
       var urlsIveSeen = {};
 
+      // This method trys to group search urls into names.
+      // we use this to do some colour grouping in the history view by engine
+      // and we use it to name the engine.  Eventually we will name our engines
+      // and this can go away.
+      // There is a known bug that after running the wizard, we have TWO tries, one
+      // with a null url, and one that is actually from what you defined in the Wizard.
       $scope.urlBucket = function(url, numBuckets) {
         urlsIveSeen[url] = 0;
         var allUrls = Object.keys(urlsIveSeen);

--- a/app/assets/javascripts/controllers/wizardModal.js
+++ b/app/assets/javascripts/controllers/wizardModal.js
@@ -51,7 +51,7 @@ angular.module('QuepidApp')
         $scope.pendingWizardSettings.urlFormat                = settings.urlFormat;
         var quepidStartsWithHttps = $location.protocol() === 'https';
         if ($scope.pendingWizardSettings.searchEngine === 'es' ){
-          $scope.pendingWizardSettings.searchUrl = settings.searchUrl
+          $scope.pendingWizardSettings.searchUrl = settings.searchUrl;
         }
         else if (quepidStartsWithHttps === true){
           $scope.pendingWizardSettings.searchUrl = settings.secureSearchUrl;

--- a/app/assets/javascripts/controllers/wizardModal.js
+++ b/app/assets/javascripts/controllers/wizardModal.js
@@ -20,6 +20,7 @@ angular.module('QuepidApp')
 
 
       // I don't think we need this as we look it up from the Try we create by default on the server side!
+      // Except that it's also defined in settingsSvc.  Sigh.
       $scope.pendingWizardSettings = angular.copy(settingsSvc.defaults.solr);
 
       // if we have restarted the wizard, then grab the searchUrl, searchEngine,
@@ -47,7 +48,7 @@ angular.module('QuepidApp')
         $scope.pendingWizardSettings.searchEngine             = settings.searchEngine;
         $scope.pendingWizardSettings.apiMethod                = settings.apiMethod;
         $scope.pendingWizardSettings.searchUrl                = settings.searchUrl;
-        $scope.pendingWizardSettings.selectedTry.queryParams  = settings.queryParams;
+        $scope.pendingWizardSettings.queryParams              = settings.queryParams;
         $scope.pendingWizardSettings.titleField               = settings.titleField;
         $scope.pendingWizardSettings.urlFormat                = settings.urlFormat;
         $scope.reset();
@@ -60,7 +61,7 @@ angular.module('QuepidApp')
       $scope.reset          = reset;
       $scope.resetUrlValid  = resetUrlValid;
       $scope.checkTLSForSearchEngineUrl = checkTLSForSearchEngineUrl;
-      $scope.reset();
+      $scope.updateSettingsDefaults();
       $scope.searchFields   = [];
 
       $scope.extractSolrConfigApiUrl = function(searchUrl) {
@@ -272,7 +273,13 @@ angular.module('QuepidApp')
 
       $scope.$watch('wizardSettingsModel.settingsId()', function() {
         // Reinit our pending settings from the service
+        var tempSearchUrl = $scope.pendingWizardSettings.searchUrl;
+        var tempApiMethod = $scope.pendingWizardSettings.apiMethod;
+        var tempQueryParams = $scope.pendingWizardSettings.queryParams;
         angular.merge($scope.pendingWizardSettings, settingsSvc.editableSettings());
+        $scope.pendingWizardSettings.searchUrl = tempSearchUrl;
+        $scope.pendingWizardSettings.apiMethod = tempApiMethod;
+        $scope.pendingWizardSettings.queryParams = tempQueryParams;
         $scope.pendingWizardSettings.newQueries = [];
 
         if(userSvc.getUser().completedCaseWizard===false){

--- a/app/assets/javascripts/factories/TryFactory.js
+++ b/app/assets/javascripts/factories/TryFactory.js
@@ -20,10 +20,21 @@
       // This method converts the response from the API to angular objects.
       var self  = this;
 
+      // check if the backend has populated these fields or not?
       if ( angular.isUndefined(data.search_engine) ) {
-        $log.info('We have an undefined data.search_engine so setting to Solr, should this ever happen?');
         data.search_engine = 'solr';
       }
+
+      if ( data.query_params === null ) {
+        // this app
+        if (data.search_engine === 'solr'){
+          data.query_params = '';
+        }
+        else {
+          data.query_params = '{}';
+        }
+      }
+
 
       // Attributes
       // Note, if you are changing these, then you probably to fix the
@@ -39,6 +50,7 @@
       self.searchEngine  = data.search_engine;
       self.searchUrl     = data.search_url;
       self.tryNo         = data.try_number;
+
 
       // transform curator vars to be more angular friendly
       var ngFriendlyCuratorVars = [];

--- a/app/assets/javascripts/services/settingsSvc.js
+++ b/app/assets/javascripts/services/settingsSvc.js
@@ -226,6 +226,7 @@ angular.module('QuepidApp')
 
         // Not sure why we have this.  Handoff from wizard requires it though.
         settingsToSave.selectedTry.apiMethod = settingsToSave.apiMethod;
+        settingsToSave.selectedTry.queryParams = settingsToSave.queryParams;
 
         // post up
         // (1) searchUrl

--- a/app/assets/javascripts/services/settingsSvc.js
+++ b/app/assets/javascripts/services/settingsSvc.js
@@ -17,15 +17,14 @@ angular.module('QuepidApp')
       TryFactory, SettingsFactory,
       broadcastSvc
     ) {
-      // many of these defaults like apiMethod are defined server side in
-      // the Try.rb set_defaults method
+      // the Try.rb set_defaults method.  These appear to only be used when you
+      // click the radio box to pick a search engine, either solr or elasticsearch.
       this.defaults = {
         solr: {
           queryParams:  [
+            'q=#$query##',
             '&defType=edismax',
             '&qf=text_all',
-            '&indent=on',
-            '&q=#$query##',
             '&tie=1.0',
           ].join('\n'),
 

--- a/app/assets/javascripts/services/settingsSvc.js
+++ b/app/assets/javascripts/services/settingsSvc.js
@@ -17,8 +17,8 @@ angular.module('QuepidApp')
       TryFactory, SettingsFactory,
       broadcastSvc
     ) {
-      // the Try.rb set_defaults method.  These appear to only be used when you
-      // click the radio box to pick a search engine, either solr or elasticsearch.
+
+      // Used by the wizard
       this.defaults = {
         solr: {
           queryParams:  [
@@ -36,7 +36,8 @@ angular.module('QuepidApp')
           additionalFields: ['overview','cast','thumb:poster_path'],
           numberOfRows:     10,
           searchEngine:     'solr',
-          searchUrl:        'http://quepid-solr.dev.o19s.com:8985/solr/tmdb/select',
+          insecureSearchUrl:'http://quepid-solr.dev.o19s.com:8985/solr/tmdb/select',
+          secureSearchUrl:  'https://quepid-solr.dev.o19s.com/solr/tmdb/select',
           urlFormat:        'http(s?)://yourdomain.com:8983/<index>/select',
         },
         es: {

--- a/app/assets/templates/views/wizardModal.html
+++ b/app/assets/templates/views/wizardModal.html
@@ -88,7 +88,7 @@ curl -X POST -H 'Content-type:application/json' -d '{
 
             <div class="row">
               <input style="width: 100%" type="text" ng-change="reset()" ng-model="pendingWizardSettings.searchUrl" class="form-control" />
-              <small title="Manually validates Quepid can get retrieve search results from your URL before continuing" class="pull-right"><a ng-click="validate(true)">ping it</a></small>
+              <small title="Manually validates Quepid can get retrieve search results from your URL before continuing" class="pull-right"><button type="button" class="btn btn-link btn-sm" ng-click="validate(true)" ng-disabled="showTLSChangeWarning">ping it</button></small>
               <p class="help-block">Unsure? <a href="http://quepid.com/how-quepid-works/" target="_blank">Learn More</a> about Quepid's light touch with your search engine &amp; data.
 
               <p class="help-block tip">

--- a/app/controllers/core_controller.rb
+++ b/app/controllers/core_controller.rb
@@ -56,16 +56,13 @@ class CoreController < ApplicationController
         # Reset the default queries
         if @try.search_engine != params[:searchEngine]
           @try.search_engine = params[:searchEngine]
-          @try.query_params  = Try::DEFAULTS[@try.search_engine.to_sym][:query_params]
-          @try.field_spec = Try::DEFAULTS[@try.search_engine.to_sym][:field_spec]
-
         end
         @try.search_url = params[:searchUrl]
       end
       @try.save
     end
 
-    search_engine_starts_with_https = @try.present? ? @try.search_url.starts_with?('https') : false
+    search_engine_starts_with_https = @try.present? && @try.search_url.present? ? @try.search_url.starts_with?('https') : false
 
     if search_engine_starts_with_https && !request.ssl? # redirect to SSL
       original_url = request.original_url

--- a/app/controllers/core_controller.rb
+++ b/app/controllers/core_controller.rb
@@ -38,6 +38,7 @@ class CoreController < ApplicationController
   # Similarily we may have only HTTPS set up for Quepid, and therefore need to stay on HTTPS,
   # so this method is only conditionally called if force_ssl is false.
   #
+  # rubocop:disable Layout/LineLength
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/CyclomaticComplexity
@@ -76,6 +77,7 @@ class CoreController < ApplicationController
       true
     end
   end
+  # rubocop:enable Layout/LineLength
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/app/controllers/core_controller.rb
+++ b/app/controllers/core_controller.rb
@@ -54,9 +54,7 @@ class CoreController < ApplicationController
       # Deal with front end UI changes to search engine being stored in backend
       if params[:searchEngine].present?
         # Reset the default queries
-        if @try.search_engine != params[:searchEngine]
-          @try.search_engine = params[:searchEngine]
-        end
+        @try.search_engine = params[:searchEngine] if @try.search_engine != params[:searchEngine]
         @try.search_url = params[:searchUrl]
       end
       @try.save

--- a/app/models/try.rb
+++ b/app/models/try.rb
@@ -28,37 +28,6 @@ class Try < ApplicationRecord
   # Scopes
   scope :latest, -> { order(id: :desc).first } # The try created the most recently
 
-  # Defaults for defining a search engine.  These defaults
-  # are duplicated in the Angular SPA layer too ;-(
-  DEFAULTS = {
-    search_engine: 'solr',
-    solr:          {
-      query_params: 'q=#$query##',
-      search_url:   'http://quepid-solr.dev.o19s.com:8985/solr/tmdb/select',
-      field_spec:   'id:id title:title',
-      api_method:   'JSONP',
-    },
-    es:            {
-      query_params:
-                    '{
-  "query": {
-    "multi_match": {
-      "query": "#$query##",
-      "type": "best_fields",
-      "fields": [
-        "title^10",
-        "overview",
-        "cast"
-      ]
-    }
-  }
-}',
-      search_url:   'http://quepid-elasticsearch.dev.o19s.com:9206/tmdb/_search',
-      field_spec:   'id:_id, title:title',
-      api_method:   'POST',
-    },
-  }.freeze
-
   # Associations
   belongs_to  :case, optional: true # shouldn't be optional, but was in rails 4
 
@@ -150,11 +119,11 @@ class Try < ApplicationRecord
   def set_defaults
     self.name = "Try #{try_number}" if name.blank?
 
-    self.search_engine = DEFAULTS[:search_engine] if search_engine.blank?
-    self.api_method    = DEFAULTS[search_engine.to_sym][:api_method]    if api_method.blank?
-    self.field_spec    = DEFAULTS[search_engine.to_sym][:field_spec]    if field_spec.blank?
-    self.query_params  = DEFAULTS[search_engine.to_sym][:query_params]  if query_params.blank?
-    self.search_url    = DEFAULTS[search_engine.to_sym][:search_url]    if search_url.blank?
+    #self.search_engine = DEFAULTS[:search_engine] if search_engine.blank?
+
+    #self.query_params = "" if query_params.nil?
+    #self.api_method = "" if api_method.nil?
+    #self.field_spec = "" if field_spec.nil?
   end
   # rubocop:enable Metrics/AbcSize
 end

--- a/app/models/try.rb
+++ b/app/models/try.rb
@@ -115,15 +115,7 @@ class Try < ApplicationRecord
 
   private
 
-  # rubocop:disable Metrics/AbcSize
   def set_defaults
     self.name = "Try #{try_number}" if name.blank?
-
-    #self.search_engine = DEFAULTS[:search_engine] if search_engine.blank?
-
-    #self.query_params = "" if query_params.nil?
-    #self.api_method = "" if api_method.nil?
-    #self.field_spec = "" if field_spec.nil?
   end
-  # rubocop:enable Metrics/AbcSize
 end

--- a/lib/es_arg_parser.rb
+++ b/lib/es_arg_parser.rb
@@ -4,6 +4,7 @@ require 'json'
 
 module EsArgParser
   def self.parse query_string, vars = {}
+    query_string = '{}' if query_string.nil?
     # Remove new line characters
     json_string = query_string.gsub(/\\n/, '').gsub(/\\r/, '').gsub(/%/, '%%')
 

--- a/lib/solr_arg_parser.rb
+++ b/lib/solr_arg_parser.rb
@@ -6,6 +6,7 @@ module SolrArgParser
   def self.parse query_string, vars = {}
     # join lines, remove extraneous whitespace
     # rubocop:disable Style/RedundantArgument
+    query_string = '' if query_string.nil?
     query_string = query_string.lines.map(&:strip).join('')
     # rubocop:enable Style/RedundantArgument
 

--- a/test/controllers/api/v1/tries_controller_test.rb
+++ b/test/controllers/api/v1/tries_controller_test.rb
@@ -327,17 +327,17 @@ module Api
           assert_match( /#{created_try.try_number}/,   created_try.name )
 
           assert_not_nil created_try.search_engine
-          assert_not_nil created_try.field_spec
-          assert_not_nil created_try.search_url
-          assert_not_nil created_try.query_params
-          assert_not_nil created_try.escape_query
+          assert_nil created_try.field_spec
+          assert_nil created_try.search_url
+          assert_nil created_try.query_params
+          assert created_try.escape_query
 
-          assert_equal created_try.search_engine,   Try::DEFAULTS[:search_engine]
-          assert_equal created_try.field_spec,      Try::DEFAULTS[:solr][:field_spec]
-          assert_equal created_try.search_url,      Try::DEFAULTS[:solr][:search_url]
-          assert_equal created_try.escape_query,    true
-          assert_equal created_try.api_method,      Try::DEFAULTS[:solr][:api_method]
-          assert_equal created_try.number_of_rows,  10
+          # assert_equal created_try.search_engine,   Try::DEFAULTS[:search_engine]
+          # assert_equal created_try.field_spec,      Try::DEFAULTS[:solr][:field_spec]
+          # assert_equal created_try.search_url,      Try::DEFAULTS[:solr][:search_url]
+          # assert_equal created_try.escape_query,    true
+          # assert_equal created_try.api_method,      Try::DEFAULTS[:solr][:api_method]
+          assert_equal created_try.number_of_rows, 10
         end
 
         describe 'analytics' do
@@ -401,16 +401,7 @@ module Api
             assert_match( /#{created_try.try_number}/,   created_try.name )
 
             assert_not_nil created_try.search_engine
-            assert_not_nil created_try.field_spec
-            assert_not_nil created_try.search_url
-            assert_not_nil created_try.query_params
-            assert_not_nil created_try.escape_query
-
-            assert_equal created_try.search_engine, Try::DEFAULTS[:search_engine]
-            assert_equal created_try.field_spec,    Try::DEFAULTS[:solr][:field_spec]
-            assert_equal created_try.search_url,    Try::DEFAULTS[:solr][:search_url]
-            assert_equal created_try.query_params,  Try::DEFAULTS[:solr][:query_params]
-            assert_equal created_try.escape_query,  true
+            assert_equal created_try.escape_query, true
           end
         end
 
@@ -430,16 +421,9 @@ module Api
             assert_match( /#{created_try.try_number}/,   created_try.name )
 
             assert_not_nil created_try.search_engine
-            assert_not_nil created_try.field_spec
-            assert_not_nil created_try.search_url
-            assert_not_nil created_try.query_params
             assert_not_nil created_try.escape_query
 
             assert_equal created_try.search_engine, 'es'
-            assert_equal created_try.field_spec,    Try::DEFAULTS[:es][:field_spec]
-            assert_equal created_try.search_url,    Try::DEFAULTS[:es][:search_url]
-            assert_equal created_try.api_method,    Try::DEFAULTS[:es][:api_method]
-            assert_equal created_try.query_params,  Try::DEFAULTS[:es][:query_params]
             assert_equal created_try.escape_query,  true
           end
 

--- a/test/lib/es_arg_parser_test.rb
+++ b/test/lib/es_arg_parser_test.rb
@@ -3,6 +3,13 @@
 require 'test_helper'
 
 class EsArgParserTest < ActiveSupport::TestCase
+
+  test 'parses nil value' do
+    params = nil
+    result = EsArgParser.parse(params)
+    assert result.empty?
+  end
+
   test 'parses basic case' do
     params = '{ "foo": 1234 }'
     result = EsArgParser.parse(params)

--- a/test/lib/es_arg_parser_test.rb
+++ b/test/lib/es_arg_parser_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 
 class EsArgParserTest < ActiveSupport::TestCase
-
   test 'parses nil value' do
     params = nil
     result = EsArgParser.parse(params)

--- a/test/lib/solr_arg_parser_test.rb
+++ b/test/lib/solr_arg_parser_test.rb
@@ -3,7 +3,6 @@
 require 'test_helper'
 
 class SolrArgParserTest < ActiveSupport::TestCase
-
   test 'parses nil value' do
     params = nil
     result = SolrArgParser.parse(params)

--- a/test/lib/solr_arg_parser_test.rb
+++ b/test/lib/solr_arg_parser_test.rb
@@ -3,6 +3,13 @@
 require 'test_helper'
 
 class SolrArgParserTest < ActiveSupport::TestCase
+
+  test 'parses nil value' do
+    params = nil
+    result = SolrArgParser.parse(params)
+    assert result.empty?
+  end
+
   test 'parses basic case' do
     params = 'foo=1234'
     result = SolrArgParser.parse(params)

--- a/test/models/case_test.rb
+++ b/test/models/case_test.rb
@@ -114,17 +114,14 @@ class CaseTest < ActiveSupport::TestCase
       assert_equal acase.tries.second.try_number, 1
     end
 
-    test 'sets the default try to the default search engine attributes' do
+    test 'sets the default try to the defaults' do
       acase = Case.create(case_name: 'test case')
 
       default_try = acase.tries.first
       assert_not_nil default_try
 
-      assert_equal default_try.search_engine, Try::DEFAULTS[:search_engine]
-      assert_equal default_try.field_spec,    Try::DEFAULTS[:solr][:field_spec]
-      assert_equal default_try.search_url,    Try::DEFAULTS[:solr][:search_url]
-      assert_equal default_try.query_params,  Try::DEFAULTS[:solr][:query_params]
-      assert_equal default_try.escape_query,  true
+      assert_equal default_try.name, 'Try 1'
+      assert_equal default_try.escape_query, true
     end
   end
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
There is an odd experience if you start out in https mode quepid, and then get a http default solr.  Plus the defaults are defined both on the server side and client side, and they are different!

Lastly, we have some bugs in the default definitions ;-)

## Motivation and Context
refactoring the code for simpliicty, and better onboarding experience.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
