### PR TITLE
Rename openai_key to llm_key

### DIFF
--- a/app/controllers/ai_judges/prompts_controller.rb
+++ b/app/controllers/ai_judges/prompts_controller.rb
@@ -31,7 +31,7 @@ module AiJudges
 
       @query_doc_pair = QueryDocPair.new(query_doc_pair_params)
 
-      llm_service = LlmService.new(@ai_judge.openai_key, @ai_judge.judge_options)
+      llm_service = LlmService.new(@ai_judge.llm_key, @ai_judge.judge_options)
       @judgement = Judgement.new(query_doc_pair: @query_doc_pair, user: @ai_judge)
       llm_service.perform_safe_judgement @judgement
 
@@ -46,7 +46,7 @@ module AiJudges
 
     # Only allow a list of trusted parameters through.
     def ai_judge_params
-      params.expect(user: [ :openai_key, :system_prompt ])
+      params.expect(user: [ :llm_key, :system_prompt ])
     end
 
     def query_doc_pair_params

--- a/app/controllers/ai_judges_controller.rb
+++ b/app/controllers/ai_judges_controller.rb
@@ -111,7 +111,7 @@ class AiJudgesController < ApplicationController
   end
 
   def ai_judge_params
-    params_to_return = params.expect(user: [ :name, :openai_key, :system_prompt, :options, { judge_options: {} } ])
+    params_to_return = params.expect(user: [ :name, :llm_key, :system_prompt, :options, { judge_options: {} } ])
     params_to_return[:options] = JSON.parse(params_to_return[:options]) if params_to_return[:options]
 
     params_to_return

--- a/app/jobs/run_judge_judy_job.rb
+++ b/app/jobs/run_judge_judy_job.rb
@@ -17,7 +17,7 @@ class RunJudgeJudyJob < ApplicationJob
   # rubocop:disable Metrics/MethodLength
   def perform book, judge, number_of_pairs
     counter = 0
-    llm_service = LlmService.new judge.openai_key, judge.judge_options
+    llm_service = LlmService.new judge.llm_key, judge.judge_options
     loop do
       break if number_of_pairs && counter >= number_of_pairs
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,7 +149,7 @@ class User < ApplicationRecord
             acceptance: { message: 'checkbox must be clicked to signify you agree to the terms and conditions.' },
             if:         :terms_and_conditions?
 
-  validates :llm_key, length: { maximum: 255 }, allow_nil: false, presence: true, if: :ai_judge? # Lets get STI in and not have this.
+  validates :llm_key, length: { maximum: 255 }, allow_nil: false, presence: true, if: :ai_judge?
   validates :system_prompt, length: { maximum: 4000 }, allow_nil: true, presence: true, if: :ai_judge?
 
   def terms_and_conditions?
@@ -213,6 +213,7 @@ class User < ApplicationRecord
   # default_scope -> { includes(:permissions) }
   scope :only_ai_judges, -> { where('`users`.`llm_key` IS NOT NULL') }
 
+  # Lets get STI in and have actual AiJudge and User objects!
   def ai_judge?
     !llm_key.nil?
   end
@@ -291,7 +292,6 @@ class User < ApplicationRecord
 
     # Set the judge_options within options
     self.options = options.merge(judge_options: value)
-    pp self.options
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,11 +20,11 @@
 #  invitation_sent_at          :datetime
 #  invitation_token            :string(255)
 #  invitations_count           :integer          default(0)
+#  llm_key                     :string(255)
 #  locked                      :boolean
 #  locked_at                   :datetime
 #  name                        :string(255)
 #  num_logins                  :integer
-#  openai_key                  :string(255)
 #  options                     :json
 #  password                    :string(120)
 #  profile_pic                 :string(4000)
@@ -32,6 +32,7 @@
 #  reset_password_token        :string(255)
 #  stored_raw_invitation_token :string(255)
 #  system_prompt               :string(4000)
+#  type                        :string(255)
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  default_scorer_id           :integer
@@ -51,7 +52,7 @@
 #  fk_rails_...  (default_scorer_id => scorers.id)
 #  fk_rails_...  (invited_by_id => users.id)
 #
-
+require 'json'
 class User < ApplicationRecord
   # Associations
   has_many :api_keys, dependent: :destroy
@@ -148,7 +149,7 @@ class User < ApplicationRecord
             acceptance: { message: 'checkbox must be clicked to signify you agree to the terms and conditions.' },
             if:         :terms_and_conditions?
 
