### PR TITLE
prevent casual users from seeing search endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,9 @@ EMAIL_LOGIN_ENABLED=true
 # Whether users are only allowed to use communal (admin controlled) scorers to prevent javascript embedding security issues
 COMMUNAL_SCORERS_ONLY=false
 
+# Whether only admins can access Search Endpoint management views (index, show, edit, mapper wizard)
+SEARCH_ENDPOINT_VIEWS_ADMIN_ONLY=false
+
 # What provider to use to send emails.  Blank disables sending emails.
 EMAIL_PROVIDER=
 

--- a/app/controllers/mapper_wizards_controller.rb
+++ b/app/controllers/mapper_wizards_controller.rb
@@ -3,6 +3,7 @@
 # rubocop:disable Metrics/ClassLength
 
 class MapperWizardsController < ApplicationController
+  before_action :require_admin_if_restricted
   before_action :set_search_endpoint, only: [ :show ]
   before_action :set_wizard_state, only: [ :fetch_html, :generate_mappers, :test_mapper, :refine_mapper, :save ]
 
@@ -180,6 +181,13 @@ class MapperWizardsController < ApplicationController
   # rubocop:enable Metrics/MethodLength
 
   private
+
+  def require_admin_if_restricted
+    return unless Rails.application.config.search_endpoint_views_admin_only
+    return if current_user.administrator?
+
+    redirect_to root_path, notice: 'Search Endpoint management is restricted to administrators.'
+  end
 
   def set_search_endpoint
     return if params[:search_endpoint_id].blank? || 'new' == params[:search_endpoint_id]

--- a/app/controllers/search_endpoints_controller.rb
+++ b/app/controllers/search_endpoints_controller.rb
@@ -3,6 +3,7 @@
 class SearchEndpointsController < ApplicationController
   include Pagy::Method
 
+  before_action :require_admin_if_restricted
   before_action :set_search_endpoint, only: [ :show, :edit, :update, :destroy, :clone, :archive ]
 
   respond_to :html
@@ -83,6 +84,13 @@ class SearchEndpointsController < ApplicationController
   end
 
   private
+
+  def require_admin_if_restricted
+    return unless Rails.application.config.search_endpoint_views_admin_only
+    return if current_user.administrator?
+
+    redirect_to root_path, notice: 'Search Endpoint management is restricted to administrators.'
+  end
 
   def set_search_endpoint
     @search_endpoint = current_user.search_endpoints_involved_with.where(id: params[:id]).first

--- a/app/services/mapper_wizard_service.rb
+++ b/app/services/mapper_wizard_service.rb
@@ -208,7 +208,7 @@ class MapperWizardService
       - Target V8 engine only (no DOM APIs like document.querySelector)
       - Use string parsing methods: indexOf, substring, split, match (simple regex only)
       - If the source is JSON not HTML, then do results = typeof data === 'string' ? JSON.parse(data) : data;
-    
+
 
       **Function Specifications:**
 

--- a/config/initializers/customize_quepid.rb
+++ b/config/initializers/customize_quepid.rb
@@ -94,6 +94,13 @@ Rails.application.config.quepid_domain = ENV.fetch('QUEPID_DOMAIN', '')
 # == If we have nested Quepid under a context, like tools.bigcorp.com/quepid then this deal with that situation.
 Rails.application.config.action_cable.url = "#{ENV.fetch('RAILS_RELATIVE_URL_ROOT', '')}/cable"
 
+# == Search Endpoint Views Admin Only
+# When enabled, only administrators can access the Search Endpoints management views
+# (index, show, edit, mapper wizard). Regular users will be redirected.
+# This is useful for organizations that want to centrally manage search endpoints.
+#
+Rails.application.config.search_endpoint_views_admin_only = bool.deserialize(ENV.fetch('SEARCH_ENDPOINT_VIEWS_ADMIN_ONLY', false))
+
 # == Set up encryption for Quepid
 # We provide some defaults, but you should set your own keys and NOT lose them.
 Rails.application.config.active_record.encryption.deterministic_key = ENV.fetch('ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY', 'OItaH6HSftjoxkl9QDejPAmQ8EaFOlwk')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
SEARCH_ENDPOINT_VIEWS_ADMIN_ONLY=true prevents non admins from viewing the search endpoint details.

## Motivation and Context
Fixeds #1565 

## How Has This Been Tested?
manual and test

## Screenshots or GIFs (if appropriate):

