### PR TITLE
Let users mark a query/doc pair as "unrateable" so it doesn't come back to haunt them!

### DIFF
--- a/app/controllers/api/v1/books_controller.rb
+++ b/app/controllers/api/v1/books_controller.rb
@@ -20,7 +20,8 @@ module Api
             @csv_array = []
             csv_headers = %w[query docid]
 
-            unique_raters = @book.judgements.collect(&:user).uniq
+            # Only return rateable judgements, filter out the unrateable ones.
+            unique_raters = @book.judgements.rateable.collect(&:user).uniq
             unique_raters.each { |rater| csv_headers << make_csv_safe(rater.nil? ? 'Unknown' : rater.name) }
 
             @csv_array << csv_headers

--- a/app/controllers/judgements_controller.rb
+++ b/app/controllers/judgements_controller.rb
@@ -27,8 +27,21 @@ class JudgementsController < ApplicationController
   def create
     @judgement = Judgement.new(judgement_params)
     @judgement.user = current_user
+    @judgement.unrateable = false
 
     if @judgement.save
+      session['previous_judgement_id'] = @judgement.id
+      redirect_to book_judge_path(@book)
+    else
+      render action: :edit
+    end
+  end
+
+  def unrateable
+    @judgement = Judgement.new(query_doc_pair_id: params[:query_doc_pair_id])
+    @judgement.user = current_user
+
+    if @judgement.mark_unrateable!
       session['previous_judgement_id'] = @judgement.id
       redirect_to book_judge_path(@book)
     else
@@ -58,7 +71,7 @@ class JudgementsController < ApplicationController
   end
 
   def judgement_params
-    params.require(:judgement).permit(:user_id, :rating, :query_doc_pair_id)
+    params.require(:judgement).permit(:user_id, :rating, :query_doc_pair_id, :unrateable)
   end
 
   def find_book

--- a/app/models/judgement.rb
+++ b/app/models/judgement.rb
@@ -6,6 +6,7 @@
 #
 #  id                :bigint           not null, primary key
 #  rating            :float(24)
+#  unrateable        :boolean          default(FALSE)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  query_doc_pair_id :bigint           not null
@@ -24,5 +25,16 @@ class Judgement < ApplicationRecord
   belongs_to :user, optional: true
 
   validates :rating,
-            presence: true
+            presence: true, unless: :unrateable
+
+  scope :rateable, -> { where(unrateable: false) }
+
+  def mark_unrateable
+    self.unrateable = true
+  end
+
+  def mark_unrateable!
+    mark_unrateable
+    save
+  end
 end

--- a/app/views/api/v1/books/_judgements.json.jbuilder
+++ b/app/views/api/v1/books/_judgements.json.jbuilder
@@ -2,4 +2,5 @@
 
 json.judgement_id   judgement.id
 json.rating         judgement.rating
+json.unrateable     judgement.unrateable
 json.user_id        judgement.user_id

--- a/app/views/judgements/_form.html.erb
+++ b/app/views/judgements/_form.html.erb
@@ -356,7 +356,11 @@
       </div>
     </div>
 
-    <div class="float-end"><%= link_to 'Skip this Document', book_judge_path(@book), class: 'btn btn-warning', role: 'button' %></div>
+    <div class="float-end">
+      <%= link_to 'Skip this Document', book_judge_path(@book), class: 'btn btn-info m-1', role: 'button' %>
+      <br/>
+      <%= link_to "Can't Rate This Document", book_query_doc_pair_unrateable_path(@book, query_doc_pair), class: 'btn btn-warning m-1', role: 'button' %>
+    </div>
 
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
     resources :judgements
     resources :query_doc_pairs do
       resources :judgements
+      get 'unrateable' => 'judgements#unrateable'
     end
     get 'judge' => 'judgements#new'
   end

--- a/db/migrate/20230324195152_add_unrateable_to_judgements.rb
+++ b/db/migrate/20230324195152_add_unrateable_to_judgements.rb
@@ -1,0 +1,5 @@
+class AddUnrateableToJudgements < ActiveRecord::Migration[7.0]
+  def change
+    add_column :judgements, :unrateable, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_07_210408) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_24_195152) do
   create_table "annotations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.text "message"
     t.string "source"
@@ -81,6 +81,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_07_210408) do
     t.bigint "query_doc_pair_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "unrateable", default: false
     t.index ["query_doc_pair_id"], name: "index_judgements_on_query_doc_pair_id"
   end
 

--- a/test/fixtures/judgements.yml
+++ b/test/fixtures/judgements.yml
@@ -4,6 +4,7 @@
 #
 #  id                :bigint           not null, primary key
 #  rating            :float(24)
+#  unrateable        :boolean          default(FALSE)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  query_doc_pair_id :bigint           not null

--- a/test/models/judgement_test.rb
+++ b/test/models/judgement_test.rb
@@ -6,6 +6,7 @@
 #
 #  id                :bigint           not null, primary key
 #  rating            :float(24)
+#  unrateable        :boolean          default(FALSE)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  query_doc_pair_id :bigint           not null
@@ -22,7 +23,27 @@
 require 'test_helper'
 
 class JudgementTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  describe 'unrateable attribute behavior' do
+    let(:query_doc_pair) { query_doc_pairs(:one) }
+
+    test 'Saving a judgement marks unrateable as false' do
+      judgement = Judgement.create(query_doc_pair: query_doc_pair, rating: 4.4)
+      assert_not judgement.unrateable
+    end
+
+    test "a judgement with no rating that isn't marked unrateable fails" do
+      judgement = Judgement.create(query_doc_pair: query_doc_pair)
+      assert_not judgement.unrateable
+      assert_not judgement.valid?
+      assert judgement.errors.include?(:rating)
+    end
+
+    test 'mark a judgement with no ratings as unratable works' do
+      judgement = Judgement.create(query_doc_pair: query_doc_pair)
+      judgement.mark_unrateable!
+      assert judgement.unrateable
+
+      assert judgement.valid?
+    end
+  end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
add a unrateable attribute to judgements.

Still need to test out the import lifecycle...

## Motivation and Context
Turns out we need to give users an option to say "not rateable"\


## How Has This Been Tested?
manually.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
