### PR TITLE
Dont change to https if proxied search endpoint has https (and vice versa)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -123,10 +123,10 @@ module ApplicationHelper
 
     path_params = {}
 
-    endpoint_url = kase.tries.first&.search_endpoint&.endpoint_url
+    search_endpoint = kase.tries.first&.search_endpoint
 
-    if endpoint_url
-      protocol = get_protocol_from_url(endpoint_url)
+    if search_endpoint && (!search_endpoint.proxy_requests? && search_endpoint.endpoint_url)
+      protocol = get_protocol_from_url(search_endpoint.endpoint_url)
       path_params = {
         protocol: protocol,
         port:     'https' == protocol ? 443 : nil,

--- a/app/models/search_endpoint.rb
+++ b/app/models/search_endpoint.rb
@@ -65,10 +65,6 @@ class SearchEndpoint < ApplicationRecord
     save
   end
 
-  def proxy_request?
-    endpoint_url.include?('/proxy/fetch')
-  end
-
   private
 
   def middle_truncate str, total: 30, lead: 15, trail: 15

--- a/test/controllers/api/v1/tries_controller_test.rb
+++ b/test/controllers/api/v1/tries_controller_test.rb
@@ -516,7 +516,7 @@ search_endpoint: es_endpoint.attributes }
 
         describe 'Test finding search endpoints' do
           test 'find by search_engine' do
-            solr_endpoint.endpoint_url = 'http://localhost:3000/proxy/fetch?url=http://mysearch.com?query=text'
+            solr_endpoint.endpoint_url = 'http://mysearch.com?query=text'
 
             post :create,
                  params: { case_id: the_case.id, try: { name: '' },
@@ -533,7 +533,6 @@ search_endpoint: solr_endpoint.attributes }
 
             assert_equal solr_search_endpoint.search_engine, try_response['search_endpoint']['search_engine']
             assert solr_search_endpoint.endpoint_url, try_response['search_endpoint']['endpoint_url']
-            assert solr_search_endpoint.proxy_request?
 
             post :create, params: { case_id: the_case.id, try: { name: '' }, search_endpoint: es_endpoint.attributes }
             try_response  = response.parsed_body

--- a/test/fixtures/search_endpoints.yml
+++ b/test/fixtures/search_endpoints.yml
@@ -142,11 +142,14 @@ bootstrap_try_1:
   name:           Solr https://test.com
   endpoint_url:   https://test.com
   search_engine:  solr
+  api_method:     GET
+  proxy_requests: false
 
 bootstrap_try_2:
   name:           Es http://test.com:9200/tmdb/_search
   endpoint_url:   http://test.com:9200/tmdb/_search
   search_engine:  es
+  api_method:     GET
 
 for_case_without_score_try_1:
   name:           Solr http://test.com/solr/tmdb/select
@@ -158,6 +161,7 @@ for_case_with_score_for_first_try_try_1:
   name:           Solr http://test.com/solr/tmdb/select
   endpoint_url:   http://test.com/solr/tmdb/select
   search_engine:  solr
+  api_method:     JSONP
 
 for_case_with_score_for_first_try_try_2:
   name:           Solr http://test.com/solr/tmdb/select

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -36,20 +36,39 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_includes result, 'class="btn btn-primary"'
   end
 
-  let(:https_search_endpoint) { search_endpoints(:bootstrap_try_1) }
-  def test_link_with_https_search_endpoint
-    assert https_search_endpoint.endpoint_url.starts_with? 'https://'
-    try_to_update = random_case.tries.first
+  describe 'Smart handling of links to HTTPS search end points' do
+    let(:https_search_endpoint) { search_endpoints(:bootstrap_try_1) }
 
-    try_to_update.search_endpoint = https_search_endpoint
-    try_to_update.save!
+    test 'link with https search_endpoint' do
+      try_to_update = random_case.tries.first
 
-    try_number = random_case.tries.first.try_number
-    options = {}
+      try_to_update.search_endpoint = https_search_endpoint
+      try_to_update.save!
 
-    # Call the helper method
-    result = link_to_core_case('View Case', random_case, try_number, options)
+      try_number = random_case.tries.first.try_number
+      options = {}
 
-    assert_includes result, 'https://'
+      # Call the helper method
+      result = link_to_core_case('View Case', random_case, try_number, options)
+
+      assert_includes result, 'https://'
+    end
+
+    test 'Proxied https endpoints do not change' do
+      https_search_endpoint.update(proxy_requests: true)
+
+      try_to_update = random_case.tries.first
+
+      try_to_update.search_endpoint = https_search_endpoint
+      try_to_update.save!
+
+      try_number = random_case.tries.first.try_number
+      options = { class: 'btn btn-primary' }
+
+      # Call the helper method
+      result = link_to_core_case('View Case', random_case, try_number, options)
+
+      assert_includes result, 'http://'
+    end
   end
 end


### PR DESCRIPTION


## Description
Bug found by @jvia and reported on Slack.

## Motivation and Context
custom search api and proxied connection!

## How Has This Been Tested?
Add a new helper test.