### PR TITLE
Render as image any query text that looks like an image.

### DIFF
--- a/app/assets/javascripts/filters/isImageUrl.js
+++ b/app/assets/javascripts/filters/isImageUrl.js
@@ -1,0 +1,8 @@
+'use strict';
+
+angular.module('QuepidApp')
+  .filter('isImageUrl', function() {
+    return function(url) {
+      return typeof url === 'string' && /\.(png|jpe?g|gif|webp|svg|bmp)(\?.*)?$/i.test(url);
+    };
+  });

--- a/app/assets/stylesheets/bootstrap3-add.css
+++ b/app/assets/stylesheets/bootstrap3-add.css
@@ -536,6 +536,16 @@ header .dropdown-content li.dropdown-header {
 	margin: 20px 80% 0 0;
 }
 
+.query-thumbnail {
+	width: 75px;
+	height: 100%;
+	margin: -10px 0;
+	padding: 0;
+	display: block;
+	line-height: 0;
+	object-fit: contain;
+}
+
 .result-thumbnail {
 	width: 75px;
 	text-align: center;

--- a/app/assets/templates/views/searchResults.html
+++ b/app/assets/templates/views/searchResults.html
@@ -7,10 +7,10 @@
     <qscore-query
       class="results-score"
       max-score="maxScore || 100";
-      scorable="query"      
+      scorable="query"
     >
     </qscore-query>
-    
+
     <!-- Snapshot query scores -->
     <qscore-query
       ng-if="query.diffs"
@@ -20,12 +20,17 @@
       scorable="searcher"
     >
     </qscore-query>
-  
-
+    
     <span class="loading-query"></span>
 
     <h2 class="results-title">
-      <span class='query' uib-tooltip="Info Need: {{query.informationNeed}}" tooltip-popup-delay="1000" tooltip-placement="right">{{query.queryText}} &nbsp;</span>
+      <span class='query' uib-tooltip="Info Need: {{query.informationNeed}}" tooltip-popup-delay="1000" tooltip-placement="right">
+        <img width="120px;" ng-if="query.options && query.options.queryWidget === 'img'"
+     ng-src="{{query.queryText}}" />
+        <span ng-if="!query.options || query.options.queryWidget !== 'img'">
+          {{query.queryText}}&nbsp;
+        </span>
+      </span>
     </h2>
 
     <span class='pull-right total-results'>
@@ -41,18 +46,18 @@
 
     <span class="error-warning glyphicon glyphicon-warning-sign"></span>
 
-    <span ng-show="query.isNotAllRated()" class="pull-right" style="margin-right: 20px;" title="Hop to it!  There are unrated results!">      
+    <span ng-show="query.isNotAllRated()" class="pull-right" style="margin-right: 20px;" title="Hop to it!  There are unrated results!">
       <div class="icon-container">
         <i class="frog-icon">🐸</i>
         <div class="notification-bubble">{{ query.currentScore.countMissingRatings }}</div>
       </div>
     </span>
 
-  
+
     <span ng-show="querqyRuleTriggered()" class="pull-right" style="margin-right: 20px;" title="Querqy Strikes Again!">
-      <i class="querqy-icon"></i>   
+      <i class="querqy-icon"></i>
     </span>
-    
+
     <span class="toggleSign glyphicon {{query.isToggled() | plusOrMinus}}" ng-hide="isSortingEnabled()" ng-click="query.toggle()"></span>
   </div>
 
@@ -75,10 +80,10 @@
           title="Copy query"
           alt="Copy query"
         ></i></button>
-       
+
       </div>
-      
-      <div class="btn-group">        
+
+      <div class="btn-group">
         <button class="btn btn-default btn-sm" ng-click="displayed.notes = !displayed.notes">Toggle Notes</button>
       </div>
 

--- a/app/assets/templates/views/searchResults.html
+++ b/app/assets/templates/views/searchResults.html
@@ -20,14 +20,14 @@
       scorable="searcher"
     >
     </qscore-query>
-    
+
     <span class="loading-query"></span>
 
     <h2 class="results-title">
       <span class='query' uib-tooltip="Info Need: {{query.informationNeed}}" tooltip-popup-delay="1000" tooltip-placement="right">
-        <img width="120px;" ng-if="query.options && query.options.queryWidget === 'img'"
-     ng-src="{{query.queryText}}" />
-        <span ng-if="!query.options || query.options.queryWidget !== 'img'">
+        <img class="img-thumbnail query-thumbnail" ng-if="query.queryText | isImageUrl"
+             ng-src="{{query.queryText}}" />
+        <span ng-if="!(query.queryText | isImageUrl)">
           {{query.queryText}}&nbsp;
         </span>
       </span>

--- a/app/controllers/api/v1/snapshots/search_controller.rb
+++ b/app/controllers/api/v1/snapshots/search_controller.rb
@@ -17,7 +17,7 @@ module Api
           @q = search_params[:q]
           @snapshot_docs = nil
 
-          @q = @q.gsub('\?', '?') # Since it's a GET, a ? in the query gets special escaping
+          @q = @q.gsub(/\\(.)/, '\1') # Unescape Lucene-escaped special chars (e.g. \: \/ \? \-)
           query = if '*:*' == @q
                     # we have a match all query.
                     @snapshot.snapshot_queries.first.query

--- a/lib/tasks/sample_data.thor
+++ b/lib/tasks/sample_data.thor
@@ -45,6 +45,10 @@ class SampleData < Thor
                                                              test_query: 'q=mental',
                                                              mapper_code: File.read(Rails.root.join('test/fixtures/files/edinburgh_uni_searchapi_mapper_code.js'))
 
+    static_endpoint = ::SearchEndpoint.find_or_create_by search_engine: :static,
+                                                         name: 'Static Endpoint',
+                                                         endpoint_url: 'TO_BE_UPDATED', api_method: 'GET'
+
     print_step 'End of seeding search endpoints................'
 
     # Users
@@ -102,11 +106,13 @@ class SampleData < Thor
     tmdb_solr_endpoint.owner = realistic_activity_user
     tmdb_es_endpoint.owner = realistic_activity_user
     search_api_endpoint.owner = realistic_activity_user
+    static_endpoint.owner = realistic_activity_user
 
     statedecoded_solr_endpoint.save
     tmdb_solr_endpoint.save
     tmdb_es_endpoint.save
     search_api_endpoint.save
+    static_endpoint.save
 
     ######################################
     # OSC Team Owner
@@ -198,6 +204,44 @@ class SampleData < Thor
 
     searchapi_case.queries.create(query_text: 'student accomodation')
     print_case_info searchapi_case
+
+    ######################################
+    # Static Case
+    ######################################
+
+    static_case = realistic_activity_user.cases.find_or_create_by case_name: 'STATIC CASE'
+    static_try = static_case.tries.latest
+    static_try.search_endpoint = static_endpoint
+    static_try.update field_spec: 'id:id, title:title, image_url', query_params: 'q=#$query##'
+
+    duck_query_text = 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/bf/Bucephala-albeola-010.jpg/250px-Bucephala-albeola-010.jpg'
+    static_case.queries.find_or_create_by(query_text: duck_query_text)
+
+    if static_case.snapshots.none?
+      snapshot = static_case.snapshots.create(name: 'Duck and Swan Results')
+      duck_docs = {
+        duck_query_text => {
+          docs: [
+            { id: 'bufflehead-001',    position: 1, fields: { title: 'Bufflehead Duck', image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/bf/Bucephala-albeola-010.jpg/250px-Bucephala-albeola-010.jpg' } },
+            { id: 'mallard-001',       position: 2, fields: { title: 'Mallard Duck',              image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Mallard-duck.jpg/250px-Mallard-duck.jpg' } },
+            { id: 'mandarin-001',      position: 3, fields: { title: 'Mandarin Duck',             image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Aix_galericulata.jpg/250px-Aix_galericulata.jpg' } },
+            { id: 'wood-duck-001',     position: 4, fields: { title: 'Wood Duck',                 image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/1/1a/Wood_duck_eclipse.jpg/250px-Wood_duck_eclipse.jpg' } },
+            { id: 'teal-001',          position: 5, fields: { title: 'Green-winged Teal',         image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/5/5e/Anas_crecca_-_Riserva_Naturale_del_Lago_di_Candia.jpg/250px-Anas_crecca_-_Riserva_Naturale_del_Lago_di_Candia.jpg' } },
+            { id: 'mute-swan-001',     position: 6, fields: { title: 'Mute Swan',                 image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/3/3e/Mute_swan_Vrhnika.jpg/250px-Mute_swan_Vrhnika.jpg' } },
+            { id: 'whooper-swan-001',  position: 7, fields: { title: 'Whooper Swan',              image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/Cygnus_cygnus_-_Oulanka.jpg/250px-Cygnus_cygnus_-_Oulanka.jpg' } },
+            { id: 'trumpeter-swan-001', position: 8, fields: { title: 'Trumpeter Swan', image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/Trumpeter_Swan_Whistling_Wings.jpg/250px-Trumpeter_Swan_Whistling_Wings.jpg' } },
+            { id: 'eider-001',         position: 9, fields: { title: 'Common Eider Duck',         image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/Somateria_mollissima_male_female.jpg/250px-Somateria_mollissima_male_female.jpg' } },
+            { id: 'canvasback-001',    position: 10, fields: { title: 'Canvasback Duck',          image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Aythya-valisineria-001.jpg/250px-Aythya-valisineria-001.jpg' } }
+          ],
+        },
+      }
+      SnapshotManager.new(snapshot).import_queries(duck_docs)
+    end
+
+    static_endpoint.endpoint_url = "http://localhost:3000/api/cases/#{static_case.id}/snapshots/#{static_case.snapshots.first.id}/search"
+    static_endpoint.save
+
+    print_case_info static_case
 
     print_step 'End of seeding cases................'
 

--- a/lib/tasks/sample_data.thor
+++ b/lib/tasks/sample_data.thor
@@ -212,7 +212,7 @@ class SampleData < Thor
     static_case = realistic_activity_user.cases.find_or_create_by case_name: 'STATIC CASE'
     static_try = static_case.tries.latest
     static_try.search_endpoint = static_endpoint
-    static_try.update field_spec: 'id:id, title:title, image_url', query_params: 'q=#$query##'
+    static_try.update field_spec: 'id:id, title:title, thumb:image_url', query_params: 'q=#$query##'
 
     duck_query_text = 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/bf/Bucephala-albeola-010.jpg/250px-Bucephala-albeola-010.jpg'
     static_case.queries.find_or_create_by(query_text: duck_query_text)
@@ -222,16 +222,16 @@ class SampleData < Thor
       duck_docs = {
         duck_query_text => {
           docs: [
-            { id: 'bufflehead-001',    position: 1, fields: { title: 'Bufflehead Duck', image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/bf/Bucephala-albeola-010.jpg/250px-Bucephala-albeola-010.jpg' } },
-            { id: 'mallard-001',       position: 2, fields: { title: 'Mallard Duck',              image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Mallard-duck.jpg/250px-Mallard-duck.jpg' } },
-            { id: 'mandarin-001',      position: 3, fields: { title: 'Mandarin Duck',             image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Aix_galericulata.jpg/250px-Aix_galericulata.jpg' } },
-            { id: 'wood-duck-001',     position: 4, fields: { title: 'Wood Duck',                 image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/1/1a/Wood_duck_eclipse.jpg/250px-Wood_duck_eclipse.jpg' } },
-            { id: 'teal-001',          position: 5, fields: { title: 'Green-winged Teal',         image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/5/5e/Anas_crecca_-_Riserva_Naturale_del_Lago_di_Candia.jpg/250px-Anas_crecca_-_Riserva_Naturale_del_Lago_di_Candia.jpg' } },
-            { id: 'mute-swan-001',     position: 6, fields: { title: 'Mute Swan',                 image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/3/3e/Mute_swan_Vrhnika.jpg/250px-Mute_swan_Vrhnika.jpg' } },
-            { id: 'whooper-swan-001',  position: 7, fields: { title: 'Whooper Swan',              image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/Cygnus_cygnus_-_Oulanka.jpg/250px-Cygnus_cygnus_-_Oulanka.jpg' } },
-            { id: 'trumpeter-swan-001', position: 8, fields: { title: 'Trumpeter Swan', image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/Trumpeter_Swan_Whistling_Wings.jpg/250px-Trumpeter_Swan_Whistling_Wings.jpg' } },
-            { id: 'eider-001',         position: 9, fields: { title: 'Common Eider Duck',         image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/Somateria_mollissima_male_female.jpg/250px-Somateria_mollissima_male_female.jpg' } },
-            { id: 'canvasback-001',    position: 10, fields: { title: 'Canvasback Duck',          image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/Aythya-valisineria-001.jpg/250px-Aythya-valisineria-001.jpg' } }
+            { id: 'bufflehead-001',     position: 1,  fields: { title: 'Bufflehead Duck', image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/1/11/Drake_Bufflehead_LBI_%28cropped%29.png/330px-Drake_Bufflehead_LBI_%28cropped%29.png' } },
+            { id: 'mallard-001',        position: 2,  fields: { title: 'Mallard Duck',         image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/bf/Anas_platyrhynchos_male_female_quadrat.jpg/330px-Anas_platyrhynchos_male_female_quadrat.jpg' } },
+            { id: 'mandarin-001',       position: 3,  fields: { title: 'Mandarin Duck',        image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/75/Mandarin_duck_%28Aix_galericulata%29.jpg/330px-Mandarin_duck_%28Aix_galericulata%29.jpg' } },
+            { id: 'wood-duck-001',      position: 4,  fields: { title: 'Wood Duck',            image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e7/Wood_Duck_Wissahickon_Creek.png/330px-Wood_Duck_Wissahickon_Creek.png' } },
+            { id: 'teal-001',           position: 5,  fields: { title: 'Green-winged Teal',    image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/Green-winged_Teal%2C_Port_Aransas%2C_Texas.jpg/330px-Green-winged_Teal%2C_Port_Aransas%2C_Texas.jpg' } },
+            { id: 'mute-swan-001',      position: 6,  fields: { title: 'Mute Swan',            image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a2/CygneVaires.jpg/330px-CygneVaires.jpg' } },
+            { id: 'whooper-swan-001',   position: 7,  fields: { title: 'Whooper Swan',         image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/1/1c/Cygnus_cygnus_Singschwan.jpg/330px-Cygnus_cygnus_Singschwan.jpg' } },
+            { id: 'trumpeter-swan-001', position: 8,  fields: { title: 'Trumpeter Swan',       image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d8/Trumpeter_swans_in_winter.jpg/330px-Trumpeter_swans_in_winter.jpg' } },
+            { id: 'eider-001',          position: 9,  fields: { title: 'Common Eider Duck',    image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/%D0%9F%D1%83%D1%85%D1%96%D0%B2%D0%BA%D0%B0_%D0%BD%D0%B0_%D0%9A%D1%96%D0%BD%D0%B1%D1%83%D1%80%D0%BD%D1%81%D1%8C%D0%BA%D0%B8%D0%B9_%D0%BA%D0%BE%D1%81%D1%96.jpg/330px-%D0%9F%D1%83%D1%85%D1%96%D0%B2%D0%BA%D0%B0_%D0%BD%D0%B0_%D0%9A%D1%96%D0%BD%D0%B1%D1%83%D1%80%D0%BD%D1%81%D1%8C%D0%BA%D0%B8%D0%B9_%D0%BA%D0%BE%D1%81%D1%96.jpg' } },
+            { id: 'canvasback-001',     position: 10, fields: { title: 'Canvasback Duck',      image_url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Aythya_valisineria_at_Las_Gallinas_Wildlife_Ponds.jpg/330px-Aythya_valisineria_at_Las_Gallinas_Wildlife_Ponds.jpg' } }
           ],
         },
       }

--- a/test/controllers/api/v1/snapshots/search_controller_test.rb
+++ b/test/controllers/api/v1/snapshots/search_controller_test.rb
@@ -175,6 +175,17 @@ module Api
 
             assert_equal 'can you compare tesla to ford?', data['responseHeader']['params']['q']
           end
+
+          test 'handles a URL as a query with escaped : and /' do
+            # the front end app escapes : as \: and / as \/ in GET params
+            get :index, params: { case_id: acase.id, snapshot_id: snapshot.id, q: 'http\:\/\/server\/image.jpeg' }
+
+            assert_response :ok
+
+            data = response.parsed_body
+
+            assert_equal 'http://server/image.jpeg', data['responseHeader']['params']['q']
+          end
         end
       end
     end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR is based on https://github.com/o19s/quepid/pull/1682 by @frutik , but instead of a configuration setting, you just provide a url taht ends in a image suffix and that makes it show as an image.

So the query_text `https://upload.wikimedia.org/wikipedia/commons/thumb/b/bf/Bucephala-albeola-010.jpg/250px-Bucephala-albeola-010.jpg` would be rendered as ![duck](https://upload.wikimedia.org/wikipedia/commons/thumb/b/bf/Bucephala-albeola-010.jpg/250px-Bucephala-albeola-010.jpg)

## Motivation and Context
Image search needs images!

## How Has This Been Tested?
New static case setup by `bin/setup_docker` for testing this use case.

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)
