### PR TITLE
spike out every try is a snapshot!

### DIFF
--- a/app/assets/javascripts/controllers/mainCtrl.js
+++ b/app/assets/javascripts/controllers/mainCtrl.js
@@ -109,6 +109,14 @@ angular.module('QuepidApp')
                   return queriesSvc.searchAll()
                     .then(function() {
                       flash.success = 'All queries finished successfully!';
+                      
+                      querySnapshotSvc.addSnapshot('eric', true, queriesSvc.queryArray())
+                      .then(function() {
+                                                
+                      }, function() {
+                        console.log('Snapshot recording failed');
+                      });
+                      
                     }, function(errorMsg) {
                       var mainErrorMsg = 'Some queries failed to resolve!';
 

--- a/app/assets/javascripts/services/querySnapshotSvc.js
+++ b/app/assets/javascripts/services/querySnapshotSvc.js
@@ -113,12 +113,17 @@ angular.module('QuepidApp')
         var docs = {};
         var queriesPayload = {};
         angular.forEach(queries, function(query) {
-          queriesPayload[query.queryId] = {
-            'score': query.currentScore.score,
-            'all_rated': query.currentScore.allRated,
+          queriesPayload[query.queryId] = {            
             'number_of_results': query.numFound
           };
-
+          
+          // If the currentScore has been calculated, then include it
+          if (query.currentScore) {
+            queriesPayload[query.queryId].score = query.currentScore.score;
+            queriesPayload[query.queryId].all_rated = query.currentScore.allRated;
+          }
+          
+    
           // The score can be -- if it hasn't actually been scored, so convert
           // that to null for the call to the backend.
           if (queriesPayload[query.queryId].score === '--') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Once a Case is loaded, we snapshot it.  We may *NOT* have scores.  But maybe that is okay?   I did the quick version where after the docs are loaded we snapshot it.  This is happening BEFORE the scorer runs.

@david-fisher how important is we store the scores?   Historically we would store a score per query, but then, we would recalcluate everything (I think) when you would do a snapshot compare.  I think the score in the snapshot_query isn't useful because we want to move to a future with multiple scorers being used!

I tried it with out 5000 queries case, and the snapshot JSON object was so big teh NGINX server puked with a 429 entity too large.  But with 400 queries worked just fine.   


## Motivation and Context
As raised by @david-fisher in #1310 we should really think about why we aren't snapshotting every try.   

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
