### PR TITLE
Move towards import maps

### DIFF
--- a/app/assets/javascripts/ace_config.js
+++ b/app/assets/javascripts/ace_config.js
@@ -1,5 +1,0 @@
-'use strict';
-
-/*global ace */
-ace.config.set('workerPath', 'javascripts/ace');
-ace.config.set('themePath',  'javascripts/ace');

--- a/app/assets/javascripts/core.js
+++ b/app/assets/javascripts/core.js
@@ -33,11 +33,7 @@
 //= require cookies_eu
 
 //= require angular/angular
-//= require ace-builds/src-min-noconflict/ace
-//= require ace-builds/src-min-noconflict/ext-language_tools
-//= require ace-builds/src-min-noconflict/mode-json
-//= require ace-builds/src-min-noconflict/mode-javascript
-//= require ace-builds/src-min-noconflict/mode-lucene
+
 
 //= require vega
 //= require vega-lite
@@ -79,8 +75,6 @@
 //= require_tree ./values
 //= require_tree ../templates
 //= require_tree ./components
-//= require footer
 //= require tether-shepherd/dist/js/tether
 //= require tether-shepherd/dist/js/shepherd
 //= require tour
-//= require ace_config

--- a/app/assets/javascripts/core.js
+++ b/app/assets/javascripts/core.js
@@ -71,7 +71,6 @@
 //= require_tree ./factories
 //= require_tree ./filters
 //= require_tree ./interceptors
-//= require_tree ./services
 //= require_tree ./values
 //= require_tree ../templates
 //= require_tree ./components

--- a/app/assets/javascripts/core.js
+++ b/app/assets/javascripts/core.js
@@ -75,6 +75,3 @@
 //= require_tree ./values
 //= require_tree ../templates
 //= require_tree ./components
-//= require tether-shepherd/dist/js/tether
-//= require tether-shepherd/dist/js/shepherd
-//= require tour

--- a/app/assets/stylesheets/core.css.scss
+++ b/app/assets/stylesheets/core.css.scss
@@ -37,7 +37,7 @@
 @import "admin2";
 
 // Tour/Guides
-@import "tether-shepherd/dist/css/shepherd-theme-arrows";
+@import "shepherd.js/dist/css/shepherd";
 @import "tour";
 
 // Screens

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,29 +2,27 @@
 
 class PagesController < ApplicationController
   skip_before_action :require_login
-  skip_before_action :verify_authenticity_token, only: [ :theme_textmate, :mode_json ]
+  skip_before_action :verify_authenticity_token, only: [:worker_javascript, :worker_json ]
   skip_before_action :check_for_announcement
   # before_action :check_page, only: [:show]
 
   # def show
   # render template: "pages/#{params[:page]}"
   # end
-
-  # this is how we deal with the ACE editor wanting this specific file.
-
-  def theme_textmate
-    path = 'node_modules/ace-builds/src-min-noconflict/theme-textmate.js'
+  
+  # ace wants to always load the workers from the root "/" end point.  So /worker-javascript.js and /worker-json.s
+  # It defines it's own full path, so we can't override it with one from importmaps
+  def worker_javascript
+    path = 'node_modules/ace-builds/src-min-noconflict/worker-javascript.js'
     file_contents = File.read(path)
     render js: file_contents, content_type: Mime::Type.lookup('application/javascript')
   end
-
-  # In production this route kicks in, and in dev we load /assets/mode-json.js from
-  # the /app/assets/javascripts/mode-json.js location..
-  def mode_json
-    path = 'node_modules/ace-builds/src-min-noconflict/mode-json.js'
+  
+  def worker_json
+    path = 'node_modules/ace-builds/src-min-noconflict/worker-json.js'
     file_contents = File.read(path)
     render js: file_contents, content_type: Mime::Type.lookup('application/javascript')
-  end
+  end  
 
   private
 

--- a/app/javascript/application2.js
+++ b/app/javascript/application2.js
@@ -6,8 +6,20 @@
 // Note: the file in vendor/javascript/vendored-local-time.js is the one that was downloaded via
 // importmap pin.  See https://github.com/basecamp/local_time/issues/113 for others who suggested
 // remaining it
