### PR TITLE
allow some basic html to render in the judgement screen

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'omniauth-google-oauth2'
 gem 'omniauth-rails_csrf_protection', '~> 1.0'
 
 gem 'rails-healthcheck', '~> 1.4'
+gem 'rails-html-sanitizer'
 
 gem 'vega', '~> 0.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -473,6 +473,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-erd (~> 1.6)
   rails-healthcheck (~> 1.4)
+  rails-html-sanitizer
   redis (~> 5.0.6)
   responders
   rubocop

--- a/app/views/query_doc_pairs/_document_fields.html.erb
+++ b/app/views/query_doc_pairs/_document_fields.html.erb
@@ -2,7 +2,7 @@
 
 if @document_fields_as_json.nil?
   %>
-  <%= @query_doc_pair.document_fields %>
+  <%= sanitize @query_doc_pair.document_fields %>
   <%
 else
 
@@ -10,22 +10,22 @@ else
   @document_fields_except_title = @document_fields_as_json.except('title')
   %>
   <h5>
-  Title: <%= @title_value %>
+  Title: <%= sanitize @title_value %>
   </h5>
 
   <%
-  @document_fields_as_json.except('title').except('thumb').map do |key, value|
+  @document_fields_as_json.except('title').except('thumb').map do |field, value|
     %>
     <p>
-    <h6><%= key.capitalize.humanize %>:</h6>
+    <h6><%= field.capitalize.humanize %>:</h6>
     <% if value.is_a? String %>
       <% if value.starts_with?('http') %>
         <%= link_to value, value, target: "_blank" %>
       <% else %>
-        <%= value %>
+        <%= sanitize value %>
       <% end %>
     <% elsif value.is_a? Array %>
-      <%= truncate((value.size == 1 ? value.first : value.to_sentence), length: 1000) %>
+      <%= (truncate(sanitize(value.size == 1 ? value.first : value.to_sentence), length: 1000)) %>
     <% end %>
     </p>
     <%

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -3,4 +3,10 @@
 require 'test_helper'
 
 class ApplicationHelperTest < ActionView::TestCase
+
+  test 'A https search url and http quepid requires redirecting to http quepid' do
+    safe_list_sanitizer = Rails::Html::SafeListSanitizer.new
+    assert_equal "Bold no more!  <a href=\"more.html\">See more here</a>...", safe_list_sanitizer.sanitize("Bold</b> no more!  <a href='more.html'>See more here</a>...")
+    assert_equal "<b>Bold</b><i>Trailing italics</i>", safe_list_sanitizer.sanitize("<b>Bold</b><i>Trailing italics")
+  end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -3,10 +3,10 @@
 require 'test_helper'
 
 class ApplicationHelperTest < ActionView::TestCase
-
-  test 'A https search url and http quepid requires redirecting to http quepid' do
+  test 'understand how the rails sanitize command works with some examples of snippetted text' do
     safe_list_sanitizer = Rails::Html::SafeListSanitizer.new
-    assert_equal "Bold no more!  <a href=\"more.html\">See more here</a>...", safe_list_sanitizer.sanitize("Bold</b> no more!  <a href='more.html'>See more here</a>...")
-    assert_equal "<b>Bold</b><i>Trailing italics</i>", safe_list_sanitizer.sanitize("<b>Bold</b><i>Trailing italics")
+    assert_equal 'Bold no more!  <a href="more.html">See more here</a>...',
+                 safe_list_sanitizer.sanitize("Bold</b> no more!  <a href='more.html'>See more here</a>...")
+    assert_equal '<b>Bold</b><i>Trailing italics</i>', safe_list_sanitizer.sanitize('<b>Bold</b><i>Trailing italics')
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When our document snippets have some B, I, etc type tags, allow that to render, but don't allow unbalenced HTML to blow things up!

## Motivation and Context
We definitly don't want ot see the html tags, it's confusing!

## How Has This Been Tested?
unit and manually

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
