### PR TITLE
Fix login and redirect problem with Keycloak

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 # Be sure to restart your server when you modify this file.
-Rails.application.config.session_store :cookie_store, key: '_quepid_session', same_site: :strict
+Rails.application.config.session_store :cookie_store, key: '_quepid_session', same_site: :lax


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes a problem when logging into quepid with Keycloak. 

## Description
<!--- Describe your changes in detail -->
Reverted `same_site: :strict` to `same_site: :lax`, which was introduced in v7.17.1.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With Firefox it was not possible to login into quepid and in Chrome the redirect after authentication in Keycloak did not work properly.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Applied the fix in quepid instance and logging in over Keycloak worked again with Firefox as well as redirection in Chrome after successful authentication.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