-import "@hotwired/turbo-rails"
-import LocalTime from "local-time"
-LocalTime.start()
+//import "@hotwired/turbo-rails"
+//import LocalTime from "local-time"
+//LocalTime.start()
 
-window.Turbo.setProgressBarDelay(1);
+//window.Turbo.setProgressBarDelay(1);
+
+import "ace"; // Import the Ace library
+import "ext-language_tools"; // Import the JavaScript mode
+import "mode-json"; // Import the Monokai theme
+import "mode-javascript";
+import "mode-lucene";
+import "theme-chrome";
+//import "worker-javascript"
+//import "ace_config"
+
+
+import "footer"

--- a/app/javascript/application2.js
+++ b/app/javascript/application2.js
@@ -23,3 +23,30 @@ import "theme-chrome";
 
 //import "tour" // Can't figure out how to get Shepherd.js to load
 import "footer"
+
+// Importing services
+import "annotationsSvc";
+import "bookSvc";
+import "bootstrapSvc";
+import "caseCSVSvc";
+import "caseSvc";
+import "caseTryNavSvc";
+import "configurationSvc";
+import "diffResultsSvc";
+import "docCacheSvc";
+import "importRatingsSvc";
+import "paneSvc";
+import "queriesSvc";
+import "querySnapshotSvc";
+import "queryViewSvc";
+import "rateBulkSvc";
+import "rateElementSvc";
+import "ratingsStoreSvc";
+import "scorerControllerActionsSvc";
+import "scorerSvc";
+import "searchEndpointSvc";
+import "searchErrorTranslatorSvc";
+import "settingsSvc";
+import "teamSvc";
+import "userSvc";
+import "varExtractorSvc";

--- a/app/javascript/application2.js
+++ b/app/javascript/application2.js
@@ -21,5 +21,5 @@ import "theme-chrome";
 //import "worker-javascript"
 //import "ace_config"
 
-
+//import "tour" // Can't figure out how to get Shepherd.js to load
 import "footer"

--- a/app/views/layouts/core.html.erb
+++ b/app/views/layouts/core.html.erb
@@ -11,6 +11,8 @@
 <%= stylesheet_link_tag 'ng-json-explorer/dist/angular-json-explorer', 'angular-wizard/dist/angular-wizard', 'ng-tags-input/build/ng-tags-input.min.css', 'ng-tags-input/build/ng-tags-input.bootstrap.min.css', media: 'all' %>
 <%= csrf_meta_tags %>
 
+<%= javascript_importmap_tags 'application2' %>
+
 <base href="<%= ENV['RAILS_RELATIVE_URL_ROOT'] %>/">
 </head>
 <body ng-app="QuepidApp">

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -13,3 +13,5 @@ pin "mode-javascript", to: "ace-builds/src-min-noconflict/mode-javascript.js"
 pin "mode-lucene", to: "ace-builds/src-min-noconflict/mode-lucene.js"
 pin "theme-chrome", to: "ace-builds/src-min-noconflict/theme-chrome.js"
 pin 'footer', preload: true
+
+# pin 'tour' // Can't figure out how to get Shepherd.js to load

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -3,5 +3,13 @@
 # Pin npm packages by running ./bin/importmap
 
 pin 'application2', preload: true
-pin 'local-time', to: 'vendored-local-time.js' # @3.0.2
-pin '@hotwired/turbo-rails', to: 'turbo.min.js'
+#pin 'local-time', to: 'vendored-local-time.js' # @3.0.2
+#pin '@hotwired/turbo-rails', to: 'turbo.min.js'
+
+pin "ace", to: "ace-builds/src-min-noconflict/ace.js"
+pin "ext-language_tools", to: "ace-builds/src-min-noconflict/ext-language_tools.js"
+pin "mode-json", to: "ace-builds/src-min-noconflict/mode-json.js"
+pin "mode-javascript", to: "ace-builds/src-min-noconflict/mode-javascript.js"
+pin "mode-lucene", to: "ace-builds/src-min-noconflict/mode-lucene.js"
+pin "theme-chrome", to: "ace-builds/src-min-noconflict/theme-chrome.js"
+pin 'footer', preload: true

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -14,4 +14,10 @@ pin "mode-lucene", to: "ace-builds/src-min-noconflict/mode-lucene.js"
 pin "theme-chrome", to: "ace-builds/src-min-noconflict/theme-chrome.js"
 pin 'footer', preload: true
 
