### PR TITLE
add keyboard shortcuts for a 0,1,2 custom scorer

### DIFF
--- a/app/views/judgements/_form.html.erb
+++ b/app/views/judgements/_form.html.erb
@@ -205,6 +205,17 @@
         return {"name": "f", "display_name": "f" }
       end
     end
+
+    if max_value == 2
+      if value == 0
+        return {"name": "s", "display_name": "s" }
+      elsif value == 1
+        return {"name": "d", "display_name": "d" }
+      else
+        return {"name": "f", "display_name": "f" }
+      end
+    end
+
     if max_value == 3
       if value == 0
         return {"name": "a", "display_name": "a" }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Add javascript to enable keyboard shortcuts when a custom scorer is configured for 0,1,2.
I made it s,d,f instead of a,s,d.
https://github.com/o19s/quepid/issues/738

## How Has This Been Tested?
Manually

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
