### PR TITLE
Adding a port to the empty ports list

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -47,7 +47,7 @@ services:
       - EMAIL_SENDER=
       - QUERY_LIST_SORTABLE=true
     command: "foreman s -f Procfile"
-    ports:
+    #ports:
     #  - 80:3000 # Map to port 80 for outside users when you are not using Nginx
     links:
       - mysql

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -47,8 +47,9 @@ services:
       - EMAIL_SENDER=
       - QUERY_LIST_SORTABLE=true
     command: "foreman s -f Procfile"
-    #ports:
+    ports:
     #  - 80:3000 # Map to port 80 for outside users when you are not using Nginx
+      - 3000:3000
     links:
       - mysql
       - redis


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adding the default port to the ports list because if you try to run the `docker-compose.prod.yml` file as-is you will get the error:

```
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.app.ports contains an invalid type, it should be an array
```

