### PR TITLE
Attach image to OpenAI request

### DIFF
--- a/app/services/llm_service.rb
+++ b/app/services/llm_service.rb
@@ -37,19 +37,35 @@ class LlmService
     judgement
   end
 
+  # rubocop:disable Metrics/MethodLength
   def make_user_prompt query_doc_pair
     document_fields = query_doc_pair.document_fields
-    fields = document_fields.blank? ? '' : JSON.parse(document_fields).to_yaml
 
-    user_prompt = <<~TEXT
+    fields = if document_fields.blank?
+               {}
+             else
+               JSON.parse(document_fields)
+             end
+
+    text_prompt = <<~TEXT
       Query: #{query_doc_pair.query_text}
 
       doc1:
-        #{fields}
+        #{fields.to_yaml}
     TEXT
 
-    user_prompt
+    prompt = [
+      { type: 'text', text: text_prompt }
+    ]
+
+    if '' != fields['image'].to_s.strip
+      image_url = fields['image']
+      prompt << { type: 'image_url', image_url: { url: image_url } }
+    end
+
+    prompt
   end
+  # rubocop:enable Metrics/MethodLength
 
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/AbcSize

--- a/test/fixtures/query_doc_pairs.yml
+++ b/test/fixtures/query_doc_pairs.yml
@@ -31,7 +31,7 @@ one:
   doc_id: "MyDocA"
   document_fields: '{"title":"MyText"}'
   book: one
-  options:      
+  options:
     special_boost: 3.1
 
 two:
@@ -89,21 +89,21 @@ jbm_qdp10:
   doc_id: Moonraker
   document_fields: '{"title":"Moonraker", "year":2023}'
   book: :james_bond_movies
-  
+
 starwars_qdp1:
   query_text: Han
   position: 1
   doc_id: Han Solo-A Star Wars Story
-  document_fields: '{"title":"Han Solo-A Star Wars Story", "description": "The film tells the origin story of Han Solo and Chewbacca, who join a heist within the criminal underworld ten years prior to the events of A New Hope."}'
+  document_fields: '{"title":"Han Solo-A Star Wars Story", "description": "The film tells the origin story of Han Solo and Chewbacca, who join a heist within the criminal underworld ten years prior to the events of A New Hope.", "image":"https://example.com/image.png"}'
   book: :book_of_star_wars_judgements
-  
+
 starwars_qdp2:
   query_text: Han
   position: 2
   doc_id: Star Wars The Movie
   document_fields: '{"title":"Star Wars The Movie"}'
   book: :book_of_star_wars_judgements
-  
+
 # This query doc pair overlaps with starwars_qdp2, to test merging books.
 book_of_comedy_qdp1:
   query_text: Han


### PR DESCRIPTION
Added explicit image attachment for LLM Chat Completions API request.

## Description
Here I added an additional image attachment to the OpenAI request only if document contains the Image field.
Otherwise we just create a simple text prompt.

Basically we create the following structure according to this article: https://platform.openai.com/docs/guides/images-vision#analyze-images
```
curl https://api.openai.com/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -d '{
    "model": "gpt-4.1-mini",
    "messages": [
      {
        "role": "user",
        "content": [
          {
            "type": "text",
            "text": "What is in this image?"
          },
          {
            "type": "image_url",
            "image_url": {
              "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
            }
          }
        ]
      }
    ],
    "max_tokens": 300
  }'
  ```

## Motivation and Context
Currently if document has the Image field containing image URL, this field is just passed to LLM in a text prompt making it impossible for most (if not all) of OpenAI models to recognize and analyze it. In our case we would like AI judge to recognize the image content before evaluating the score. I think this logic would be reasonable in general, not only in our case.