### PR TITLE
Remove activerecord import gem in favour of native Rails ActiveRecord calls

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,9 @@ AllCops:
     - node_modules/**/*
     - config/initializers/content_security_policy.rb
 
-
+Rails/SkipsModelValidations:
+  Enabled: false # we use .insert_all for our bulk imports
+  
 Capybara/ClickLinkOrButtonStyle:
   Enabled: false # we aren't running system tests
   

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 
 ruby '3.4.4'
 
-gem 'activerecord-import', '>= 1.0.7'
 gem 'active_storage_db'
 gem 'acts_as_list', '>= 1.0.1'
 gem 'addressable', '~> 2.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,8 +56,6 @@ GEM
       activemodel (= 8.0.2)
       activesupport (= 8.0.2)
       timeout (>= 0.4.0)
-    activerecord-import (2.2.0)
-      activerecord (>= 4.2)
     activestorage (8.0.2)
       actionpack (= 8.0.2)
       activejob (= 8.0.2)
@@ -613,7 +611,6 @@ PLATFORMS
 
 DEPENDENCIES
   active_storage_db
-  activerecord-import (>= 1.0.7)
   acts_as_list (>= 1.0.1)
   addressable (~> 2.8)
   ahoy_matey

--- a/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
+++ b/app/assets/javascripts/components/import_ratings/import_ratings_modal_instance_controller.js
@@ -290,7 +290,7 @@ angular.module('QuepidApp')
         ];
 
         if (!angular.equals(headers, expectedHeaders)) {
-          var alert = 'Headers mismatch! Please make sure you have the correct headers in you file (check for correct spelling and capitalization): ';
+          var alert = 'Headers mismatch! Please make sure you have the correct headers in your file (check for correct spelling and capitalization): ';
           alert += '<br /><strong>';
           alert += expectedHeaders.join(',');
           alert += '</strong>';
@@ -335,7 +335,7 @@ angular.module('QuepidApp')
         ];
 
         if (!caseCSVSvc.arrayContains(headers, expectedHeaders)) {
-          var alert = 'Required headers mismatch! Please make sure you have the correct headers in you file (check for correct spelling and capitalization): ';
+          var alert = 'Required headers mismatch! Please make sure you have the correct headers in your file (check for correct spelling and capitalization): ';
           alert += '<br /><strong>';
           alert += expectedHeaders.join(',');
           alert += '</strong>';
@@ -353,7 +353,7 @@ angular.module('QuepidApp')
         ];
 
         if (!angular.equals(headers, expectedHeaders)) {
-          var alert = 'Headers mismatch! Please make sure you have the correct headers in you file (check for correct spelling and capitalization): ';
+          var alert = 'Headers mismatch! Please make sure you have the correct headers in your file (check for correct spelling and capitalization): ';
           alert += '<br /><strong>';
           alert += expectedHeaders.join(',');
           alert += '</strong>';

--- a/app/assets/javascripts/components/import_to_cases/import_snapshot_modal_instance_controller.js
+++ b/app/assets/javascripts/components/import_to_cases/import_snapshot_modal_instance_controller.js
@@ -37,10 +37,19 @@ angular.module('QuepidApp')
           'Snapshot Name', 'Snapshot Time', 'Case ID', 'Query Text', 'Doc ID', 'Doc Position'
         ];
 