-  validates :openai_key, length: { maximum: 255 }, allow_nil: true, if: :ai_judge?
+  validates :llm_key, length: { maximum: 255 }, allow_nil: true, if: :ai_judge?
   validates :system_prompt, length: { maximum: 4000 }, allow_nil: true, presence: true, if: :ai_judge?
 
   def terms_and_conditions?
@@ -210,10 +211,10 @@ class User < ApplicationRecord
 
   # Scopes
   # default_scope -> { includes(:permissions) }
-  scope :only_ai_judges, -> { where('`users`.`openai_key` IS NOT NULL') }
+  scope :only_ai_judges, -> { where('`users`.`llm_key` IS NOT NULL') }
 
   def ai_judge?
-    !openai_key.nil?
+    !llm_key.nil?
   end
 
   def num_queries

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,6 @@
 #  reset_password_token        :string(255)
 #  stored_raw_invitation_token :string(255)
 #  system_prompt               :string(4000)
-#  type                        :string(255)
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  default_scorer_id           :integer
@@ -52,7 +51,6 @@
 #  fk_rails_...  (default_scorer_id => scorers.id)
 #  fk_rails_...  (invited_by_id => users.id)
 #
-require 'json'
 class User < ApplicationRecord
   # Associations
   has_many :api_keys, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,7 +149,7 @@ class User < ApplicationRecord
             acceptance: { message: 'checkbox must be clicked to signify you agree to the terms and conditions.' },
             if:         :terms_and_conditions?
 
-  validates :llm_key, length: { maximum: 255 }, allow_nil: true, if: :ai_judge?
+  validates :llm_key, length: { maximum: 255 }, allow_nil: false, presence: true, if: :ai_judge? # Lets get STI in and not have this.
   validates :system_prompt, length: { maximum: 4000 }, allow_nil: true, presence: true, if: :ai_judge?
 
   def terms_and_conditions?

--- a/app/services/llm_service.rb
+++ b/app/services/llm_service.rb
@@ -5,15 +5,15 @@ require 'faraday/retry'
 require 'json'
 
 class LlmService
-  def initialize openai_key, opts = {}
+  def initialize llm_key, opts = {}
     default_options = {
       llm_service_url: 'https://api.openai.com',
       llm_model:       'gpt-4',
       llm_timeout:     30,
     }
 
-    @openai_key = openai_key
-    @options    = default_options.merge(opts.deep_symbolize_keys)
+    @llm_key = llm_key
+    @options = default_options.merge(opts.deep_symbolize_keys)
   end
 
   def perform_safe_judgement judgement
@@ -57,6 +57,7 @@ class LlmService
   end
 
   # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
   def get_llm_response user_prompt, system_prompt
     conn = Faraday.new(url: @options[:llm_service_url]) do |f|
       f.request :json
@@ -82,7 +83,7 @@ class LlmService
     }
 
     response = conn.post('/v1/chat/completions') do |req|
-      req.headers['Authorization'] = "Bearer #{@openai_key}"
+      req.headers['Authorization'] = "Bearer #{@llm_key}" if @llm_key.present?
       req.options.timeout = @options[:llm_timeout].to_i # Set request timeout
       req.body = body
     end
@@ -106,4 +107,5 @@ class LlmService
     end
   end
   # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
 end

--- a/app/views/ai_judges/_form.html.erb
+++ b/app/views/ai_judges/_form.html.erb
@@ -28,6 +28,10 @@
       <div class="col-sm-4">
         <%= form.text_field :llm_key %>
       </div>
+      <div class="form-text">
+        This is the key to access your LLM provider's API.  
+        It also lets Quepid distingush between AI Judges and regular Users, so you must provide something, even "abc".
+      </div>
     </div>
     
     <ul class="nav nav-underline mb-3" id="pills-tab" role="tablist">

--- a/app/views/ai_judges/_form.html.erb
+++ b/app/views/ai_judges/_form.html.erb
@@ -24,9 +24,9 @@
     </div>
   
     <div class="row mb-3">
-      <%= form.label :openai_key, class: 'col-sm-2 col-form-label' %>
+      <%= form.label :llm_key, class: 'col-sm-2 col-form-label' %>
       <div class="col-sm-4">
-        <%= form.text_field :openai_key %>
+        <%= form.text_field :llm_key %>
       </div>
     </div>
     

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,4 +39,4 @@ en:
               
     attributes:
       user:
-        openai_key: "OpenAI Key"
+        llm_key: "LLM Key"

