### PR TITLE
swap to released version of Bullet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,8 +58,7 @@ gem 'vega'
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: [ :mri, :windows ], require: 'debug/prelude'
-  # gem 'bullet' not Rails 8 compatible
-  gem 'bullet', git: 'https://github.com/adiaz04/bullet.git', branch: 'main'
+  gem 'bullet'
   gem 'memory_profiler'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/adiaz04/bullet.git
-  revision: f4b09256b8151c290f6bf4cd6c7aadd829435128
-  branch: main
-  specs:
-    bullet (7.2.0)
-      activesupport (>= 3.0.0)
-      uniform_notifier (~> 1.11)
-
-GIT
   remote: https://github.com/epugh/angular-rails-templates.git
   revision: c45588bec096089e51d84ee3461736f000dff87a
   branch: bump_rails_8
@@ -121,6 +112,9 @@ GEM
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     builder (3.3.0)
+    bullet (8.0.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     cal-heatmap-rails (3.6.2)
     capybara (3.40.0)
       addressable
@@ -548,7 +542,7 @@ DEPENDENCIES
   apipie-rails (~> 1.2)
   bcrypt (~> 3.1.7)
   bootsnap
-  bullet!
+  bullet
   cal-heatmap-rails (~> 3.6)
   capybara
   colorize

--- a/test/controllers/api/v1/bulk/queries_controller_test.rb
+++ b/test/controllers/api/v1/bulk/queries_controller_test.rb
@@ -87,7 +87,7 @@ module Api
               post :create, params: data
             end
 
-            assert result.real < 5, "Expecting less than 5 seconds. Elapsed time: #{result.real} seconds\n"
+            assert result.real < 8, "Expecting less than 8 seconds. Elapsed time: #{result.real} seconds\n"
             # puts "Elapsed time: #{result.real} seconds\n"
 
             acase.reload


### PR DESCRIPTION
Bullet is now on Rails 8..  so let's use it.