### PR TITLE
Fix prefer ssl logic to not blindly force port 80

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 require: 
-  - rubocop-rails
   - rubocop-capybara
-
+plugins: 
+  - rubocop-rails
 
 AllCops:
   NewCops: enable

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -121,14 +121,19 @@ module ApplicationHelper
     options[:data] ||= {}
     options[:data][:turbo_prefetch] = false
 
+    path_params = {}
+
     endpoint_url = kase.tries.first&.search_endpoint&.endpoint_url
-    protocol = nil
+
     if endpoint_url
       protocol = get_protocol_from_url(endpoint_url)
-      port = 443 if 'https' == protocol
+      path_params = {
+        protocol: protocol,
+        port:     'https' == protocol ? 443 : nil,
+      }.compact
     end
-    path = case_core_url(kase, try_number, protocol: protocol, port: port)
 
+    path = case_core_url(kase, try_number, **path_params)
     # Call the original link_to method with the modified options
     link_to(name, path, options)
   end
@@ -147,7 +152,7 @@ module ApplicationHelper
     if Rails.configuration.prefer_ssl
       { protocol: 'https', port: 443 }
     else
-      { protocol: 'http', port: 80 }
+      { protocol: 'http' }
     end
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -82,8 +82,7 @@
               <li><%= link_to 'My profile', profile_path, class: 'dropdown-item', target: '_self' %></li>
               <li><%= link_to 'Log out', logout_path, class: 'dropdown-item', target: '_self' %></li>
               <li><hr class="dropdown-divider"></li>
-              <li><%= link_to 'Judgements', books_path, class: 'dropdown-item', target: '_self' %></li>
-              <li><%#= link_to 'API Docs', apipie_apipie_path, class: 'dropdown-item', target: '_self' %></li>
+              <li><%= link_to 'API Docs', apipie_apipie_path, class: 'dropdown-item', target: '_self' %></li>
               <% if current_user.administrator? %>
               <li><hr class="dropdown-divider"></li>
               <li><%= link_to 'Admin Home', admin_path, class: 'dropdown-item', target: '_self' %></li>

--- a/app/views/layouts/_header_core_app.html.erb
+++ b/app/views/layouts/_header_core_app.html.erb
@@ -93,7 +93,6 @@
             <li><%= link_to 'My profile', profile_url(determine_prefer_ssl_options()), class: 'dropdown-link', target: '_self' %></li>
             <li><%= link_to 'Log out', logout_url(determine_prefer_ssl_options()), class: 'dropdown-link', target: '_self' %></li>
             <li role="separator" class=""></li>
-            <li><%= link_to 'Judgements', books_url(determine_prefer_ssl_options()), class: 'dropdown-link', target: '_self' %></li>
             <li><%= link_to 'API Docs', apipie_apipie_url(determine_prefer_ssl_options()), class: 'dropdown-item', target: '_self' %></li>
             <% if current_user.administrator? %>
             <li role="separator" class=""></li>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -35,4 +35,21 @@ class ApplicationHelperTest < ActionView::TestCase
     # Assertions for the options
     assert_includes result, 'class="btn btn-primary"'
   end
+
+  let(:https_search_endpoint) { search_endpoints(:bootstrap_try_1) }
+  def test_link_with_https_search_endpoint
+    assert https_search_endpoint.endpoint_url.starts_with? 'https://'
+    try_to_update = random_case.tries.first
+
+    try_to_update.search_endpoint = https_search_endpoint
+    try_to_update.save!
+
+    try_number = random_case.tries.first.try_number
+    options = {}
+
+    # Call the helper method
+    result = link_to_core_case('View Case', random_case, try_number, options)
+
+    assert_includes result, 'https://'
+  end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
don't force port 80 blindly.

## Motivation and Context
If you want Quepid on port 3000, then don't force to 80 blindly.   Chorus requires Quepid to be on port 3000 always.

## How Has This Been Tested?
Manually and a unit test

