### PR TITLE
Extend query doc query text length

### DIFF
--- a/app/models/query_doc_pair.rb
+++ b/app/models/query_doc_pair.rb
@@ -10,7 +10,7 @@
 #  notes            :text(65535)
 #  options          :text(65535)
 #  position         :integer
-#  query_text       :string(2048)     not null
+#  query_text       :string(2048)
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  book_id          :bigint           not null

--- a/app/views/admin/announcements/index.html.erb
+++ b/app/views/admin/announcements/index.html.erb
@@ -29,7 +29,8 @@
       <td><%= announcement.announcement_viewed.size %> </td>
       <td>
         <%= link_to 'Edit', edit_admin_announcement_path(announcement) %>
-        <%= link_to 'Delete', admin_announcement_path(announcement), method: :delete, data: { confirm: 'Are you sure?' } %>
+        <%= button_to 'Delete', admin_announcement_path(announcement), method: :delete, class: 'btn btn-sm btn-danger'%>
+
         <%= button_to (announcement.live? ? 'Hide' : 'Make Live'), publish_admin_announcement_path(announcement), method: :post, class: 'btn btn-sm btn-danger' %>
       </td>
     </tr>

--- a/app/views/admin/communal_scorers/show.html.erb
+++ b/app/views/admin/communal_scorers/show.html.erb
@@ -1,7 +1,7 @@
 <h1>Show Scorer</h1>
 
 <%= link_to 'Edit', edit_admin_communal_scorer_path(@scorer) %> |
-<%= link_to 'Destroy', admin_communal_scorer_path(@scorer), method: :delete, data: { confirm: 'Are you sure you want to delete this communal scorer?' } %> |
+<%= button_to 'Destroy', admin_communal_scorer_path(@scorer), method: :delete, class: 'btn btn-sm btn-danger'%>
 <%= link_to 'Back', admin_communal_scorers_path %>
 
 <div class='scorer container'>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -147,7 +147,7 @@
 <%= link_to 'Edit', edit_admin_user_path(@user) %> |
 <%= link_to 'Back', admin_users_path %> |
 <%= button_to (@user.locked? ? 'Unlock' : 'Lock'), admin_user_lock_path(@user), method: :patch, class: 'btn btn-danger btn-sm' %> |
-<%= link_to 'Destroy', admin_user_path(@user), method: :delete, data: { confirm: 'Are you sure you want to delete this user?' } %>
+<%= button_to 'Destroy', admin_user_path(@user), method: :delete, class: 'btn btn-danger btn-sm' %>
 
 <!-- has to be at the end to let JQuery and Heatmap work -->
 <%= javascript_include_tag 'admin_users' %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -146,12 +146,12 @@ This book consists of <%= @book.query_doc_pairs.count %> query document pairs an
       <th scope="row"><%=display_judge_name (row[:judge]) %></th>
       <td>
         <% if row[:judge] %>
-          <%=row[:unrateable] %> <%= link_to_if(row[:judge] && row[:unrateable] > 0, "reset", reset_unrateable_book_path(@book,row[:judge].id), method: :delete, data: { confirm: "Are you sure?" }){ '' } %>
+          <%=row[:unrateable] %> <%= link_to_if(row[:judge] && row[:unrateable] > 0, "reset", reset_unrateable_book_path(@book,row[:judge].id), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }){ '' } %>
         <% end %>
       </td>
       <td>
         <% if row[:judge] %>
-          <%=row[:judge_later] %> <%= link_to_if(row[:judge] && row[:judge_later] > 0, "reset", reset_judge_later_book_path(@book,row[:judge].id), method: :delete, data: { confirm: "Are you sure?" }){ '' } %>
+          <%=row[:judge_later] %> <%= link_to_if(row[:judge] && row[:judge_later] > 0, "reset", reset_judge_later_book_path(@book,row[:judge].id), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }){ '' } %>
         <% end %>
       </td>
       <td><%=row[:judgements] %></td>

