### PR TITLE
Fix wizard validation UI stuck after splainer-search 3.x migration.

### DIFF
--- a/app/assets/javascripts/controllers/wizardModal.js
+++ b/app/assets/javascripts/controllers/wizardModal.js
@@ -346,6 +346,7 @@ angular.module('QuepidApp')
         // exit early if we have the TLS issue, this really should be part of the below logic.
         // validator.validateTLS().then.validateURL().then....
         if ($scope.showTLSChangeWarning || $scope.invalidHeaders || $scope.invalidProxyApiMethod ){
+          $scope.validating = false;
           return;
         }
         
@@ -401,6 +402,7 @@ angular.module('QuepidApp')
             console.error('Error stack:', evalError.stack);
             $scope.mapperInvalid = true;
             $scope.mapperErrorMessage = 'Mapper code evaluation failed: ' + evalError.message;
+            $scope.validating = false;
             return; // Exit early if eval fails
           }
           
@@ -462,6 +464,9 @@ angular.module('QuepidApp')
               $scope.pendingWizardSettings.searchUrl = settingsForValidation.searchUrl;
               WizardHandler.wizard().next();
             }
+          }
+          else {
+            $scope.validating = false;
           }
         }, function (error) {
           if (error.toString().startsWith('Error: MapperError')){

--- a/app/javascript/splainer_search_adapter.js
+++ b/app/javascript/splainer_search_adapter.js
@@ -3,7 +3,28 @@
 // `createWiredServices(...)`.
 import { createFetchClient, createWiredServices, isAbortError } from 'splainer-search/wired.js';
 
-const httpClient = createFetchClient();
+// Route splainer's native fetch promises through Angular's $q so that consumer
+// .then() handlers run inside a digest. Otherwise $scope mutations from those
+// handlers leave the UI stale until another Angular event triggers a digest.
+function withAngularDigest(client) {
+  let $q;
+  const get$q = () => {
+    if ($q) return $q;
+    // ng-app="QuepidApp" lives on <body>, not <html>, so the injector is only
+    // reachable via the ng-app element (or any descendant) — not document itself.
+    const ngApp = document.querySelector('[ng-app]') || document.body;
+    $q = angular.element(ngApp).injector().get('$q');
+    return $q;
+  };
+  const wrap = (method) => (...args) => get$q().when(client[method](...args));
+  return {
+    get: wrap('get'),
+    post: wrap('post'),
+    jsonp: wrap('jsonp'),
+  };
+}
+
+const httpClient = withAngularDigest(createFetchClient({ credentials: 'include' }));
 const api = createWiredServices(httpClient);
 
 const ngModule = angular.module('o19s.splainer-search', []);


### PR DESCRIPTION
## Description
Route splainer HTTP through Angular $q so validate/ping handlers trigger a digest, and clear validating on wizard early-exit paths.

## Motivation and Context
Ping a server when adding a case wasn't completing.

## How Has This Been Tested?
- Playwright MCP
- Manually

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