--- a/db/migrate/20250314170144_rename_openai_key_to_llm_key_in_users.rb
+++ b/db/migrate/20250314170144_rename_openai_key_to_llm_key_in_users.rb
@@ -1,0 +1,6 @@
+class RenameOpenaiKeyToLlmKeyInUsers < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :users, :openai_key, :llm_key
+    add_column :users, :type, :string # introduce single table inheritance    
+  end
+end

--- a/db/migrate/20250314170144_rename_openai_key_to_llm_key_in_users.rb
+++ b/db/migrate/20250314170144_rename_openai_key_to_llm_key_in_users.rb
@@ -1,6 +1,5 @@
 class RenameOpenaiKeyToLlmKeyInUsers < ActiveRecord::Migration[8.0]
   def change
-    rename_column :users, :openai_key, :llm_key
-    add_column :users, :type, :string # introduce single table inheritance    
+    rename_column :users, :openai_key, :llm_key   
   end
 end

--- a/db/migrate/20250314172243_map_users_and_judges_to_type.rb
+++ b/db/migrate/20250314172243_map_users_and_judges_to_type.rb
@@ -1,0 +1,8 @@
+class MapUsersAndJudgesToType < ActiveRecord::Migration[8.0]
+  def change
+    User.where(llm_key: nil).update_all(type: 'User')
+    User.where.not(llm_key: nil).update_all(type: 'Judge')    
+    
+    add_index :users, :type
+  end
+end

--- a/db/migrate/20250314172243_map_users_and_judges_to_type.rb
+++ b/db/migrate/20250314172243_map_users_and_judges_to_type.rb
@@ -1,8 +1,0 @@
-class MapUsersAndJudgesToType < ActiveRecord::Migration[8.0]
-  def change
-    User.where(llm_key: nil).update_all(type: 'User')
-    User.where.not(llm_key: nil).update_all(type: 'Judge')    
-    
-    add_index :users, :type
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -606,7 +606,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_14_172243) do
     t.string "system_prompt", limit: 4000
     t.string "llm_key"
     t.json "options"
-    t.string "type"
     t.index ["default_scorer_id"], name: "index_users_on_default_scorer_id"
     t.index ["email"], name: "ix_user_username", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true, length: 191

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_10_172421) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_14_172243) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -604,8 +604,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_10_172421) do
     t.string "stored_raw_invitation_token"
     t.string "profile_pic", limit: 4000
     t.string "system_prompt", limit: 4000
-    t.string "openai_key"
+    t.string "llm_key"
     t.json "options"
+    t.string "type"
     t.index ["default_scorer_id"], name: "index_users_on_default_scorer_id"
     t.index ["email"], name: "ix_user_username", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true, length: 191

--- a/lib/tasks/sample_data.thor
+++ b/lib/tasks/sample_data.thor
@@ -126,7 +126,7 @@ class SampleData < Thor
 
     user_specifics = {
       name:          'OSC AI Judge',
-      openai_key:    'key123456',
+      llm_key:       'key123456',
       system_prompt: AiJudgesController::DEFAULT_SYSTEM_PROMPT,
     }
     user_params = user_specifics # user_defaults.merge(user_specifics)

--- a/test/controllers/ai_judges_controller_test.rb
+++ b/test/controllers/ai_judges_controller_test.rb
@@ -20,7 +20,7 @@ class AiJudgesControllerTest < ActionDispatch::IntegrationTest
     assert_difference('User.count') do
       post team_ai_judges_url(team_id: team.id),
            params: { user: {
-             name: ai_judge.name, openai_key: ai_judge.openai_key, system_prompt: ai_judge.system_prompt
+             name: ai_judge.name, llm_key: ai_judge.llm_key, system_prompt: ai_judge.system_prompt
            } }
     end
     assert_redirected_to teams_core_url(id: team.id)

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -28,7 +28,6 @@
 #  reset_password_token        :string(255)
 #  stored_raw_invitation_token :string(255)
 #  system_prompt               :string(4000)
-#  type                        :string(255)
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  default_scorer_id           :integer

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -16,11 +16,11 @@
 #  invitation_sent_at          :datetime
 #  invitation_token            :string(255)
 #  invitations_count           :integer          default(0)
+#  llm_key                     :string(255)
 #  locked                      :boolean
 #  locked_at                   :datetime
 #  name                        :string(255)
 #  num_logins                  :integer
-#  openai_key                  :string(255)
 #  options                     :json
 #  password                    :string(120)
 #  profile_pic                 :string(4000)
