### PR TITLE
Sample scores to reduce volume of data

### DIFF
--- a/app/controllers/analytics/sparkline_controller.rb
+++ b/app/controllers/analytics/sparkline_controller.rb
@@ -12,7 +12,11 @@ module Analytics
     end
 
     def vega_data
-      @scores = Score.where(case_id: @current_user.cases.not_archived.select(:id)).includes([ :case ])
+      @scores = []
+      @current_user.cases.not_archived.recent.limit(8).each do |kase|
+        @scores << kase.scores.sampled(kase.id, 100)
+      end
+      @scores.flatten!
     end
   end
 end

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -106,6 +106,12 @@ class Case < ApplicationRecord
     where(id: ids.uniq)
   }
 
+  # return cases sorted by recently either updated or viewed by the user
+  scope :recent, -> {
+    left_outer_joins(:metadata)
+      .order(Arel.sql('`case_metadata`.`last_viewed_at` DESC, `cases`.`updated_at` DESC'))
+  }
+
   # Not proud of this method, but it's the only way I can get the dependent
   # objects of a Case to actually delete!
   def really_destroy

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -53,6 +53,8 @@ class Score < ApplicationRecord
 
   scope :scored, -> { where('score > ?', 0) }
 
+  # Due to a bug, we have cases with 60,000+ scores, which kills our performance.
+  # This is a terrible workaround till we get that problem fixed.
   # Have to pass in the case_id and the number of records to randomly sample.
   # Yes, needing to pass in the case_id is awkward if you have kase.scorers.sampled(kase.id, 100).count
   scope :sampled, ->(case_id, count) {

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -52,4 +52,14 @@ class Score < ApplicationRecord
   }
 
   scope :scored, -> { where('score > ?', 0) }
+
+  # Have to pass in the case_id and the number of records to randomly sample.
+  # Yes, needing to pass in the case_id is awkward if you have kase.scorers.sampled(kase.id, 100).count
+  scope :sampled, ->(case_id, count) {
+    joins("
+      JOIN (
+        SELECT id FROM case_scores where case_id=#{case_id} ORDER BY RAND() LIMIT #{count}
+      ) as filtered_case_scores ON `case_scores`.`id`=filtered_case_scores.id
+    ")
+  }
 end

--- a/app/views/analytics/sparkline/_event.json.jbuilder
+++ b/app/views/analytics/sparkline/_event.json.jbuilder
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-json.case_id        score.case_id
-json.date           score.created_at
-json.y              score.score
-json.symbol         score.case.case_name

--- a/app/views/analytics/sparkline/vega_data.json.jbuilder
+++ b/app/views/analytics/sparkline/vega_data.json.jbuilder
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-json.array! @scores, partial: 'event', as: :score

--- a/app/views/home/_case_summary.html.erb
+++ b/app/views/home/_case_summary.html.erb
@@ -10,7 +10,7 @@
       </p>
       <!-- Look at https://github.com/ankane/prophet-ruby -->
       <%
-      data = kase.scores.collect{ |score| {ds: score.created_at.to_date.to_fs(:db), y: score.score, datetime: score.created_at.to_date } }.uniq
+      data = kase.scores.sampled(kase.id,100).collect{ |score| {ds: score.created_at.to_date.to_fs(:db), y: score.score, datetime: score.created_at.to_date } }.uniq
       # warning! blunt filter below!
       data = data.uniq { |h| h[:ds] }
       data = data.map {|h| h.transform_keys(&:to_s)  }
@@ -53,7 +53,7 @@
       
       <% 
         # look at https://github.com/ankane/prophet-ruby to remove outliers.
-        data = kase.scores.collect{ |score| {x: score.created_at.to_date.to_fs(:db), y: score.score } }.uniq
+        data = kase.scores.sampled(kase.id, 100).collect{ |score| {x: score.created_at.to_date.to_fs(:db), y: score.score } }.uniq
         # warning! blunt filter below!
         data = data.uniq { |h| h[:x] }
       %>

--- a/app/views/home/_grouped_cases.html.erb
+++ b/app/views/home/_grouped_cases.html.erb
@@ -2,7 +2,7 @@
   <h5 class="card-header">Results for <%=grouped_cases_name %> Cases</h5>
   <div class="card-body">
     
-    <% grouped_cases_data =  grouped_cases.each.collect{|kase| kase.scores.collect{ |score| {x: score.created_at.to_date.to_fs(:db), y: score.score, z: score.case.case_name } }}.flatten.uniq
+    <% grouped_cases_data =  grouped_cases.each.collect{|kase| kase.scores.sampled(kase.id,100).collect{ |score| {x: score.created_at.to_date.to_fs(:db), y: score.score, z: score.case.case_name } }}.flatten.uniq
     %>
     
   <%= Vega.lite


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ensure that when we load scores for a case, we keep it to 100 max, randomly sampled across the full set.

## Motivation and Context
Due to a bug in Quepid front end, we tend to record too many scores per change in the front end.   This means tehre are some cases that have 60,000+ scores.  `myCase.scores` is then loading up a huge amount of data and killing Heroku.

## How Has This Been Tested?
manually in prod.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