-        if ( !angular.equals(headers, expectedHeaders) ) {
-          var alert = 'Headers mismatch! Please make sure you have the correct headers in you file (check for correct spelling and capitalization): ';
+        // Check if all expected headers are included in the uploaded CSV
+        var allHeadersIncluded = expectedHeaders.every(function(header) {
+          return headers.indexOf(header) !== -1;
+        });
+        
+        if (!allHeadersIncluded) {
+          // Get missing headers for the error message
+          var missingHeaders = expectedHeaders.filter(function(header) {
+            return headers.indexOf(header) === -1;
+          });
+          var alert = 'Missing required headers! Please make sure your file includes all required headers (check for correct spelling and capitalization): ';
           alert += '<br /><strong>';
-          alert += expectedHeaders.join(',');
+          alert += missingHeaders.join(', ');
           alert += '</strong>';
 
           ctrl.import.alert = {

--- a/app/assets/javascripts/controllers/wizardModal.js
+++ b/app/assets/javascripts/controllers/wizardModal.js
@@ -738,7 +738,7 @@ angular.module('QuepidApp')
         console.log(expectedHeaders);
 
         if (!caseCSVSvc.arrayContains(headers, expectedHeaders)) {
-          let alert = 'Required headers mismatch! Please make sure you have the correct headers in you file (check for correct spelling and capitalization): ';
+          let alert = 'Required headers mismatch! Please make sure you have the correct headers in your file (check for correct spelling and capitalization): ';
           alert += '<br /><strong>';
           alert += expectedHeaders.join(',');
           alert += '</strong>';

--- a/app/assets/javascripts/services/caseTryNavSvc.js
+++ b/app/assets/javascripts/services/caseTryNavSvc.js
@@ -144,13 +144,18 @@ angular.module('QuepidApp')
       
       this.getQuepidRootUrl = function(){     
         var absUrl = $location.absUrl();
-        // Look for /case/ or /teams/ in url.
-        var match = absUrl.match(/(.*?)(\/case\/|\/teams\/)/);
+       
+        if (!absUrl.endsWith('/')) {
+          absUrl += '/';
+        }
+        
+        // Look for /case/, /cases/, or /teams/ in url.
+        var match = absUrl.match(/(.*?)(\/case\/|\/teams\/|\/cases\/)/);
         if (match && match[1]) {
           return match[1]; // Return the part of URL before the pattern
         } 
         else {
-          console.warn('Neither "/case/" nor "/teams/" found in URL');
+          console.warn('Neither "/case/", "/cases/", nor "/teams/" found in URL');
         }       
       };
       

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -63,7 +63,6 @@ module Admin
       if @user.save
         if params[:password_encrypted].present?
           # avoid the encrypt call back
-          # rubocop:disable Rails/SkipsModelValidations
           @user.update_column(:password, params[:password_encrypted])
           # rubocop:enable Rails/SkipsModelValidations
         end

--- a/app/controllers/api/v1/bulk/queries_controller.rb
+++ b/app/controllers/api/v1/bulk/queries_controller.rb
@@ -48,7 +48,6 @@ module Api
             }
           end
 
-          # rubocop:disable Rails/SkipsModelValidations
           Query.upsert_all(queries_to_import)
           # rubocop:enable Rails/SkipsModelValidations
 

--- a/app/controllers/api/v1/scorers_controller.rb
+++ b/app/controllers/api/v1/scorers_controller.rb
@@ -102,7 +102,6 @@ module Api
 
         @users = User.where(default_scorer_id: @scorer.id)
         if @users.any? && force
-          # rubocop:disable Rails/SkipsModelValidations
           @users.update_all(default_scorer_id: replacement_scorer.id)
           # rubocop:enable Rails/SkipsModelValidations
         elsif @users.any?

--- a/app/jobs/populate_book_job.rb
+++ b/app/jobs/populate_book_job.rb
@@ -7,8 +7,7 @@ class PopulateBookJob < ApplicationJob
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/AbcSize
   def perform book, kase
-    # down the road we should be using ActiveRecord-import and first_or_initialize instead.
-    # See how snapshots are managed.
+    # Using Rails' bulk insert methods for better performance.
 
     book.update(populate_job: "populate started at #{Time.zone.now}")
     compressed_data = book.populate_file.download

--- a/app/jobs/populate_book_job.rb
+++ b/app/jobs/populate_book_job.rb
@@ -74,7 +74,6 @@ class PopulateBookJob < ApplicationJob
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
 
-  # rubocop:disable Rails/SkipsModelValidations
   def fix_duplicate_positions book
     duplicates = book.query_doc_pairs.group(:query_text, :position)
       .having('COUNT(*) > 1')

--- a/app/jobs/populate_snapshot_job.rb
+++ b/app/jobs/populate_snapshot_job.rb
@@ -5,8 +5,7 @@ class PopulateSnapshotJob < ApplicationJob
 
   # rubocop:disable Security/MarshalLoad
   def perform snapshot
-    # down the road we should be using ActiveRecord-import and first_or_initialize instead.
-    # See how snapshots are managed.
+    # Using Rails' bulk insert methods for better performance.
 
     compressed_data = snapshot.snapshot_file.download
     serialized_data = Zlib::Inflate.inflate(compressed_data)

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -38,7 +38,6 @@ class Announcement < ApplicationRecord
     live
   end
 
-  # rubocop:disable Rails/SkipsModelValidations
   def make_live!
     Announcement.update_all(live: false) # Set all announcements to not live
     update(live: true) # Set the current announcement as live

--- a/app/services/case_score_manager.rb
+++ b/app/services/case_score_manager.rb
@@ -37,7 +37,6 @@ class CaseScoreManager
 
     @score = @the_case.scores.build score_data.except(:try_number)
     saved = @score.save
-    # rubocop:disable Rails/SkipsModelValidations
     if saved
       # for some reason the scorer isn't doing the :touch on the parent case
       @the_case.touch

--- a/app/services/fetch_service.rb
+++ b/app/services/fetch_service.rb
@@ -150,7 +150,14 @@ class FetchService
     )
     snapshot_manager = SnapshotManager.new(@snapshot)
     query_docs = snapshot_manager.setup_docs_for_query(snapshot_query, docs)
-    SnapshotDoc.import query_docs
+    # Using Rails' insert_all for bulk insert without callbacks
+    if query_docs.any?
+      SnapshotDoc.insert_all(
+        query_docs.map do |doc|
+          doc.attributes.except('id')
+        end
+      )
+    end
 
     snapshot_query.reload # without this we get duplicate sets of snapshot_docs
 

--- a/app/services/fetch_service.rb
+++ b/app/services/fetch_service.rb
@@ -151,7 +151,6 @@ class FetchService
     )
     snapshot_manager = SnapshotManager.new(@snapshot)
     query_docs = snapshot_manager.setup_docs_for_query(snapshot_query, docs)
-    # Using Rails' insert_all for bulk insert without callbacks
     if query_docs.any?
       SnapshotDoc.insert_all(
         query_docs.map do |doc|

--- a/app/services/fetch_service.rb
+++ b/app/services/fetch_service.rb
@@ -138,6 +138,7 @@ class FetchService
   # rubocop:enable Metrics/PerceivedComplexity
 
   # This maybe should be split out into a snapshot_query and a snapshot_docs?
+  # rubocop:disable Metrics/MethodLength
   def store_query_results query, docs, response_status, response_body
     snapshot_query = @snapshot.snapshot_queries.create(
       query:             query,
@@ -163,6 +164,7 @@ class FetchService
 
     snapshot_query
   end
+  # rubocop:enable Metrics/MethodLength
 
   # Scores phase
   #

--- a/app/services/ratings_importer.rb
+++ b/app/services/ratings_importer.rb
@@ -96,8 +96,17 @@ class RatingsImporter
         queries_to_import << query
       end
 
-      # Mass insert queries
-      Query.import queries_to_import
+      # Mass insert queries using Rails' insert_all
+      if queries_to_import.any?
+        Query.insert_all(
+          queries_to_import.map do |query|
+            query.attributes.except('id').merge(
+              'created_at' => Time.current,
+              'updated_at' => Time.current
+            )
+          end
+        )
+      end
 
       # Refetch the queries now that we've created new ones
       queries_params = {
@@ -140,8 +149,17 @@ class RatingsImporter
       ratings_to_update.each(&:save)
     end
 
-    # Mass insert ratings
-    Rating.import ratings_to_import
+    # Mass insert ratings using Rails' insert_all
+    if ratings_to_import.any?
+      Rating.insert_all(
+        ratings_to_import.map do |rating|
+          rating.attributes.except('id').merge(
+            'created_at' => Time.current,
+            'updated_at' => Time.current
+          )
+        end
+      )
+    end
 
     return unless @options[:clear_existing]
 

--- a/app/services/ratings_importer.rb
+++ b/app/services/ratings_importer.rb
@@ -101,8 +101,8 @@ class RatingsImporter
         Query.insert_all(
           queries_to_import.map do |query|
             query.attributes.except('id').merge(
-              'created_at' => Time.current,
-              'updated_at' => Time.current
+              'created_at' => Time.zone.now,
+              'updated_at' => Time.zone.now
             )
           end
         )
@@ -154,8 +154,8 @@ class RatingsImporter
       Rating.insert_all(
         ratings_to_import.map do |rating|
           rating.attributes.except('id').merge(
-            'created_at' => Time.current,
-            'updated_at' => Time.current
+            'created_at' => Time.zone.now,
+            'updated_at' => Time.zone.now
           )
         end
       )

--- a/app/services/snapshot_manager.rb
+++ b/app/services/snapshot_manager.rb
@@ -66,7 +66,14 @@ class SnapshotManager
     end
 
     # Second, mass insert queries.
-    SnapshotQuery.import queries_to_import
+    # Using Rails' insert_all for bulk insert without callbacks
+    if queries_to_import.any?
+      SnapshotQuery.insert_all(
+        queries_to_import.map do |query|
+          query.attributes.except('id')
+        end
+      )
+    end
     # End of queries import.
 
     # Then import docs for the queries that were just created.
@@ -135,7 +142,14 @@ class SnapshotManager
     end
 
     # Second, mass insert queries.
-    SnapshotQuery.import queries_to_import
+    # Using Rails' insert_all for bulk insert without callbacks
+    if queries_to_import.any?
+      SnapshotQuery.insert_all(
+        queries_to_import.map do |query|
+          query.attributes.except('id')
+        end
+      )
+    end
     # End of queries import.
 
     # Updates keys after we switched them out from the text to the id
@@ -238,7 +252,14 @@ class SnapshotManager
       docs_to_import += query_docs
     end
 
-    SnapshotDoc.import docs_to_import
+    # Using Rails' insert_all for bulk insert without callbacks
+    if docs_to_import.any?
+      SnapshotDoc.insert_all(
+        docs_to_import.map do |doc|
+          doc.attributes.except('id')
+        end
+      )
+    end
 
     self
   end

--- a/app/services/snapshot_manager.rb
+++ b/app/services/snapshot_manager.rb
@@ -42,7 +42,8 @@ class SnapshotManager
   #   ]
   # }
   # manager.add_docs data
-  #
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   def add_docs docs, queries
     queries_to_import = []
 
@@ -83,6 +84,8 @@ class SnapshotManager
 
     self
   end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
 
   #
   # Imports queries and docs to a snapshot.
@@ -112,6 +115,7 @@ class SnapshotManager
   # manager.import_queries data
   #
   # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
   def import_queries queries
     queries_to_import = []
     keys              = queries.keys
@@ -163,6 +167,7 @@ class SnapshotManager
     self
   end
   # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
 
   def csv_to_queries_hash docs
     # print_step 'Transforming csv into a queries hash'
@@ -232,6 +237,7 @@ class SnapshotManager
     result
   end
 
+  # rubocop:disable Metrics/MethodLength
   def import_docs keys, data
     docs_to_import = []
 
@@ -263,6 +269,7 @@ class SnapshotManager
 
     self
   end
+  # rubocop:enable Metrics/MethodLength
 
   def fetch_or_create_query indexed_queries, query_text
     if indexed_queries[query_text].present?

--- a/app/services/snapshot_manager.rb
+++ b/app/services/snapshot_manager.rb
@@ -67,7 +67,6 @@ class SnapshotManager
     end
 
     # Second, mass insert queries.
-    # Using Rails' insert_all for bulk insert without callbacks
     if queries_to_import.any?
       SnapshotQuery.insert_all(
         queries_to_import.map do |query|
@@ -146,7 +145,6 @@ class SnapshotManager
     end
 
     # Second, mass insert queries.
-    # Using Rails' insert_all for bulk insert without callbacks
     if queries_to_import.any?
       SnapshotQuery.insert_all(
         queries_to_import.map do |query|
@@ -258,7 +256,6 @@ class SnapshotManager
       docs_to_import += query_docs
     end
 
-    # Using Rails' insert_all for bulk insert without callbacks
     if docs_to_import.any?
       SnapshotDoc.insert_all(
         docs_to_import.map do |doc|

--- a/lib/tasks/sample_data.thor
+++ b/lib/tasks/sample_data.thor
@@ -480,7 +480,7 @@ class SampleData < Thor
     book_params = data.to_h.deep_symbolize_keys
 
     @book = ::Book.find_by(id: 25)
-    @book&.destroy
+    @book&.really_destroy
     @book = ::Book.new(id: 25)
     options = { force_create_users: true }
     book_importer = ::BookImporter.new @book, realistic_activity_user, book_params, options

--- a/test/integration/experiment_with_bulk_insert_test.rb
+++ b/test/integration/experiment_with_bulk_insert_test.rb
@@ -6,7 +6,6 @@ class ExperimentWithBulkInsertTest < ActionDispatch::IntegrationTest
   # This test used to also do activerecord-import .import method test, but we removed that
   # dependency.
 
-  # rubocop:disable Rails/SkipsModelValidations
   let(:user) { users(:doug) }
   let(:scorer) { scorers(:quepid_default_scorer) }
   let(:selection_strategy) { selection_strategies(:multiple_raters) }

--- a/test/integration/experiment_with_bulk_insert_test.rb
+++ b/test/integration/experiment_with_bulk_insert_test.rb
@@ -3,6 +3,9 @@
 require 'test_helper'
 require 'benchmark'
 class ExperimentWithBulkInsertTest < ActionDispatch::IntegrationTest
+  # This test used to also do activerecord-import .import method test, but we removed that
+  # dependency.
+
   # rubocop:disable Rails/SkipsModelValidations
   let(:user) { users(:doug) }
   let(:scorer) { scorers(:quepid_default_scorer) }
@@ -29,30 +32,6 @@ class ExperimentWithBulkInsertTest < ActionDispatch::IntegrationTest
         assert qdp.valid?
       end
       puts "Traditional. Sample data generated successfully.  #{book.query_doc_pairs.count} query doc pairs"
-    end
-
-    # Print the elapsed time
-    puts "Elapsed time: #{result.real} seconds\n"
-  end
-
-  test 'generate and import query/doc pairs with bulk import' do
-    skip('Ignoring all tests in ExperimentWithBulkInsertTest') if @@skip_tests
-    book = user.books.create name: '50000 Query Doc Pairs', scorer: scorer, selection_strategy: selection_strategy
-    assert book.valid?
-    result = Benchmark.measure do
-      query_doc_pairs = []
-      50_000.times do
-        query_text = generate_random_string
-        doc_id = generate_random_string
-        document_fields = generate_lorem_ipsum_json
-        information_need = generate_lorem_ipsum_json
-
-        qdp = QueryDocPair.new book: book, query_text: query_text, doc_id: doc_id, document_fields: document_fields,
-                               information_need: information_need
-        query_doc_pairs << qdp
-      end
-      QueryDocPair.import query_doc_pairs
-      puts "Import. Sample data generated successfully.  #{book.query_doc_pairs.count} query doc pairs"
     end
 
     # Print the elapsed time

--- a/test/integration/experiment_with_json_render.rb
+++ b/test/integration/experiment_with_json_render.rb
@@ -54,7 +54,6 @@ class ExperimentWithJsonRender < ActionController::TestCase
         updated_at:       Time.current,
       }
     end
-    # rubocop:disable Rails/SkipsModelValidations
     QueryDocPair.insert_all!(query_doc_pairs)
     # rubocop:enable Rails/SkipsModelValidations
   end

--- a/test/services/case_score_manager_test.rb
+++ b/test/services/case_score_manager_test.rb
@@ -2,7 +2,6 @@
 
 require 'test_helper'
 
-# rubocop:disable Rails/SkipsModelValidations
 class CaseScoreManagerTest < ActiveSupport::TestCase
   let(:service) { CaseScoreManager.new the_case }
   let(:the_try) { the_case.tries.latest }

--- a/test/services/fetch_service_test.rb
+++ b/test/services/fetch_service_test.rb
@@ -307,14 +307,11 @@ class FetchServiceTest < ActiveSupport::TestCase
       results = fetch_service.setup_docs_for_query snapshot_query, docs
       assert_equal 2, results.count
 
-      # Using Rails' insert_all for bulk insert
-      if results.any?
-        SnapshotDoc.insert_all(
-          results.map do |doc|
-            doc.attributes.except('id')
-          end
-        )
-      end
+      SnapshotDoc.insert_all(
+        results.map do |doc|
+          doc.attributes.except('id')
+        end
+      )
 
       snapshot_query.reload
       assert_equal 2, snapshot_query.snapshot_docs.count

--- a/test/services/fetch_service_test.rb
+++ b/test/services/fetch_service_test.rb
@@ -307,7 +307,14 @@ class FetchServiceTest < ActiveSupport::TestCase
       results = fetch_service.setup_docs_for_query snapshot_query, docs
       assert_equal 2, results.count
 
-      SnapshotDoc.import results
+      # Using Rails' insert_all for bulk insert
+      if results.any?
+        SnapshotDoc.insert_all(
+          results.map do |doc|
+            doc.attributes.except('id')
+          end
+        )
+      end
 
       snapshot_query.reload
       assert_equal 2, snapshot_query.snapshot_docs.count


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove ActiveRecord Import in favour of native Rails ActiveRecord equivalents.

## Motivation and Context
ActiveRecord Import has much less need these days, so simplify our code base...

## How Has This Been Tested?
Manually and existing tests.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
