### PR TITLE
Remove legacy attempt to put an index on tries.ancestry colum

### DIFF
--- a/db/migrate/20210917212115_add_ancestry_to_tries.rb
+++ b/db/migrate/20210917212115_add_ancestry_to_tries.rb
@@ -1,6 +1,10 @@
 class AddAncestryToTries < ActiveRecord::Migration[6.1]
   def change
     add_column :tries, :ancestry, :string
-    add_index :tries, :ancestry
+
+    # Please see RemoveIndexFromAncestryColumnInTries migration which removes the add_index.
+    # For folks upgrading from older versions of Quepid, since the add_index eventually gets remove_index,
+    # lets just never add it.   See more info on https://github.com/rails/rails/issues/30305
+    #add_index :tries, :ancestry
   end
 end

--- a/db/migrate/20220407201223_remove_index_from_ancestry_column_in_tries.rb
+++ b/db/migrate/20220407201223_remove_index_from_ancestry_column_in_tries.rb
@@ -5,7 +5,9 @@ class RemoveIndexFromAncestryColumnInTries < ActiveRecord::Migration[6.1]
   # https://dev.mysql.com/doc/refman/8.0/en/innodb-limits.html#:~:text=The%20index%20key%20prefix%20length,REDUNDANT%20or%20COMPACT%20row%20format.
   # we don't need the index as there is only one page that shows this data...
   def up
-    remove_index :tries, :ancestry
+    if index_exists?(:tries, :ancestry)
+      remove_index :tries, :ancestry
+    end
   end
 
   def down


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The index on the tries.ancestry column doesnt work with older mysqls, and isn't used, remove it from migration.

## Motivation and Context
We added it in one migration, `AddAncestryToTries`, and then later, in `RemoveIndexFromAncestryColumnInTries` removed it.  

However, if you have an older Mysql, the initial add will fail.    So let's just remove the first add in `AddAncestryToTries`, and, if you do run the `RemoveIndexFromAncestryColumnInTries`, be smart about dropping the index only if it exists.

## How Has This Been Tested?
manually

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