+#pin 'services/annotationsSvc.js'
+# Pin each JavaScript file in the app/javascript/custom directory
+Dir.glob(Rails.root.join('app', 'assets', 'javascripts','services', '*.js')).each do |file|
+  pin File.basename(file, '.js'), to: "services/#{File.basename(file)}"
+end
+
 # pin 'tour' // Can't figure out how to get Shepherd.js to load

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -19,6 +19,22 @@ Rails.application.config.assets.precompile += %w[ core.css core.js admin.css adm
                                                   analytics.js ]
 Rails.application.config.assets.precompile += %w[ application_spec.js ]
 
+# need to precompile stuff for importmaps
+# In the past we made a giant single jS file, and then precompiled it
+# but now we list each individaul file.
+Rails.application.config.assets.precompile += %w[ footer.js ace_config.js ]
+
+# JS from node modules
+Rails.application.config.assets.precompile += %w[
+  ace-builds/src-min-noconflict/ace.js
+  ace-builds/src-min-noconflict/ext-language_tools.js
+  ace-builds/src-min-noconflict/mode-json.js
+  ace-builds/src-min-noconflict/mode-javascript.js
+  ace-builds/src-min-noconflict/mode-lucene.js
+  ace-builds/src-min-noconflict/theme-chrome.js
+  ace-builds/src-min-noconflict/worker-javascript.js
+]
+
 # CSS from node modules
 Rails.application.config.assets.precompile += %w[
   ng-json-explorer/dist/angular-json-explorer.css
@@ -26,6 +42,7 @@ Rails.application.config.assets.precompile += %w[
   ng-tags-input/build/ng-tags-input.min.css
   ng-tags-input/build/ng-tags-input.bootstrap.min.css
 ]
+
 
 # For some reason the mapping in core.css.scss isn't working, so do this.'
 Rails.application.config.assets.paths << Rails.root.join('node_modules/bootstrap-icons/font')

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -24,6 +24,16 @@ Rails.application.config.assets.precompile += %w[ application_spec.js ]
 # but now we list each individaul file.
 Rails.application.config.assets.precompile += %w[ footer.js ace_config.js ]
 
+# JS from AngularJS app
+Dir.glob(Rails.root.join('app', 'assets', 'javascripts', 'services', '*.js')).each do |file|
+  #relative_path = Pathname.new(file).relative_path_from(Pathname.new(Rails.root)).to_s
+  #puts "File.basename(file): #{relative_path}"
+  Rails.application.config.assets.precompile << "services/#{File.basename(file, '.js')}"
+end
+Rails.application.config.assets.precompile += %w[
+  services/annotationsSvc.js
+]
+
 # JS from node modules
 Rails.application.config.assets.precompile += %w[
   ace-builds/src-min-noconflict/ace.js

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -272,8 +272,8 @@ Rails.application.routes.draw do
   # get '*page' => 'pages#show'
   #
 
-  # Deal with ACE Editor really really wanting this file here
-  get '/javascripts/ace/theme-textmate.js' => 'pages#theme_textmate'
-  get '/assets/mode-json.js' => 'pages#mode_json'
+  # Deal with ACE Editor really really wanting workers to be in specific urls.
+  get '/worker-javascript.js' => 'pages#worker_javascript'
+  get '/worker-json.js' => 'pages#worker_json'
 end
 # rubocop:enable Metrics/BlockLength

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "ngclipboard": "^2.0.0",
     "party-js": "^2.2.0",
     "popper.js": "^1.16.1",
+    "shepherd.js": "^14.1.0", 
     "splainer-search": "2.33.0",
-    "tether-shepherd": "latest",
     "vega": "^5.27.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,6 +30,26 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
+"@floating-ui/core@^1.6.0":
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.8.tgz#aa43561be075815879305965020f492cdb43da12"
+  integrity sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==
+  dependencies:
+    "@floating-ui/utils" "^0.2.8"
+
+"@floating-ui/dom@^1.6.5":
+  version "1.6.12"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.12.tgz#6333dcb5a8ead3b2bf82f33d6bc410e95f54e556"
+  integrity sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==
+  dependencies:
+    "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.8"
+
+"@floating-ui/utils@^0.2.8":
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.8.tgz#21a907684723bbbaa5f0974cf7730bd797eb8e62"
+  integrity sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==
+
 "@popperjs/core@^2.11.6":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
@@ -60,6 +80,11 @@
   integrity sha512-N4Lb2xW+6OFeE8f0nvOo6vigVM3VWlEYO6+wPBgc26CFstVG2zXbj4SV88JW3hZSArcCVox726hbXogwMV7hcg==
   dependencies:
     spark-md5 "^3.0.1"
+
+"@scarf/scarf@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-1.3.0.tgz#f8c75560d0dace4452dee1e31995e6396e61f3ee"
+  integrity sha512-lHKK8M5CTcpFj2hZDB3wIjb0KAbEOgDmiJGDv1WBRfQgRm/a8/XMEkG/N1iM01xgbUDsPQwi42D+dFo1XPAKew==
 
 "@socket.io/component-emitter@~3.1.0":
   version "3.1.2"
@@ -870,6 +895,11 @@ debug@4, debug@^4.1.1, debug@^4.3.4, debug@^4.3.6, debug@^4.3.7, debug@~4.3.1, d
   integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
   dependencies:
     ms "^2.1.3"
+
+deepmerge-ts@^7.1.1:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/deepmerge-ts/-/deepmerge-ts-7.1.3.tgz#9a07e5e7dff7afa8ddf48b90b7161ca9439ca4ca"
+  integrity sha512-qCSH6I0INPxd9Y1VtAiLpnYvz5O//6rCfJXKk0z66Up9/VOSr+1yS8XSKA5IWRxjocFGlzPyaZYe+jxq7OOLtQ==
 
 define-data-property@^1.1.4:
   version "1.1.4"
@@ -1977,6 +2007,15 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
+shepherd.js@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/shepherd.js/-/shepherd.js-14.1.0.tgz#bbfccec9027426051976b6c98de8481c3de84cf9"
+  integrity sha512-nFJElQ0KLF0zaDBINHpnUeBQVEOfRPyDrYkJkOj4ziQIyvSkQeJogEIAWwtpCEIxZOWNXxMYXcPVErjGE9EP6Q==
+  dependencies:
+    "@floating-ui/dom" "^1.6.5"
+    "@scarf/scarf" "^1.3.0"
+    deepmerge-ts "^7.1.1"
+
 side-channel@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.6.tgz#abd25fb7cd24baf45466406b1096b7831c9215f2"
@@ -2143,18 +2182,6 @@ tar-stream@^3.1.5:
     b4a "^1.6.4"
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
-
-tether-shepherd@latest:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/tether-shepherd/-/tether-shepherd-1.8.1.tgz#4fd9b2fdd9059f04b6c4249456d5ae145a3e9223"
-  integrity sha512-KO0GWox9vCwTV2V/gILhV+rlABnDSMGvkUKJ63h0rRqzsXPFR4A2/xpgADgcooiqGXyK4zI8ZmJ/lpM8MOfMxw==
-  dependencies:
-    tether "^1.0.1"
-
-tether@^1.0.1:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/tether/-/tether-1.4.7.tgz#d56a818590d8fe72e387f77a67f93ab96d8e1fb2"
-  integrity sha512-Z0J1aExjoFU8pybVkQAo/vD2wfSO63r+XOPfWQMC5qtf1bI7IWqNk4MiyBcgvvnY8kqnY06dVdvwTK2S3PU/Fw==
 
 text-decoder@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
This is a spike to see if we can load the AngularJS via import maps..   It still uses sprockets to handle making the public/assets/myfile-timestamped.js.   Presumably propshaft will take that over!