### PR TITLE
#1335 nDCG behavior not as desired. Add new scorer, NDCG_CUT@10 to 

### DIFF
--- a/db/migrate/20250514142459_addn_dcg_cut.rb
+++ b/db/migrate/20250514142459_addn_dcg_cut.rb
@@ -1,0 +1,18 @@
+class AddnDcgCut < ActiveRecord::Migration[8.0]
+  def change
+      scorer = Scorer.where(name: 'NDCG_CUT@10').first
+
+      if scorer.nil?
+        scorer = Scorer.new(name: 'NDCG_CUT@10', communal: true)
+      end
+
+      scorer.update(
+        scale:              (0..3).to_a,
+        scale_with_labels:  {"0":"Poor","1":"Fair","2":"Good","3":"Perfect"},
+        show_scale_labels:  true,
+        code:               File.readlines('./db/scorers/ndcg_cut@10.js','\n').join('\n'),
+        name:               'NDCG_CUT@10',
+        communal:           true
+      )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_14_214403) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_14_142459) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false

--- a/db/scorers/ndcg_cut@10.js
+++ b/db/scorers/ndcg_cut@10.js
@@ -1,0 +1,33 @@
+var k = 10 // @Rank
+var missing_rating = 0; // pessimistic assumption
+
+var ideal = topRatings(k) // could return less than k if less than k docs have ratings
+var scores = Array(k);
+for (var i = 0; i < k; i++) {
+  if (!ideal[i]) {
+    ideal[i] = missing_rating;
+  }
+  if (hasDocRating(i)) {
+    scores[i] = (docRating(i));
+  } else {
+    scores[i] = missing_rating;
+  }
+}
+
+function DCG(vals, k) {
+  var dcg = 0;
+  for (var i = 0; i < k; i++) {
+    var d = Math.log2(i + 2);
+    var n = Math.pow(2, vals[i]) - 1;
+    dcg += d ? (n / d) : 0;
+  }
+  return dcg;
+}
+
+function nDCG(vals, ideal, k) {
+  var n = DCG(vals, k);
+  var d = DCG(ideal, k);
+  return d ? (n / d) : 0;
+}
+
+setScore(nDCG(scores, ideal, k));


### PR DESCRIPTION
provide the pre 8.1 behavior.

Closes 1335

<!--- Provide a general summary of your changes in the Title above -->

Add the ndcg_cut variant of trec_eval as the scorer NDCG_CUT@10. Provides the behavior of the pre-8.1 Quepid nDCG@10 scorer.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
