### PR TITLE
doc: add ruby as a prereq

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Provisioning from an already built machine takes approximately 3 - 4 minutes. Pr
 
 #### 1. Prerequisites
 
+Make sure you have installed Ruby.
+
 Make sure you have installed Docker. Go here https://www.docker.com/community-edition#/download for installation instructions. And the Docker app is launched.
 
 To install using brew follow these steps:


### PR DESCRIPTION
Make the fact Ruby is a pre-requisite and not installed by the setup_docker script explicit

## Description
setup_docker will fail if you do not have ruby installed, so make that more explicit.

## Motivation and Context
I'm currently working on setting up quepid locally and this would have made the process simpler.
