### PR TITLE
Targeted utf8mb3 to utf8mb4 fix for query_doc_pairs.document_field

### DIFF
--- a/db/migrate/20240512144038_fix_query_doc_pairs_document_fields_type.rb
+++ b/db/migrate/20240512144038_fix_query_doc_pairs_document_fields_type.rb
@@ -1,0 +1,6 @@
+class FixQueryDocPairsDocumentFieldsType < ActiveRecord::Migration[7.1]
+  def change    
+    execute "ALTER TABLE query_doc_pairs MODIFY document_fields mediumtext CHARACTER SET utf8mb4"  
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_09_190305) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_12_144038) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -183,7 +183,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_09_190305) do
   create_table "query_doc_pairs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "query_text", limit: 500
     t.integer "position"
-    t.text "document_fields", size: :medium
+    t.text "document_fields", size: :medium, collation: "utf8mb4_0900_ai_ci"
     t.bigint "book_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This just makes the minimal change to support emoji.

## Motivation and Context
This is a targted fix for #1013 issue, that doesn't try to clean up the overall schema....

It is an alternative to #1016 which I am more nervous about rolling out!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
