### PR TITLE
Fix image lookup by llm as judge

### DIFF
--- a/app/controllers/ai_judges/prompts_controller.rb
+++ b/app/controllers/ai_judges/prompts_controller.rb
@@ -30,6 +30,12 @@ module AiJudges
       @ai_judge.update(ai_judge_params)
 
       @query_doc_pair = QueryDocPair.new(query_doc_pair_params)
+      # Form posts document_fields/options as JSON strings; .new doesn't run
+      # validations, so the JsonFormatValidator hasn't parsed them into Hashes
+      # yet. Trigger validation so the LLM service sees a proper Hash (otherwise
+      # document_fields['image'] does substring matching on the raw JSON text
+      # and the image branch never fires).
+      @query_doc_pair.valid?
 
       llm_service = LlmService.new(@ai_judge.llm_key, @ai_judge.judge_options)
       @judgement = Judgement.new(query_doc_pair: @query_doc_pair, user: @ai_judge)

--- a/app/services/llm_service.rb
+++ b/app/services/llm_service.rb
@@ -57,6 +57,8 @@ class LlmService
       { type: 'text', text: text_prompt }
     ]
 
+    # This is hard coded to `image` and should be any image.
+    # image or thumb ;-(
     if '' != document_fields['image'].to_s.strip
       image_url = document_fields['image']
       prompt << { type: 'image_url', image_url: { url: image_url } }

--- a/app/views/ai_judges/_form.html.erb
+++ b/app/views/ai_judges/_form.html.erb
@@ -25,12 +25,12 @@
 
     <div class="row mb-3">
       <%= form.label :llm_key, class: 'col-sm-2 col-form-label' %>
-      <div class="col-sm-4">
-        <%= form.text_field :llm_key %>
-      </div>
-      <div class="form-text">
-        This is the key to access your LLM provider's API.
-        It also lets Quepid distingush between AI Judges and regular Users, so you must provide something, even "abc123".
+      <div class="col-sm-10">
+        <%= form.text_field :llm_key, class: "form-control" %>
+        <div class="form-text">
+          This is the key to access your LLM provider's API.
+          It also lets Quepid distingush between AI Judges and regular Users, so you must provide something, even "abc123".
+        </div>
       </div>
     </div>
 
@@ -44,7 +44,9 @@
     </ul>
     <div class="tab-content" id="pills-tabContent">
       <div class="tab-pane fade show active" id="pills-structured-fields" role="tabpanel" aria-labelledby="pills-structured-fields-tab" tabindex="0">
-        <% @ai_judge.judge_options.each do |key, value| %>
+
+        <% sorted_judge_options = @ai_judge.judge_options.sort_by { |k, _| k.to_s == 'llm_provider' ? 0 : 1 } %>
+        <% sorted_judge_options.each do |key, value| %>
           <div class="row mb-3">
             <%= label_tag "judge_options[#{key}]", key.to_s.humanize.titleize, class: 'col-sm-2 col-form-label' %>
             <div class="col-sm-4">
@@ -81,7 +83,7 @@
             This the raw JSON stored as <code>options</code> for the Judge.
             Make sure you are editing under the <code>judge_options</code> key.
           </div>
-          <%= form.text_area :options, value: JSON.pretty_generate(@ai_judge.options.as_json),
+          <%= form.text_area :options, value: format_json(@ai_judge.options),
             class: 'form-control json-field', rows: 10, disabled: true %>
         </div>
       </div>
