### PR TITLE
fix #958, have the proxy follow redirects

### DIFF
--- a/app/controllers/proxy_controller.rb
+++ b/app/controllers/proxy_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'faraday'
+require 'faraday/follow_redirects'
 
 # rubocop:disable Layout/LineLength
 # rubocop:disable Metrics/AbcSize
@@ -25,8 +26,10 @@ class ProxyController < ApplicationController
     uri = URI.parse(url_param)
     url_without_path = "#{uri.scheme}://#{uri.host}"
     url_without_path += ":#{uri.port}" unless uri.port.nil?
+
     connection = Faraday.new(url: url_without_path) do |faraday|
       # Configure the connection options, such as headers or middleware
+      faraday.response :follow_redirects
       faraday.response :logger, nil, { headers: proxy_debug, bodies: proxy_debug, errors: true }
       faraday.ssl.verify = false
       faraday.request :url_encoded

--- a/test/controllers/proxy_controller_test.rb
+++ b/test/controllers/proxy_controller_test.rb
@@ -63,6 +63,17 @@ class ProxyControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  describe 'should follow 302 redirects' do
+    test 'on a get' do
+      old_url = 'https://example.com/old-url'
+
+      get proxy_fetch_url params: {
+        url: old_url,
+      }
+      assert_response :success
+    end
+  end
+
   describe 'logging of http requests by the proxy' do
     before do
       # Create a StringIO object to capture the output

--- a/test/support/webmock.rb
+++ b/test/support/webmock.rb
@@ -182,6 +182,13 @@ module ActiveSupport
           }
         )
         .to_return(status: 200, body: mock_statedecoded_body)
+
+      redirect_url = 'https://example.com/new-location'
+      stub_request(:get, 'https://example.com/old-url')
+        .to_return(status: 302, headers: { 'Location' => redirect_url })
+
+      stub_request(:get, redirect_url)
+        .to_return(status: 200, body: mock_statedecoded_body)
     end
 
     # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The Quepid proxy doesn't follow redirects, but if we get one...

## Motivation and Context
Working with a custom serach api where their search ends with "http://blahblah/search/?q=tiktok".....    However, do to url parsing in the wizrd, that gets convert to "http://blahblah/search?q=tiktok", which then causes the client to want to do a redirect BACK to the "http://blahblah/search/?q=tiktok".   Sigh.

Easier to change Quepid then the api!

## How Has This Been Tested?
webmock test and manually

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
