### PR TITLE
Need to track which scorer provided the score!

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,8 @@
+[
+  {
+    "label": "test $ZED_RELATIVE_FILE:$ZED_ROW",
+    "command": "bin/docker r rails",
+    "args": ["test", "\"$ZED_RELATIVE_FILE:$ZED_ROW\""],
+    "tags": ["ruby-test"]
+  }
+]

--- a/app/controllers/api/v1/case_scores_controller.rb
+++ b/app/controllers/api/v1/case_scores_controller.rb
@@ -24,7 +24,7 @@ module Api
       end
 
       def index
-        @scores = @case.scores.includes(:annotation, :user).limit(10)
+        @scores = @case.scores.where(scorer: @case.scorer).includes(:annotation, :user).limit(10)
 
         respond_with @scores
       end
@@ -44,7 +44,8 @@ module Api
         service = CaseScoreManager.new @case
 
         begin
-          score_data  = { user_id: current_user.id }.merge(score_params)
+          scorer_id = @case.scorer.present? ? @case.scorer.id : nil
+          score_data  = { user_id: current_user.id, scorer_id: scorer_id }.merge(score_params)
           @score      = service.update score_data
 
           unless @score

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -48,14 +48,14 @@ class HomeController < ApplicationController
 
       puts "we have decided we are stale for case #{@case.id} at #{@case.updated_at}"
 
-      sampled_scores = @case.scores.sampled(@case.id, 25)
+      scores = @case.scores.where(scorer: @case.scorer)
 
-      unless sampled_scores.empty?
-        @for_single_day = sampled_scores.first.updated_at.all_day.overlaps?(sampled_scores.last.updated_at.all_day)
+      unless scores.empty?
+        @for_single_day = scores.first.updated_at.all_day.overlaps?(scores.last.updated_at.all_day)
         @final = @case.scores.last_one.score
       end
 
-      data = sampled_scores.collect do |score|
+      data = scores.collect do |score|
         if @for_single_day
           { ds: score.updated_at.to_fs(:db), y: score.score, datetime: score.updated_at }
         else

--- a/app/jobs/judgement_from_rating_job.rb
+++ b/app/jobs/judgement_from_rating_job.rb
@@ -8,8 +8,9 @@ class JudgementFromRatingJob < ApplicationJob
     book = query.case.book
     if book
       query_doc_pair = book.query_doc_pairs.find_or_create_by query_text: rating.query.query_text, doc_id: rating.doc_id
+      query.
 
-      judgement = query_doc_pair.judgements.find_or_initialize_by(user: user)
+        judgement = query_doc_pair.judgements.find_or_initialize_by(user: user)
       judgement.rating = rating.rating
       judgement.save!
     end

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -12,6 +12,7 @@
 #  updated_at    :datetime
 #  annotation_id :integer
 #  case_id       :integer
+#  scorer_id     :bigint
 #  try_id        :integer
 #  user_id       :integer
 #
@@ -19,6 +20,7 @@
 #
 #  case_id                          (case_id)
 #  index_case_scores_annotation_id  (annotation_id) UNIQUE
+#  index_case_scores_on_scorer_id   (scorer_id)
 #  support_last_score               (updated_at,created_at,id)
 #  user_id                          (user_id)
 #
@@ -39,6 +41,7 @@ class Score < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :try
   belongs_to :annotation, optional: true
+  belongs_to :scorer, optional: true # optional for legacy reasons, we have old data.
 
   # Validations
 

--- a/app/models/scorer.rb
+++ b/app/models/scorer.rb
@@ -32,6 +32,8 @@ class Scorer < ApplicationRecord
   has_many   :snapshots,
              dependent: :nullify
 
+  has_many :scores, dependent: :nullify
+
   # too late now!
   # rubocop:disable Rails/HasAndBelongsToMany
   has_and_belongs_to_many :teams,

--- a/app/services/case_score_manager.rb
+++ b/app/services/case_score_manager.rb
@@ -69,6 +69,7 @@ class CaseScoreManager
     return false if last_score.try.nil?
     return false if last_score.try.try_number != score_data[:try_number].to_i
     return false if last_score.user_id != score_data[:user_id].to_i
+    return false if last_score.scorer_id != score_data[:scorer_id].to_i
 
     true
   end

--- a/app/services/fetch_service.rb
+++ b/app/services/fetch_service.rb
@@ -198,7 +198,7 @@ class FetchService
         { score: snapshot_query.score, text: snapshot_query.query.query_text }
     end
 
-    # Opportunity here to fix the averageing logic
+    # Opportunity here to fix the averaging logic
     # at the case level.
     if queries_detail.any?
       scores = queries_detail.values.map { |q| q[:score] }
