### PR TITLE
increase custom header len to 6000 and migrated db

### DIFF
--- a/app/models/search_endpoint.rb
+++ b/app/models/search_endpoint.rb
@@ -8,7 +8,7 @@
 #  api_method            :string(255)
 #  archived              :boolean          default(FALSE)
 #  basic_auth_credential :string(255)
-#  custom_headers        :string(1000)
+#  custom_headers        :string(6000)
 #  endpoint_url          :string(500)
 #  mapper_code           :text(65535)
 #  name                  :string(255)

--- a/db/migrate/20231201201946_increase_custom_header_length.rb
+++ b/db/migrate/20231201201946_increase_custom_header_length.rb
@@ -1,0 +1,5 @@
+class IncreaseCustomHeaderLength < ActiveRecord::Migration[7.1]
+  def change
+    change_column :search_endpoints, :custom_headers, :string, limit: 6000
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_11_181543) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_01_201946) do
   create_table "annotations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.text "message"
     t.string "source"
@@ -162,7 +162,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_11_181543) do
     t.string "search_engine", limit: 50
     t.string "endpoint_url", limit: 500
     t.string "api_method"
-    t.string "custom_headers", limit: 1000
+    t.string "custom_headers", limit: 6000
     t.boolean "archived", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/test/fixtures/search_endpoints.yml
+++ b/test/fixtures/search_endpoints.yml
@@ -6,7 +6,7 @@
 #  api_method            :string(255)
 #  archived              :boolean          default(FALSE)
 #  basic_auth_credential :string(255)
-#  custom_headers        :string(1000)
+#  custom_headers        :string(6000)
 #  endpoint_url          :string(500)
 #  mapper_code           :text(65535)
 #  name                  :string(255)

--- a/test/models/search_endpoint_test.rb
+++ b/test/models/search_endpoint_test.rb
@@ -8,7 +8,7 @@
 #  api_method            :string(255)
 #  archived              :boolean          default(FALSE)
 #  basic_auth_credential :string(255)
-#  custom_headers        :string(1000)
+#  custom_headers        :string(6000)
 #  endpoint_url          :string(500)
 #  mapper_code           :text(65535)
 #  name                  :string(255)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
New schema migration for the field custom_header in search_endpoints database.

## Motivation and Context
We had custom headers that were longer than the previously set. 

## How Has This Been Tested?
Manually 

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
