### PR TITLE
Unify AngularJS bundle rebuilds and improve dev watch workflow.

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -394,21 +394,21 @@ When developing Quepid alongside changes to `splainer-search`, you can mount you
    bin/docker s
    ```
 
-3. **Rebuild after making changes**: This is the critical step! The esbuild watch process monitors changes to `app/javascript/angular_app.js` but does NOT automatically watch files inside `node_modules/`. Your mounted splainer-search files ARE being used during builds, but changes won't be detected automatically.
+3. **After splainer changes**: **splainer-search 3.x** is installed under **`node_modules/splainer-search`** and pulled into the bundle via `app/javascript/angular_app.js` and **`splainer_search_adapter.js`**.
 
-   **After making ANY changes to your local splainer-search files, run:**
-   
-```bash
-   bin/docker r yarn build:angular-vendor
+   With **`bin/docker s`**, Foreman rebuilds the AngularJS bundles when you save; **hard-refresh** the case page.
+
+   Manual rebuild only if watchers are not running:
+
+   ```bash
+   bin/docker r yarn build:angular
    ```
 
    Then refresh your browser to see the changes.
 
-4. **Why is this rebuild needed?**
-   - Splainer-search gets bundled into `app/assets/builds/angular_app.js` by esbuild
-   - The bundling happens at build time, not runtime
-   - Changes to files in `node_modules/` aren't watched by default
-   - Your local files ARE being used, but you need to trigger a rebuild to bundle them
+4. **Why bundles work this way**
+   - Splainer-search ESM modules are inlined into **`app/assets/builds/angular_app.js`** at build time, not runtime (`splainer_search_adapter.js` registers wired singletons on the legacy Angular module **`o19s.splainer-search`** so existing DI keeps working).
+   - With **`bin/docker s`**, Foreman watches the vendor import graph (including **`node_modules/splainer-search`**) and keeps **`angular_app.js`** + **`quepid_angular_app.js`** in sync. Save edits and hard-refresh. Run **`yarn build:angular`** only if watchers are not running (that script runs both bundles).
 
 
 ## Convenience Scripts

--- a/app/javascript/splainer_search_adapter.js
+++ b/app/javascript/splainer_search_adapter.js
@@ -5,12 +5,9 @@ import { createFetchClient, createWiredServices, isAbortError } from 'splainer-s
 
 // Route splainer's native fetch promises through Angular's $q so that consumer
 // .then() handlers run inside a digest. Otherwise $scope mutations from those
