### PR TITLE
Adopt splainer-search 3.x with Angular shim for wired services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Big upgrade of the core application stack, moving Ruby from 3.4.8 to 4.0.1, Rails from 8.1.1 to 8.1.2, and the Debian base image from Bookworm to Trixie, along with Bundler and numerous gem/Node package updates.
 
+* **splainer-search 3.0.0:** The `splainer-search` npm package is now a vanilla JavaScript (ESM) library rather than an AngularJS module. The Angular app still depends on the `o19s.splainer-search` module name; `app/javascript/splainer_search_adapter.js` wires the new `createWiredServices` API from the package to that module so existing injectors and services keep working.
+
 ## 8.5.0 -- 2026-01-14
 
 Changes are coming fast and furious!

--- a/app/javascript/angular_app.js
+++ b/app/javascript/angular_app.js
@@ -43,8 +43,8 @@ window.ace = ace;
 // Angular UI ACE
 import 'angular-ui-ace/src/ui-ace';
 
-// Splainer Search
-import 'splainer-search';
+// Splainer Search (vanilla-JS 3.x wrapped in a local Angular shim)
+import './splainer_search_adapter';
 
 // ng-json-explorer - use the dist file to avoid gulpfile issues
 import 'ng-json-explorer/dist/angular-json-explorer';

--- a/app/javascript/splainer_search_adapter.js
+++ b/app/javascript/splainer_search_adapter.js
@@ -1,0 +1,34 @@
+// Angular 1.x shim for splainer-search 3.0.0 (vanilla-JS ESM).
+// Registers the `o19s.splainer-search` module consumers expect, backed by
+// `createWiredServices(...)` from the rewrite. See docs/splainer_search_v3_migration.md.
+import { createFetchClient, createWiredServices, isAbortError } from 'splainer-search/wired.js';
+
+const httpClient = createFetchClient();
+const api = createWiredServices(httpClient);
+
+const ngModule = angular.module('o19s.splainer-search', []);
+
+[
+  'searchSvc',
+  'fieldSpecSvc',
+  'normalDocsSvc',
+  'esExplainExtractorSvc',
+  'solrExplainExtractorSvc',
+  'esUrlSvc',
+  'solrUrlSvc',
+  'vectaraUrlSvc',
+  'queryTemplateSvc',
+  'explainSvc',
+  'vectorSvc',
+  'docResolverSvc',
+  'utilsSvc',
+  'transportSvc',
+  'activeQueries',
+].forEach(function (name) {
+  ngModule.value(name, api[name]);
+});
+
+// Quepid injects this under the PascalCase name and uses it as a constructor.
+ngModule.value('SettingsValidatorFactory', api.settingsValidatorFactory);
+
+ngModule.constant('isAbortError', isAbortError);

--- a/app/javascript/splainer_search_adapter.js
+++ b/app/javascript/splainer_search_adapter.js
@@ -1,6 +1,6 @@
 // Angular 1.x shim for splainer-search 3.0.0 (vanilla-JS ESM).
 // Registers the `o19s.splainer-search` module consumers expect, backed by
-// `createWiredServices(...)` from the rewrite. See docs/splainer_search_v3_migration.md.
+// `createWiredServices(...)`.
 import { createFetchClient, createWiredServices, isAbortError } from 'splainer-search/wired.js';
 
 const httpClient = createFetchClient();

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ng-tags-input": "3.2.0",
     "ngclipboard": "^2.0.0",
     "popper.js": "^1.16.1",
-    "splainer-search": "o19s/splainer-search#bbc825c73e95728250d83423fad3f2a5d07cba30",
+    "splainer-search": "3.0.0",
     "tether-shepherd": "latest",
     "urijs": "^1.19.11",
     "vega": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ng-tags-input": "3.2.0",
     "ngclipboard": "^2.0.0",
     "popper.js": "^1.16.1",
-    "splainer-search": "^2.35.1",
+    "splainer-search": "o19s/splainer-search#bbc825c73e95728250d83423fad3f2a5d07cba30",
     "tether-shepherd": "latest",
     "urijs": "^1.19.11",
     "vega": "^6.0.0",

