### PR TITLE
Issue-568: Case snapshot isn't successful - Fixed

### DIFF
--- a/app/assets/javascripts/services/querySnapshotSvc.js
+++ b/app/assets/javascripts/services/querySnapshotSvc.js
@@ -72,7 +72,7 @@ angular.module('QuepidApp')
           queriesPayload[query.queryId] = {
             'score': query.currentScore.score,
             'all_rated': query.currentScore.allRated,
-            'number_of_results': query.getNumFound()
+            'number_of_results': query.numFound
           };
 
           // The score can be -- if it hasn't actually been scored, so convert


### PR DESCRIPTION
The case snapshot feature facing some hiccups due to searchResults.js -> getNumfound method not returning value

## Description
Removed the call to the method searchResults.js -> getNumfound() and returned the total numFound for the given query in the snapshot.
 
## Motivation and Context
#568 

## How Has This Been Tested?
This has been tested by being able to create snapshot successfully and also use in the notebook feature

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