-// handlers leave the UI stale until another Angular event triggers a digest.
-//
-// createFetchClient currently exposes exactly { get, post, jsonp }. If a
-// splainer-search bump adds new methods (e.g. put/delete/patch), wrap them
-// here too — otherwise they'd bypass the digest and re-introduce the
-// wizard-stuck-spinner class of bug (PR #1704).
+// handlers leave the UI stale until another Angular event triggers a digest
+// (wizard-stuck-spinner class of bug, PR #1704). Wrap every createFetchClient
+// method so future splainer-search HTTP entry points cannot bypass the digest.
 function withAngularDigest(client) {
   let $q;
   const get$q = () => {
@@ -22,11 +19,11 @@ function withAngularDigest(client) {
     return $q;
   };
   const wrap = (method) => (...args) => get$q().when(client[method](...args));
-  return {
-    get: wrap('get'),
-    post: wrap('post'),
-    jsonp: wrap('jsonp'),
-  };
+  return Object.fromEntries(
+    Object.keys(client)
+      .filter((method) => typeof client[method] === 'function')
+      .map((method) => [method, wrap(method)])
+  );
 }
 
 const httpClient = withAngularDigest(createFetchClient({ credentials: 'include' }));

--- a/app/javascript/splainer_search_adapter.js
+++ b/app/javascript/splainer_search_adapter.js
@@ -6,6 +6,11 @@ import { createFetchClient, createWiredServices, isAbortError } from 'splainer-s
 // Route splainer's native fetch promises through Angular's $q so that consumer
 // .then() handlers run inside a digest. Otherwise $scope mutations from those
 // handlers leave the UI stale until another Angular event triggers a digest.
+//
+// createFetchClient currently exposes exactly { get, post, jsonp }. If a
+// splainer-search bump adds new methods (e.g. put/delete/patch), wrap them
+// here too — otherwise they'd bypass the digest and re-introduce the
+// wizard-stuck-spinner class of bug (PR #1704).
 function withAngularDigest(client) {
   let $q;
   const get$q = () => {

--- a/bin/setup
+++ b/bin/setup
@@ -26,7 +26,8 @@ FileUtils.chdir APP_ROOT do
 
   puts "\n== Instally node packages =="
   system! "yarn"
-  
+  system! "yarn build"
+
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
   system! "bin/rails db:reset" if ARGV.include?("--reset")

--- a/bin/setup_docker
+++ b/bin/setup_docker
@@ -35,6 +35,7 @@ docker compose up ${build_arg} --no-start --remove-orphans
 bin/docker r bundle config set --local no-document true
 
 bin/docker r yarn
+bin/docker r yarn build
 bin/docker r ./wait-for mysql:3306 --timeout=60 -- bin/rake db:setup
 bin/docker r bin/rake db:migrate
 

--- a/build_angular_app.js
+++ b/build_angular_app.js
@@ -8,6 +8,7 @@ const path = require('path');
 const { execSync } = require('child_process');
 
 const OUTPUT_FILE = 'app/assets/builds/quepid_angular_app.js';
+const VENDOR_OUTPUT = 'app/assets/builds/angular_app.js';
 
 // Directories and files to watch
 const WATCH_PATHS = [
@@ -183,12 +184,20 @@ function buildAngularApp() {
   }
 }
 
+function rebuildCaseAngularBundles() {
+  console.log('Rebuilding angular_app.js + quepid_angular_app.js...');
+  execSync('npm run build:angular', { stdio: 'inherit', cwd: path.resolve(__dirname) });
+}
+
 // Main execution
 function main() {
   const isWatchMode = process.argv.includes('--watch');
   
-  // Initial build
-  buildAngularApp();
+  if (isWatchMode) {
+    rebuildCaseAngularBundles();
+  } else {
+    buildAngularApp();
+  }
   
   if (isWatchMode) {
     console.log('Watching for Angular app changes...');
@@ -199,8 +208,20 @@ function main() {
       let debounceTimer;
       const DEBOUNCE_DELAY = 300; // Wait 300ms before rebuilding
       
-      const watcher = chokidar.watch(WATCH_PATHS, {
-        ignored: [/(^|[\/\\])\./, 'node_modules', 'app/assets/builds'],
+      const vendorOutputPath = path.resolve(VENDOR_OUTPUT);
+      const watcher = chokidar.watch([...WATCH_PATHS, VENDOR_OUTPUT], {
+        ignored: (filePath) => {
+          if (/node_modules/.test(filePath)) {
+            return true;
+          }
+          if (/(^|[\/\\])\../.test(filePath)) {
+            return true;
+          }
+          if (filePath.includes(`${path.sep}app${path.sep}assets${path.sep}builds${path.sep}`)) {
+            return path.resolve(filePath) !== vendorOutputPath;
+          }
+          return false;
+        },
         persistent: true,
         awaitWriteFinish: {
           stabilityThreshold: 100,
@@ -208,26 +229,30 @@ function main() {
         }
       });
 
-      const debouncedRebuild = () => {
+      const debouncedRebuild = (changedPath) => {
         clearTimeout(debounceTimer);
         debounceTimer = setTimeout(() => {
-          console.log('Rebuilding Angular app...');
-          buildAngularApp();
+          if (changedPath && path.resolve(changedPath) === path.resolve(VENDOR_OUTPUT)) {
+            console.log('Vendor bundle updated, rebuilding quepid_angular_app.js...');
+            buildAngularApp();
+          } else {
+            rebuildCaseAngularBundles();
+          }
         }, DEBOUNCE_DELAY);
       };
 
-      watcher.on('change', (path) => {
-        console.log(`Angular file changed: ${path}`);
-        debouncedRebuild();
+      watcher.on('change', (changedPath) => {
+        console.log(`Angular file changed: ${changedPath}`);
+        debouncedRebuild(changedPath);
       });
 
-      watcher.on('add', (path) => {
-        debouncedRebuild();
+      watcher.on('add', (changedPath) => {
+        debouncedRebuild(changedPath);
       });
 
-      watcher.on('unlink', (path) => {
-        console.log(`Angular file removed: ${path}`);
-        debouncedRebuild();
+      watcher.on('unlink', (changedPath) => {
+        console.log(`Angular file removed: ${changedPath}`);
+        debouncedRebuild(changedPath);
       });
 
       watcher.on('error', error => {

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,14 +1,9 @@
 # Demonstrate how to load your own local copy of a node package into Quepid.
 # Commonly used when you are developing against an unreleased package.
 #
-# IMPORTANT: After making changes to your local splainer-search files, you MUST rebuild
-# the Angular vendor bundle for changes to take effect:
+# With bin/docker s, Foreman rebuilds the AngularJS bundles just hard-refresh the browser.
 #
-#   bin/docker r yarn build:angular-vendor
-#
-# Why? The esbuild watch process monitors changes to app/javascript/angular_app.js,
-# but does NOT automatically watch files inside node_modules/. Your mounted splainer-search
-# files ARE being used, but esbuild won't detect when they change.
+# If watchers are not running: bin/docker r yarn build:angular
 #
 # The mounted files below will be bundled into app/assets/builds/angular_app.js during
 # the build process, so any changes you make locally will be included after rebuilding.

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "build:angular-vendor": "esbuild app/javascript/angular_app.js --bundle --sourcemap --format=iife --outdir=app/assets/builds --public-path=/assets --loader:.png=dataurl --loader:.svg=dataurl --loader:.woff=dataurl --loader:.woff2=dataurl --loader:.ttf=dataurl --loader:.eot=dataurl --external:jquery",
     "build:angular-app": "node build_angular_app.js",
     "build:angular-app:watch": "node build_angular_app.js --watch",
+    "build:angular": "npm run build:angular-vendor && npm run build:angular-app",
     "build:angular-templates": "node build_templates.js",
     "build:angular-templates:watch": "node build_templates.js --watch",
     "build:admin": "esbuild app/javascript/admin_users.js --bundle --sourcemap --format=iife --outdir=app/assets/builds --public-path=/assets",


### PR DESCRIPTION
# Unify AngularJS bundle rebuilds and improve dev watch workflow

## Description

The core case UI is built from two esbuild outputs:

- `app/assets/builds/angular_app.js` — vendor bundle (`angular_app.js`, splainer-search, npm deps)
- `app/assets/builds/quepid_angular_app.js` — legacy Angular app under `app/assets/javascripts/`

Under `bin/docker s`, Foreman runs separate watchers for each (`Procfile.dev`: `angular_vendor` + `angular`). Previously, developers had to remember to run `yarn build:angular-vendor` manually after splainer-search or vendor changes, and the app watcher only rebuilt `quepid_angular_app.js` on startup — making the two bundles easy to get out of sync.

This PR:

- Adds **`yarn build:angular`** — one command to rebuild vendor + app bundles.
- Updates **`build_angular_app.js --watch`** to:
  - Rebuild **both** bundles on startup in watch mode.
  - Watch **`angular_app.js`** output; when the vendor watcher updates it, rebuild only `quepid_angular_app.js`.
  - Rebuild **both** bundles when legacy Angular source files change.
- Runs **`yarn build`** in **`bin/setup`** and **`bin/setup_docker`** so fresh checkouts have compiled case assets.
- Updates **`DEVELOPER_GUIDE.md`** and **`docker-compose.override.yml.example`** to describe the new workflow (save + hard-refresh with Foreman; manual `yarn build:angular` only when watchers aren't running).
- Updates **`splainer_search_adapter.js`** so every `createFetchClient` method is wrapped through the Angular `$q` digest shim (related to PR #1704).

## Motivation and Context

After the splainer-search 3.x migration, the case page depends on two coordinated bundles. The old docs told developers to run `yarn build:angular-vendor` by hand because esbuild's vendor watcher and the app watcher weren't wired together — easy to miss, and a common source of “I changed splainer but nothing happened” frustration.

Unifying manual rebuilds under `yarn build:angular` and teaching the app watcher to react to vendor output changes keeps `angular_app.js` and `quepid_angular_app.js` in sync during normal `bin/docker s` development without extra steps.

## How Has This Been Tested?

- [X] `bin/docker r yarn build:angular` — both bundles rebuild successfully.
- [X] `bin/docker s` — on startup, watch mode logs a full vendor + app rebuild.
- [X] Edit a file under `app/assets/javascripts/` — both bundles rebuild.
- [X] Edit / mount `node_modules/splainer-search` — vendor watcher updates `angular_app.js`; app watcher picks it up and rebuilds `quepid_angular_app.js`.
- [X] Fresh checkout path: `bin/setup_docker` (or `bin/setup`) produces usable `app/assets/builds/` assets without a separate manual build.
- [X] Case page loads and functions after rebuild (`/case/*` — no raw `{{ … }}` in header).

## Screenshots or GIFs (if appropriate)

N/A — build/dev-workflow change only.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
