### PR TITLE
restore ruby 2.7 method removed in ruby 3 that gabba requires

### DIFF
--- a/config/initializers/uri.rb
+++ b/config/initializers/uri.rb
@@ -1,0 +1,9 @@
+# config/initializers/uri.rb
+
+# Ruby  3 got rid of this method, however the Gabba gem requires it.  Monkeypatch for now ;-(.
+
+module URI
+  def self.escape(*args)
+    DEFAULT_PARSER.escape(*args)
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Logging events to GA has been failing since April 7th as the method `URI.escape` was removed from Ruby 3.0 and Gabba requires it.  This has led to production redis filling up with keys, and now giving errors.

We tweaked redis to throw away old data, so Quepid works, but we want to see if we can get the GoogleAnalyticsJob to work again.

## How Has This Been Tested?
Fired up Quepid, it loaded...  minimally :-( 

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