@@ -211,6 +211,7 @@ class FetchService
       all_rated:  nil,
       queries:    queries_detail,
       score:      average_score,
+      scorer_id:  @case.scorer.id,
       try_number: try.try_number,
       user_id:    nil,
     }

--- a/bin/docker
+++ b/bin/docker
@@ -17,7 +17,7 @@ Dir.chdir APP_ROOT do
   when 'console', 'c'
     system 'docker compose run --rm app rails console '  # add -e test for test environment
   when 'run', 'r'
-    system "docker compose run --rm app #{rest.shelljoin()}"
+    system "docker compose --progress=quiet run --rm app #{rest.shelljoin()}"
   when 'daemon', 'q'
     system 'docker compose run -d --service-ports app foreman s -f Procfile'
   when 'destroy', 'd'

--- a/db/migrate/20250204192202_add_scorer_to_scores.rb
+++ b/db/migrate/20250204192202_add_scorer_to_scores.rb
@@ -1,0 +1,5 @@
+class AddScorerToScores < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :case_scores, :scorer, null: true, foreign_key: false
+  end
+end

--- a/db/migrate/20250204192632_populate_last_scorer_on_case_scores.rb
+++ b/db/migrate/20250204192632_populate_last_scorer_on_case_scores.rb
@@ -1,0 +1,16 @@
+class PopulateLastScorerOnCaseScores < ActiveRecord::Migration[8.0]
+  # We can't assume that all the scores are from the same scorer, but we can assume the most recent used the current Case Scorer
+  def up
+    Case.find_each do |kase|
+      unless kase.last_score.blank?       
+        score = kase.last_score
+        score.scorer = kase.scorer
+        score.save!     
+      end
+    end
+  end
+  
+  def down
+    Score.update_all(scorer_id: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_19_130032) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_04_192632) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -233,8 +233,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_19_130032) do
     t.binary "queries", size: :medium
     t.integer "annotation_id"
     t.datetime "updated_at", precision: nil
+    t.bigint "scorer_id"
     t.index ["annotation_id"], name: "index_case_scores_annotation_id", unique: true
     t.index ["case_id"], name: "case_id"
+    t.index ["scorer_id"], name: "index_case_scores_on_scorer_id"
     t.index ["updated_at", "created_at", "id"], name: "support_last_score"
     t.index ["user_id"], name: "user_id"
   end

--- a/lib/tasks/sample_data.thor
+++ b/lib/tasks/sample_data.thor
@@ -198,6 +198,7 @@ class SampleData < Thor
         user:       realistic_activity_user,
         try:        new_try,
         score:      (0.01 * counter),
+        scorer:     tens_of_queries_case.scorer,
         created_at: DateTime.now - (30 - counter).days,
         updated_at: DateTime.now - (30 - counter).days,
       }
@@ -290,6 +291,7 @@ class SampleData < Thor
           user:       realistic_activity_user,
           try:        new_try,
           score:      (0.01 * counter),
+          scorer:     kase.scorer,
           created_at: DateTime.now - (days_of_experimentation - counter).days,
           updated_at: DateTime.now - (days_of_experimentation - counter).days,
         }

--- a/test/controllers/api/v1/case_scores_controller_test.rb
+++ b/test/controllers/api/v1/case_scores_controller_test.rb
@@ -78,12 +78,13 @@ module Api
         end
 
         test 'updates existing score and does not create a new one if score is super recent' do
-          old_score = acase.scores.create(user_id: user.id, try_id: first_try.id, score: 80)
+          old_score = acase.scores.create(user_id: user.id, try_id: first_try.id, score: 80, scorer_id: acase.scorer.id)
 
           data = {
             score:      (1..100).to_a.sample,
             all_rated:  [ true, false ].sample,
             try_number: first_try.try_number,
+            scorer_id:  acase.scorer.id,
           }
 
           assert_no_difference 'acase.scores.count' do
@@ -145,8 +146,10 @@ module Api
 
         test 'returns an array of all the case scores' do
           now = DateTime.current
-          acase.scores.create(try_id: first_try.id,   user_id: user.id, created_at: now, score: 80)
-          acase.scores.create(try_id: second_try.id,  user_id: user.id, created_at: now, score: 80)
+          acase.scores.create(try_id: first_try.id,   user_id: user.id, created_at: now, score: 80,
+                              scorer_id: acase.scorer.id)
+          acase.scores.create(try_id: second_try.id,  user_id: user.id, created_at: now, score: 80,
+                              scorer_id: acase.scorer.id)
 
           get :index, params: { case_id: acase.id }
 