@@ -28,6 +28,7 @@
 #  reset_password_token        :string(255)
 #  stored_raw_invitation_token :string(255)
 #  system_prompt               :string(4000)
+#  type                        :string(255)
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  default_scorer_id           :integer
@@ -220,6 +221,6 @@ admin:
   
 judge_judy:
   name:           Judge Judy
-  openai_key:     1234asdf5678
+  llm_key:        1234asdf5678
   system_prompt:  You are a grocery store shopper.  You like cheese.  Is this a cheese?
   options:      '{"judge_options":{"llm_model":"gpt-4","llm_timeout":"3000","llm_service_url":"https://api.openai.com"}}'

--- a/test/jobs/run_judge_judy_job_test.rb
+++ b/test/jobs/run_judge_judy_job_test.rb
@@ -9,7 +9,7 @@ class RunJudgeJudyJobTest < ActiveJob::TestCase
   describe 'failure scenarios' do
     test 'not authorized to access OpenAI' do
       # Tell webmock to return a 401 by matching the below key.
-      judge_judy.openai_key = 'BAD_OPENAI_KEY'
+      judge_judy.llm_key = 'BAD_OPENAI_KEY'
       judge_judy.options = nil # no idea why
       judge_judy.save!
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -20,11 +20,11 @@ require 'test_helper'
 #  invitation_sent_at          :datetime
 #  invitation_token            :string(255)
 #  invitations_count           :integer          default(0)
+#  llm_key                     :string(255)
 #  locked                      :boolean
 #  locked_at                   :datetime
 #  name                        :string(255)
 #  num_logins                  :integer
-#  openai_key                  :string(255)
 #  options                     :json
 #  password                    :string(120)
 #  profile_pic                 :string(4000)
@@ -32,6 +32,7 @@ require 'test_helper'
 #  reset_password_token        :string(255)
 #  stored_raw_invitation_token :string(255)
 #  system_prompt               :string(4000)
+#  type                        :string(255)
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  default_scorer_id           :integer
@@ -340,19 +341,19 @@ class UserTest < ActiveSupport::TestCase
     it 'uses the existence of the key to decide ai_judge' do
       user = User.new
       assert_not user.ai_judge?
-      user.openai_key = ''
+      user.llm_key = ''
       assert user.ai_judge?
       assert_not user.valid?
     end
 
     it 'does not require an email or password address to be valid when is a judge' do
-      user = User.new(openai_key: '1234', name: 'Judge Judy')
+      user = User.new(llm_key: '1234', name: 'Judge Judy')
       assert user.ai_judge?
       assert user.valid?
     end
 
     it 'does require name to be valid when is a judge' do
-      user = User.new(openai_key: '1234')
+      user = User.new(llm_key: '1234')
       assert user.ai_judge?
       assert_not user.valid?
       user.name = 'Judge Judy'
@@ -361,13 +362,13 @@ class UserTest < ActiveSupport::TestCase
 
     describe 'options to configure the llm server' do
       it 'provides an empty hash' do
-        user = User.new(openai_key: '1234')
+        user = User.new(llm_key: '1234')
         opts_hash = user.judge_options
         assert_equal({}, opts_hash)
       end
 
       it 'lets you update the options hash' do
-        user = User.new(openai_key: '1234')
+        user = User.new(llm_key: '1234')
         opts_hash = user.judge_options
 
         opts_hash[:model] = 'gpt-3.5-turbo'

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -362,13 +362,13 @@ class UserTest < ActiveSupport::TestCase
 
     describe 'options to configure the llm server' do
       it 'provides an empty hash' do
-        user = User.new(openai_key: '1234', name: 'Judge Judy')
+        user = User.new(llm_key: '1234', name: 'Judge Judy')
         opts_hash = user.judge_options
         assert_equal({}, opts_hash)
       end
 
       it 'lets you update the options hash via passing in a hash with new values' do
-        user = User.new(openai_key: '1234', name: 'Judge Judy')
+        user = User.new(llm_key: '1234', name: 'Judge Judy')
         opts_hash = user.judge_options
 
         opts_hash[:model] = 'gpt-3.5-turbo'

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -32,7 +32,6 @@ require 'test_helper'
 #  reset_password_token        :string(255)
 #  stored_raw_invitation_token :string(255)
 #  system_prompt               :string(4000)
-#  type                        :string(255)
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  default_scorer_id           :integer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Now that we support more than just OpenAI, rename the field.

## Motivation and Context
We have ollama based model support, though we only support hte openai way of doing things.

