### PR TITLE
Update docker-compose.prod.yml

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,15 +12,11 @@ services:
       - MYSQL_ROOT_PASSWORD=password
     volumes:
       - ./volumes/mysql_data:/var/lib/mysql
-
-#  Redis is used to support sending to Google Analytics events.
-#  Enable this if you are running in Docker and have GA setup.
   redis:
     container_name: quepid_prod_redis
     image: redis:6.0.5
     ports:
       - 6379:6379
-
   app:
     container_name: quepid_prod_app
     image: o19s/quepid:latest
@@ -52,7 +48,7 @@ services:
       - QUERY_LIST_SORTABLE=true
     command: "foreman s -f Procfile"
     ports:
-      - 3000:3000 # Map to port 80 for outside users when you are not using Nginx
+    #  - 80:3000 # Map to port 80 for outside users when you are not using Nginx
     links:
       - mysql
       - redis

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,11 +15,11 @@ services:
 
 #  Redis is used to support sending to Google Analytics events.
 #  Enable this if you are running in Docker and have GA setup.
-#  redis:
-#    container_name: quepid_prod_redis
-#    image: redis:6.0.5
-#    ports:
-#      - 6379:6379
+  redis:
+    container_name: quepid_prod_redis
+    image: redis:6.0.5
+    ports:
+      - 6379:6379
 
   app:
     container_name: quepid_prod_app
@@ -31,7 +31,7 @@ services:
       - RACK_ENV=production
       - RAILS_ENV=production
       - DATABASE_URL=mysql2://root:password@mysql:3306/quepid
-#      - REDIS_URL=redis://redis:6379/1
+      - REDIS_URL=redis://redis:6379/1
       - FORCE_SSL=false
       - MAX_THREADS=2
       - WEB_CONCURRENCY=2
@@ -52,10 +52,21 @@ services:
       - QUERY_LIST_SORTABLE=true
     command: "foreman s -f Procfile"
     ports:
-      - 80:3000 # Map to port 80 for outside users.
+      - 3000:3000 # Map to port 80 for outside users when you are not using Nginx
     links:
       - mysql
-#      - redis
+      - redis
     depends_on:
       - mysql
-#      - redis
+      - redis
+  nginx:
+    image: nginx:1.21.4
+    container_name: quepid_nginx
+    ports:
+      - "443:8443"
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./.ssl/:/etc/nginx/certs
+    links:
+      - app


### PR DESCRIPTION
Changes to make installation guide work with latest version of Quepid

## Description
## Motivation and Context
Current installation guide doesn't work for latest version of Quepid as it needs Redis to work.
## How Has This Been Tested?
On a dedicated Ubuntu server with 1Gb memory and 4 Gb swap using a named domain.
## Screenshots or GIFs (if appropriate):
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
