### PR TITLE
Define solid queue polling interval in env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ WEB_CONCURRENCY=2
 # You may need to dial it back if you are overloading the database.
 SOLID_CABLE_POLLING=0.1.seconds
 
+# How often should SOLID_QUEUE poll the database for new jobs to process.
+# You may need to dial it back if you are overloading the database.
+SOLID_QUEUE_POLLING=0.1.seconds
 
 # This makes Quepid run only on SSL, including all interactions
 # with search engines on SSL.  If FORCE_SSL is false, then Quepid will switch

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -7,7 +7,7 @@ default: &default
     - queues: "*"
       threads: 3
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
-      polling_interval: 0.1
+      polling_interval: <%= ENV.fetch("SOLID_QUEUE_POLLING", 0.1) %>
 
 development:
   <<: *default

--- a/docs/operating_documentation.md
+++ b/docs/operating_documentation.md
@@ -6,12 +6,14 @@ This document explains how Quepid can be operated and configured.   You may also
 - [Running behind a load balancer](#running-behind-a-load-balancer)
 - [Setting up a Context Path](#setting-up-a-context-path)
 - [Mail](#mail)
-- [OAuth](#OAuth)
+- [Postmark](#postmark)
+- [SMTP](#smtp)
+- [OAuth](#oauth)
+  - [Keycloak Setup Details](#keycloak-setup-details)
 - [Managing Websocket Load](#managing-websocket-load)
-- [Legal Pages & GDPR](#legal-pages-&-gdpr)
-- [User Tracking](#user-tracking)
-- [Heathcheck Endpoint](#healthcheck)
-- [Analytics Settings](#analytics-settings)
+- [Managing Job Queue Polling Frequency](#managing-job-queue-polling-frequency)
+- [Legal Pages \& GDPR](#legal-pages--gdpr)
+- [Healthcheck](#healthcheck)
 - [Troubleshoot Your Deploy](#troubleshoot-your-deploy)
 - [Database Management](#database-management)
 - [Jupyterlite Notebooks](#jupyterlite-notebooks)
@@ -153,12 +155,19 @@ Keycloak 17+ removes the `/auth` portion of the url.  If you are using earlier v
 
 ## Managing Websocket Load
 
-Quepid uses [SolidCable]() to back the websocket messaging that drives some asynchrnous communication. The state is managed in the database.
+Quepid uses [SolidCable](https://github.com/rails/solid_cable) to back the websocket messaging that drives some asynchronous communication. The state is managed in the database.
 
 By default we issue a query every tenth of a second, which can overload your database.
 
 Set `SOLID_CABLE_POLLING` to `1.seconds` or even `5.seconds` to change how often updates are checked for.  The default is `0.1.seconds`.
 
+## Managing Job Queue Polling Frequency
+
+Quepid uses [SolidQueue](https://github.com/rails/solid_queue) to back the job queue. The state is managed in the database.
+
+By default we issue a query every tenth of a second, which can overload your database.
+
+Set `SOLID_QUEUE_POLLING` to `1.seconds` or even `5.seconds` to change how often updates are checked for.  The default is `0.1.seconds`.
 
 ## Legal Pages & GDPR
 
@@ -200,7 +209,7 @@ Confirm the setup by visiting `/api/test_exception` which raises an error and wi
 
 See the details in [](./database.md).
 
-## Jupuyterlite Notebooks
+## Jupyterlite Notebooks
 
 See the details in [](./jupyterlite.md).
 


### PR DESCRIPTION
## Description

This updates config/queue.yml to read default.workers.polling_interval from a new environment variable, SOLID_QUEUE_POLLING. The default value for this variable is the currently-defined value, 0.1 seconds.

The variable is optional - if left undefined, the application uses the current interval of 0.1 seconds as the default. As a result, proposing this change should not cause any problems to any existing instance of the application.

This also adds some documentation for this new value to the operating documentation file, as well as to the example .env file.

### Side effects

While preparing this change, we made some incidental changes to the documentation in docs/operating_documentation.md

- Updated the table of contents to add some headings that hadn't been included yet.

- Adds a link to the Solid Cable documentation (there was an empty link in the markdown on line 156).

## Motivation and Context

Currently, the solid queue polling interval is explicitly defined in a yaml file to a pretty frequent value (every 0.1 seconds). This is a reasonable default for high-resource environments, but when we tired deploying the application on Heroku on low-cost tiers, we pretty quickly tripped the limits on database interactions per hour.

_I acknowledge that I have not opened an issue for this behavior. I'm happy to do so if that is preferable, but this is such a small change that it didn't feel necessary._

## How Has This Been Tested?

When we deployed this change to the instance of our application in Heroku, it gave us much greater leeway to define cases, books, and other work without tripping the database interaction limits. We were using a value of either 5 or 10 seconds, I can't recall the exact value. 

To be clear, we still tripped the database limit at times - but we were nonetheless able to do the work we needed on a relatively low cost tier on Heroku, which was not the case before implementing this change (we tripped the database limit within five minutes each time, locking us out of the application for the next hour).

While using this setting to lessen our database use, we were able to build out a few hundred queries into a few dozen cases and books, and establish that it was worth putting Quepid into production in our infrastructure.

Note also that we did not run through full measurement campaigns by multiple users under this setup - so I can't say what frequency interval would have been needed, or what database tier would have been required. Those details feel pretty specific to each institution, however, and aren't particularly relevant for whether having this setting at all is a good idea. Implementing institutions would be free to use this new setting to give themselves greater flexibility in their infrastructure, which I think our experience indicates is achieved.

## Screenshots or GIFs (if appropriate):

n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

_I'm not sure which of these types is most appropriate for this - I'm happy to adjust if needed. We've tried to make this not a breaking change, and I don't think this should be described as a bug fix_

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. _(not sure if this is the case? We tried to match the approach used for the SOLID_CABLE_POLLING variable)_
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly. _(Hopefully we updated the right documentation...)_
- [X] I have read the **CONTRIBUTING** document. _(This document references a staging branch, but I don't see one in the repo? I'm happy to close this and propose in a different way if that's what's needed. I'm leaning into this being a process, and a conversation - so I'm happy to accept guidance as we figure out how to contribute.)_
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.