### PR TITLE
Fix links to cases and who ran what last score

### DIFF
--- a/app/assets/javascripts/services/teamSvc.js
+++ b/app/assets/javascripts/services/teamSvc.js
@@ -24,6 +24,8 @@ angular.module('QuepidApp')
 
         angular.forEach(this.cases, function(c) {
           // This is really ugly.  We don't use our standard CaseSvc mapping, and probably should!
+          c.caseNo = c.case_id;
+          c.lastScore = c.last_score;
           c.caseName = c.case_name;
           c.ownerName = c.owner_name;
           c.lastTry  = c.last_try_number;

--- a/db/sample_data_seeds.rb
+++ b/db/sample_data_seeds.rb
@@ -313,6 +313,8 @@ print_step "Seeding teams................"
 
 osc = Team.where(owner_id: osc_owner_user.id, name: 'OSC').first_or_create
 osc.members << osc_member_user
+osc.members << realistic_activity_user
+osc.cases << tens_of_queries_case
 print_step "End of seeding teams................"
 
 # Big Cases


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix the mapping from snake_case to camelCase.

## Motivation and Context
Fixes broken links from the teams page to a case and showing the last score info for a case on the case listing page.

## How Has This Been Tested?
manually

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