@@ -142,6 +144,7 @@
       openai: {
         llm_service_url: 'https://api.openai.com',
         llm_api_version: '',
+        llm_model:       'gpt-4o',
         help: '<strong>OpenAI</strong> &mdash; Direct API access.<br>' +
               '<b>URL:</b> <code>https://api.openai.com</code><br>' +
               '<b>Model:</b> e.g. <code>gpt-4o</code>, <code>gpt-4.1</code><br>' +
@@ -151,6 +154,7 @@
       azure_openai: {
         llm_service_url: 'https://RESOURCE.openai.azure.com',
         llm_api_version: '',
+        llm_model:       'gpt-4.1',
         help: '<strong>Azure OpenAI</strong> &mdash; OpenAI models hosted on Azure.<br>' +
               '<b>URL:</b> <code>https://YOUR-RESOURCE.openai.azure.com</code><br>' +
               '<b>Model:</b> Your deployment name, e.g. <code>gpt-4.1</code>, <code>gpt-5.1</code><br>' +
@@ -161,6 +165,7 @@
       azure_ai_foundry: {
         llm_service_url: 'https://RESOURCE.services.ai.azure.com',
         llm_api_version: '2025-01-01-preview',
+        llm_model:       'gpt-4o',
         help: '<strong>Azure AI Foundry</strong> &mdash; Unified Azure AI endpoint.<br>' +
               '<b>URL:</b> <code>https://YOUR-RESOURCE.services.ai.azure.com</code><br>' +
               '<b>Model:</b> Model name, e.g. <code>gpt-4o</code><br>' +
@@ -170,6 +175,7 @@
       azure_ai_foundry_serverless: {
         llm_service_url: 'https://MODEL-NAME.REGION.models.ai.azure.com',
         llm_api_version: '',
+        llm_model:       '',
         help: '<strong>Azure AI Foundry (Serverless)</strong> &mdash; Models-as-a-Service pay-per-token endpoint.<br>' +
               '<b>URL:</b> <code>https://MODEL-NAME.REGION.models.ai.azure.com</code><br>' +
               '<b>Model:</b> Model name from the deployment<br>' +
@@ -179,6 +185,7 @@
       azure_ai_foundry_anthropic: {
         llm_service_url: 'https://RESOURCE.services.ai.azure.com/anthropic',
         llm_api_version: '',
+        llm_model:       'claude-3-5-haiku-20241022',
         help: '<strong>Azure AI Foundry (Anthropic)</strong> &mdash; Claude models via Azure using the native Anthropic Messages API.<br>' +
               '<b>URL:</b> <code>https://YOUR-RESOURCE.services.ai.azure.com/anthropic</code><br>' +
               '<b>Model:</b> e.g. <code>claude-3-5-haiku-20241022</code><br>' +
@@ -188,6 +195,7 @@
       anthropic: {
         llm_service_url: 'https://api.anthropic.com',
         llm_api_version: '',
+        llm_model:       'claude-sonnet-4-5-20250514',
         help: '<strong>Anthropic</strong> &mdash; Direct Anthropic API access.<br>' +
               '<b>URL:</b> <code>https://api.anthropic.com</code><br>' +
               '<b>Model:</b> e.g. <code>claude-opus-4-6</code>, <code>claude-sonnet-4-5-20250514</code><br>' +
@@ -197,6 +205,7 @@
       google_gemini: {
         llm_service_url: 'https://generativelanguage.googleapis.com/v1beta/openai',
         llm_api_version: '',
+        llm_model:       'gemini-2.0-flash',
         help: '<strong>Google Gemini</strong> &mdash; Uses the OpenAI-compatible endpoint.<br>' +
               '<b>URL:</b> <code>https://generativelanguage.googleapis.com/v1beta/openai</code><br>' +
               '<b>Model:</b> e.g. <code>gemini-2.0-flash</code><br>' +
@@ -206,6 +215,7 @@
       ollama: {
         llm_service_url: 'http://ollama:11434',
         llm_api_version: '',
+        llm_model:       'qwen3:0.6b',
         help: '<strong>Ollama</strong> &mdash; Local models via the Ollama container.<br>' +
               '<b>URL:</b> <code>http://ollama:11434</code> (Docker) or <code>http://localhost:11434</code> (local)<br>' +
               '<b>Model:</b> e.g. <code>qwen3:0.6b</code>, <code>llama3</code><br>' +
@@ -237,9 +247,11 @@
 
         const urlField = document.getElementById('judge_options_llm_service_url');
         const apiVersionField = document.getElementById('judge_options_llm_api_version');
+        const modelField = document.getElementById('judge_options_llm_model');
 
         if (urlField) urlField.value = preset.llm_service_url;
         if (apiVersionField) apiVersionField.value = preset.llm_api_version;
+        if (modelField) modelField.value = preset.llm_model;
 
         updateProviderHelp(this.value);
       });

--- a/app/views/ai_judges/prompts/_form.html.erb
+++ b/app/views/ai_judges/prompts/_form.html.erb
@@ -10,13 +10,13 @@
       </ul>
     </div>
   <% end %>
-  
+
   <%= hidden_field_tag :book_id, @book.id if @book%>
-  
+
   <div class="row gx-5">
     <div class="col-md-6">
       <h2>Prompt Settings</h2>
-      <div>      
+      <div>
         <div>
           <%= form.textarea :system_prompt, class: "form-control", rows: 20  %>
         </div>
@@ -25,7 +25,7 @@
         </div>
         <div>
           <%= form.submit 'Run Prompt', class: 'btn btn-default btn-primary' %>
-          
+
           <%= link_to 'Back', judgement_stats_book_path(@book), method: :get, class: 'btn btn-block btn-light float-end' if @book %>
           <%= link_to 'Edit Judge', edit_team_ai_judge_path(team_id: @ai_judge.teams.first.id, id: @ai_judge.id), method: :get, class: 'btn btn-block btn-light float-end' %>
         </div>
@@ -40,7 +40,7 @@
           <p class="mt-2">Evaluating with AI Judge...</p>
         </div>
       </div>
-      
+
       <!-- Rating information shown after response -->
       <div data-prompt-form-target="ratingInfo">
         <% if @judgement %>
@@ -57,46 +57,46 @@
     </div>
     <div class="col-md-6">
       <h2>Query Doc Pair to Evaluate</h2>
-      <div>        
+      <div>
         <%= link_to 'Change Query Doc Pair', edit_ai_judge_prompt_path(@ai_judge, book_id: @book.id), class: 'btn btn-block btn-light float-end', role: 'button', method: :get if @book%>
         <%= fields_for :query_doc_pair, query_doc_pair do |query_doc_pair_fields| %>
-            
+
           <div class="field">
             <%= query_doc_pair_fields.label :query_text %>
             <%= query_doc_pair_fields.text_field :query_text %>
           </div>
-        
+
           <div class="field">
             <%= query_doc_pair_fields.label :doc_id, "Doc ID" %>
             <%= query_doc_pair_fields.text_field :doc_id %>
           </div>
-          
+
           <div class="field">
             <%= query_doc_pair_fields.label :information_need, "Information Need" %>
             <%= query_doc_pair_fields.text_field :information_need, size: 80 %>
           </div>
-          
+
           <div class="field">
             <%= query_doc_pair_fields.label :document_fields %> <small>JSON</small><br/>
-            <%= query_doc_pair_fields.text_area :document_fields, data: { codemirror_mode: "json", codemirror_height: 400  } %>
-          </div>          
-          
+            <%= query_doc_pair_fields.text_area :document_fields, value: format_json(query_doc_pair_fields.object.document_fields), data: { codemirror_mode: "json", codemirror_height: 400  } %>
+          </div>
+
           <div class="field">
             <%= query_doc_pair_fields.label :options %> <small>JSON</small><br/>
-            <%= query_doc_pair_fields.text_area :options, data: { codemirror_mode: "json", codemirror_height: 200  } %>
-          </div>  
-          
+            <%= query_doc_pair_fields.text_area :options, value: format_json(query_doc_pair_fields.object.options), data: { codemirror_mode: "json", codemirror_height: 200  } %>
+          </div>
+
           <div class="field">
             <%= query_doc_pair_fields.label :notes %><br/>
             <%= query_doc_pair_fields.text_area :notes, size: "80x8" %>
-          </div>  
-          
+          </div>
+
           <div class="field">
             <%= query_doc_pair_fields.label :position %>
             <%= query_doc_pair_fields.text_field :position %>
           </div>
-        
-   
+
+
         <% end %>
 
 
@@ -104,5 +104,5 @@
     </div>
   </div>
 
- 
+
 <% end %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is to fix #1697, the big refactor to handle json data in ActiveRecord objects the same way everywhere still had some nuanced issues, like here.

More broadly, we need to move to RubyLLM for interacting with LLMs.  Right now we have some brittle logic that if a attribute is called `image` then we use teh vision capablties of an llm. However, we don't check if a LLM supports vision, we just blinding pass the data.  (hey, a joke!)...