### PR TITLE
Reduce logging when creating snapshots

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/integer/time'
+require 'truncating_formatter'
 
 # rubocop:disable Metrics/BlockLength
 Rails.application.configure do
@@ -104,6 +105,8 @@ Rails.application.configure do
       protocol: 'https', # Replace with 'https' if using HTTPS  # we have relative urls so may not be sed
     }
   end
+
+  config.log_formatter = TruncatingFormatter.new
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -11,12 +11,8 @@ Rails.application.config.filter_parameters += [
 ]
 
 Rails.application.config.filter_parameters += [
-  ->(key, _value) { 'query_doc_pair.document_fields' == key.to_s }
-]
-
-Rails.application.config.filter_parameters += [
-  ->(key, _value) { 'snapshot_doc.fields' == key.to_s }
-]
-Rails.application.config.filter_parameters += [
-  ->(key, _value) { 'snapshot_doc.explain' == key.to_s }
+  'query_doc_pair.document_fields',
+  'snapshot.docs',
+  'snapshot_doc.explain',
+  'snapshot_doc.fields'
 ]

--- a/lib/truncating_formatter.rb
+++ b/lib/truncating_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TruncatingFormatter < ActiveSupport::Logger::SimpleFormatter
   def initialize limit: 5_000
     super()

--- a/lib/truncating_formatter.rb
+++ b/lib/truncating_formatter.rb
@@ -1,0 +1,11 @@
+class TruncatingFormatter < ActiveSupport::Logger::SimpleFormatter
+  def initialize limit: 5_000
+    super()
+    @limit = limit
+  end
+
+  def call severity, timestamp, progname, msg
+    truncated_msg = msg.truncate(@limit)
+    super(severity, timestamp, progname, truncated_msg)
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Snapshot creation is slow and clunky to test because the amount of logging it generates. This does two things:
- Filters snapshot.docs to not output the giant POST body
- Sets up TruncatingFormatter in dev mode to shorten SQL logging