--- a/app/views/judgements/edit.html.erb
+++ b/app/views/judgements/edit.html.erb
@@ -10,7 +10,7 @@
   <%= button_to 'Go Back to Previous Query/Doc Pair', edit_book_query_doc_pair_judgement_path(@book, @previous_judgement.query_doc_pair, @previous_judgement), method: :get %>
   <br>
 <% end %>
-<%= button_to 'Exit', book_judgements_path(@book), method: :get, data: { turbo: false } %>
+<%= button_to 'Quit Judging', book_path(@book), method: :get, data: { turbo: false } %>
 
 <br>
 

--- a/app/views/judgements/new.html.erb
+++ b/app/views/judgements/new.html.erb
@@ -54,7 +54,7 @@
     <%= button_to 'Go Back to Previous Query/Doc Pair', edit_book_query_doc_pair_judgement_path(@book, @previous_judgement.query_doc_pair, @previous_judgement), method: :get %>
     <br>
   <% end %>
-  <%= button_to 'Exit', book_path(@book), method: :get, data: { turbo: false } %>
+  <%= button_to 'Quit Judging', book_path(@book), method: :get, data: { turbo: false } %>
   <br>
   
 <% end %>

--- a/app/views/judgements/show.html.erb
+++ b/app/views/judgements/show.html.erb
@@ -5,7 +5,7 @@
 
 <br>
 
-<%= button_to 'Exit', book_path(@judgement.query_doc_pair.book), method: :get %>
+<%= button_to 'Quit Judging', book_path(@judgement.query_doc_pair.book), method: :get %>
 
 <br>
 

--- a/db/migrate/20240626172846_extend_query_text_length.rb
+++ b/db/migrate/20240626172846_extend_query_text_length.rb
@@ -1,0 +1,9 @@
+class ExtendQueryTextLength < ActiveRecord::Migration[7.1]
+  def up
+    change_column :queries, :query_text, :string, limit: 2048
+  end
+
+  def down
+    change_column :queries, :query_text, :string, limit: 500
+  end
+end

--- a/db/migrate/20240626173902_extend_query_doc_query_text_length.rb
+++ b/db/migrate/20240626173902_extend_query_doc_query_text_length.rb
@@ -1,0 +1,11 @@
+class ExtendQueryDocQueryTextLength < ActiveRecord::Migration[7.1]
+  def up
+    # this index prevents us from having long queries.  Let's deal with it another way.
+    remove_index :query_doc_pairs, [:query_text, :doc_id, :book_id]
+    change_column :query_doc_pairs, :query_text, :string, limit: 2048
+  end
+
+  def down
+    change_column :query_doc_pairs, :query_text, :string, limit: 500
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_17_144746) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_26_173902) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -181,7 +181,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_17_144746) do
   end
 
   create_table "query_doc_pairs", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
-    t.string "query_text", limit: 2048, null: false
+    t.string "query_text", limit: 2048
     t.integer "position"
     t.text "document_fields", size: :medium, collation: "utf8mb4_0900_ai_ci"
     t.bigint "book_id", null: false

--- a/test/fixtures/query_doc_pairs.yml
+++ b/test/fixtures/query_doc_pairs.yml
@@ -8,7 +8,7 @@
 #  notes            :text(65535)
 #  options          :text(65535)
 #  position         :integer
-#  query_text       :string(2048)     not null
+#  query_text       :string(2048)
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  book_id          :bigint           not null

--- a/test/models/query_doc_pair_test.rb
+++ b/test/models/query_doc_pair_test.rb
@@ -10,7 +10,7 @@
 #  notes            :text(65535)
 #  options          :text(65535)
 #  position         :integer
-#  query_text       :string(2048)     not null
+#  query_text       :string(2048)
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
 #  book_id          :bigint           not null


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This actually restores the database migration to support really long query_text...  like those queries we see in RAG.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