--- a/test/fixtures/cases.yml
+++ b/test/fixtures/cases.yml
@@ -130,6 +130,7 @@ score_case:
   owner:     :random
   case_name: Score Case
   archived:  false
+  scorer:   :case_default_scorer
 
 other_score_case:
   owner:     :random
@@ -205,6 +206,7 @@ case_with_score:
   owner:     :random
   case_name: case_with_score
   archived:  false
+  scorer:    case_default_scorer
 
 case_owned_by_team_owner:
   owner:     :team_owner

--- a/test/fixtures/scores.yml
+++ b/test/fixtures/scores.yml
@@ -10,6 +10,7 @@
 #  updated_at    :datetime
 #  annotation_id :integer
 #  case_id       :integer
+#  scorer_id     :bigint
 #  try_id        :integer
 #  user_id       :integer
 #
@@ -17,6 +18,7 @@
 #
 #  case_id                          (case_id)
 #  index_case_scores_annotation_id  (annotation_id) UNIQUE
+#  index_case_scores_on_scorer_id   (scorer_id)
 #  support_last_score               (updated_at,created_at,id)
 #  user_id                          (user_id)
 #

--- a/test/fixtures/scores.yml
+++ b/test/fixtures/scores.yml
@@ -83,6 +83,7 @@ score_for_try_1:
   try:        :for_case_with_score_try_1
   score:      65
   all_rated:  false
+  scorer:     :case_default_scorer
 
 score_for_try_2:
   case:       :case_with_score
@@ -90,3 +91,4 @@ score_for_try_2:
   try:        :for_case_with_score_try_2
   score:      75
   all_rated:  false
+  scorer:     :case_default_scorer

--- a/test/models/score_test.rb
+++ b/test/models/score_test.rb
@@ -12,6 +12,7 @@
 #  updated_at    :datetime
 #  annotation_id :integer
 #  case_id       :integer
+#  scorer_id     :bigint
 #  try_id        :integer
 #  user_id       :integer
 #
@@ -19,6 +20,7 @@
 #
 #  case_id                          (case_id)
 #  index_case_scores_annotation_id  (annotation_id) UNIQUE
+#  index_case_scores_on_scorer_id   (scorer_id)
 #  support_last_score               (updated_at,created_at,id)
 #  user_id                          (user_id)
 #

--- a/test/services/case_score_manager_test.rb
+++ b/test/services/case_score_manager_test.rb
@@ -123,7 +123,9 @@ class CaseScoreManagerTest < ActiveSupport::TestCase
       let(:the_case) { cases(:case_with_score) }
 
       test 'updates existing score if last score was last updated less than 5 min ago' do
-        the_case.scores.update_all user_id: user.id, try_id: the_try.id, updated_at: 1.minute.ago
+        the_case.scores.update_all user_id: user.id, try_id: the_try.id, scorer_id: the_case.scorer.id,
+                                   updated_at: 1.minute.ago
+        score_data[:scorer_id] = the_case.scorer.id
 
         last_score = the_case.last_score
 
@@ -153,6 +155,8 @@ class CaseScoreManagerTest < ActiveSupport::TestCase
 
       test 'updates existing score if same score and last score was last updated less than 1 day ago' do
         last_score = the_case.last_score
+
+        score_data[:scorer_id] = the_case.scorer.id
         score_data[:score] = last_score.score
 
         assert_equal the_case.last_score.score, score_data[:score]
@@ -221,6 +225,8 @@ class CaseScoreManagerTest < ActiveSupport::TestCase
       test 'creates a new score' do
         assert_empty the_case.scores
         assert_not_empty the_case.tries
+
+        score_data[:scorer_id] = the_case.scorer.id
 
         assert_difference 'the_case.scores.count' do
           assert_changes 'the_case.updated_at' do

--- a/test/services/fetch_service_test.rb
+++ b/test/services/fetch_service_test.rb
@@ -333,9 +333,12 @@ class FetchServiceTest < ActiveSupport::TestCase
       asnapshot.scorer.code = File.readlines('./db/scorers/p@10.js', '\n').join('\n')
 
       fetch_service = FetchService.new options
+      fetch_service.begin acase, atry
       score_data = fetch_service.score_snapshot(asnapshot, atry)
       assert_equal 2, score_data[:queries].size
       assert_equal 0.25, score_data[:score]
+      assert_not_nil asnapshot.case.scorer
+      assert_equal acase.scorer.id, score_data[:scorer_id]
 
       snapshot_query.reload
       assert_equal 0.5, snapshot_query.score


### PR DESCRIPTION
Last bit of the puzzle for Quepid 8.  Now that we can run scorers at night, and therefore build up a picture of what is happening, well, we should associate the score with the scorer!

Shocking that this hasn't been modeled since the beginning.