### PR TITLE
reduce the logging when running in test mode, errors are expected as …

### DIFF
--- a/app/controllers/proxy_controller.rb
+++ b/app/controllers/proxy_controller.rb
@@ -30,7 +30,7 @@ class ProxyController < ApplicationController
     connection = Faraday.new(url: url_without_path) do |faraday|
       # Configure the connection options, such as headers or middleware
       faraday.response :follow_redirects
-      faraday.response :logger, nil, { headers: proxy_debug, bodies: proxy_debug, errors: true }
+      faraday.response :logger, nil, { headers: proxy_debug, bodies: proxy_debug, errors: true, errors: !Rails.env.test? }
       faraday.ssl.verify = false
       faraday.request :url_encoded
 

--- a/app/controllers/proxy_controller.rb
+++ b/app/controllers/proxy_controller.rb
@@ -30,7 +30,7 @@ class ProxyController < ApplicationController
     connection = Faraday.new(url: url_without_path) do |faraday|
       # Configure the connection options, such as headers or middleware
       faraday.response :follow_redirects
-      faraday.response :logger, nil, { headers: proxy_debug, bodies: proxy_debug, errors: true, errors: !Rails.env.test? }
+      faraday.response :logger, nil, { headers: proxy_debug, bodies: proxy_debug, errors: !Rails.env.test? }
       faraday.ssl.verify = false
       faraday.request :url_encoded
 


### PR DESCRIPTION
…part of tests

<!--- Provide a general summary of your changes in the Title above -->

## Description
don't log errors in Test mode

## Motivation and Context

we generate errors during testing to validate the logger, so don't clustter the logs.  It's okay in Rails according to @reid-rigo  to be aware of a Test environment in our code ;-).