### PR TITLE
Fix for Books and Cases drop down links

### DIFF
--- a/app/views/dropdown/books.html.erb
+++ b/app/views/dropdown/books.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="dropdown_books">
   <% @books.each do |book| %>
-    <li><%= link_to book.name, book_path(book) %></li>
+    <li><%= link_to book.name, book_path(book), data: { turbo_frame: "_top" } %></li>
     <li><hr class="dropdown-divider"></li>
   <% end %>
 </turbo-frame>

--- a/app/views/dropdown/cases.html.erb
+++ b/app/views/dropdown/cases.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="dropdown_cases">
   <% @cases.each do |kase| %>
-  <li><%= link_to_core_case  kase.case_name, kase, kase.last_try_number %></li>
+  <li><%= link_to_core_case  kase.case_name, kase, kase.last_try_number, data: { turbo_frame: "_top" } %></li>
   <li><hr class="dropdown-divider"></li>
   <% end %>
 </turbo-frame>


### PR DESCRIPTION
## Description
Add `turbo_frame` data as `_top` to the cases and books drop-down links so the links break out of the turbo frame and navigate the full page.

## Motivation and Context
Fix [issue 1246](https://github.com/o19s/quepid/issues/1246) where the recent books and recent cases list links don't work. 

## How Has This Been Tested?
The changes have been tested manually on a local machine.

## Screenshots or GIFs (if appropriate):
https://github.com/user-attachments/assets/568cc281-3102-4432-9dfb-eba758d71451


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