--- a/test/services/fetch_service_test.rb
+++ b/test/services/fetch_service_test.rb
@@ -181,8 +181,9 @@ class FetchServiceTest < ActiveSupport::TestCase
       end
 
       fetch_service.delete_extra_web_requests acase
-      assert_not_nil acase.snapshots.first.snapshot_queries.first.web_request
-      assert_nil acase.snapshots.second.snapshot_queries.first.web_request
+      ordered_snapshots = acase.snapshots.order(created_at: :desc)
+      assert_not_nil ordered_snapshots.first.snapshot_queries.first.web_request
+      assert_nil ordered_snapshots.second.snapshot_queries.first.web_request
     end
   end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -333,7 +333,7 @@ angular-utils-pagination@~0.11.1:
   version "0.4.2"
   resolved "https://github.com/softwaredoug/angular-wizard/archive/0.4.2.tar.gz#8de95afb5ce02915e422fd4c8f87a3cf437d264b"
 
-angular@1.8.3, angular@>=1.2.x, angular@^1.2.10, angular@~1.8.3:
+angular@>=1.2.x, angular@^1.2.10, angular@~1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/angular/-/angular-1.8.3.tgz#851ad75d5163c105a7e329555ef70c90aa706894"
   integrity sha512-5qjkWIQQVsHj4Sb5TcEs4WZWpFeVFHXwxEBHUhrny41D8UrBAd6T/6nPPAsLngJCReIOqi95W3mxdveveutpZw==
@@ -2277,12 +2277,10 @@ spark-md5@^3.0.1:
   resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
   integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
 
-splainer-search@^2.35.1:
-  version "2.36.4"
-  resolved "https://registry.yarnpkg.com/splainer-search/-/splainer-search-2.36.4.tgz#e9abb4ce1dbff2ef8243e1198af1abad35473c47"
-  integrity sha512-p0N6/NuhgoI6K8/ITCWxVzrA6hIMK6EEU3FQnSbOZ70upk4c41MJsAF/PWA5rCCc0mDVYwNp+lvMEUKUzBWzyg==
+splainer-search@o19s/splainer-search#bbc825c73e95728250d83423fad3f2a5d07cba30:
+  version "3.0.0"
+  resolved "https://codeload.github.com/o19s/splainer-search/tar.gz/bbc825c73e95728250d83423fad3f2a5d07cba30"
   dependencies:
-    angular "1.8.3"
     urijs "^1.19.7"
 
 statuses@~1.5.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2277,9 +2277,10 @@ spark-md5@^3.0.1:
   resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
   integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
 
-splainer-search@o19s/splainer-search#bbc825c73e95728250d83423fad3f2a5d07cba30:
+splainer-search@3.0.0:
   version "3.0.0"
-  resolved "https://codeload.github.com/o19s/splainer-search/tar.gz/bbc825c73e95728250d83423fad3f2a5d07cba30"
+  resolved "https://registry.yarnpkg.com/splainer-search/-/splainer-search-3.0.0.tgz#14b5ac444482804f81897d1069944f5446d15601"
+  integrity sha512-hxfS8RM0xcQFKG1Bg4euHCkHDC6XrMRlwwRzfDzJOQZE8mEoQ5UxeTM+FQbTxcWf8mUo9y6EEbz+j3F134xEcA==
   dependencies:
     urijs "^1.19.7"
 


### PR DESCRIPTION
## Description

Replace the v2 Angular package with splainer-search 3.0.0 from the splainer-rewrite branch (pinned commit for reproducible builds). The new library is vanilla ESM and no longer registers an Angular module.

- Add splainer_search_adapter.js: wire createWiredServices(createFetchClient()) once and register the same service names on o19s.splainer-search, plus SettingsValidatorFactory and isAbortError, so existing DI is unchanged.
- Point angular_app.js at the local adapter instead of importing splainer-search directly.
- Update yarn.lock; splainer-search no longer pulls Angular as a dependency.

## Motivation and Context
We want to move away from the AngularJS version of splainer-search as part of our move away from AngularJS within Quepid - this is a first step.

## How Has This Been Tested?
Tested by @epugh and myself, including running tests.

## Screenshots or GIFs (if appropriate):
NA

## Types of changes
- [] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
