### PR TITLE
Revert "Bump mini_racer from 0.16.0 to 0.18.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,4 +90,4 @@ group :test do
   gem 'selenium-webdriver'
 end
 
-gem 'mini_racer', '~> 0.18.0'
+gem 'mini_racer', '~> 0.16.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,9 +249,9 @@ GEM
       childprocess (~> 5.0)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
-    libv8-node (23.6.1.0-aarch64-linux)
-    libv8-node (23.6.1.0-x86_64-darwin)
-    libv8-node (23.6.1.0-x86_64-linux)
+    libv8-node (18.19.0.0-aarch64-linux)
+    libv8-node (18.19.0.0-x86_64-darwin)
+    libv8-node (18.19.0.0-x86_64-linux)
     lint_roller (1.1.0)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -271,8 +271,8 @@ GEM
     memory_profiler (1.1.0)
     mini_histogram (0.3.1)
     mini_mime (1.1.5)
-    mini_racer (0.18.0)
-      libv8-node (~> 23.6.1.0)
+    mini_racer (0.16.0)
+      libv8-node (~> 18.19.0.0)
     minitest (5.25.4)
     minitest-reporters (1.7.1)
       ansi
@@ -587,7 +587,7 @@ DEPENDENCIES
   listen (~> 3.3)
   local_time
   memory_profiler
-  mini_racer (~> 0.18.0)
+  mini_racer (~> 0.16.0)
   minitest-reporters (>= 0.5.0)
   mission_control-jobs (~> 0.5.0)
   mocha (~> 2.7)


### PR DESCRIPTION
Reverts o19s/quepid#1264

We are seeing libc errors in 0.18.0.