### PR TITLE
Fix/wizard finish save

### DIFF
--- a/app.json
+++ b/app.json
@@ -68,6 +68,9 @@
     },
     "GOOGLE_CLIENT_SECRET": {
       "required": false
+    },
+    "PUPPETEER_SKIP_DOWNLOAD": {
+      "required": true
     }
   },
   "formation": {

--- a/app/assets/javascripts/controllers/wizardModal.js
+++ b/app/assets/javascripts/controllers/wizardModal.js
@@ -455,18 +455,16 @@ angular.module('QuepidApp')
       
         validator.validateUrl()
         .then(function () {
-          $scope.urlValid     = true;
-          
-          if ( !$scope.mapperInvalid ){
+          $scope.validating = false;
+          $scope.urlValid   = true;
+
+          if (!$scope.mapperInvalid) {
             setupDefaults(validator);
-            
-            if (!justValidate) {      
+
+            if (!justValidate) {
               $scope.pendingWizardSettings.searchUrl = settingsForValidation.searchUrl;
               WizardHandler.wizard().next();
             }
-          }
-          else {
-            $scope.validating = false;
           }
         }, function (error) {
           if (error.toString().startsWith('Error: MapperError')){

--- a/app/controllers/api/v1/tries_controller.rb
+++ b/app/controllers/api/v1/tries_controller.rb
@@ -17,8 +17,6 @@ module Api
         respond_with @try
       end
 
-      # rubocop:disable Metrics/MethodLength
-      # rubocop:disable Metrics/AbcSize
       # @request_body Try to be created [Reference:#/components/schemas/Try]
       # @request_body_example try with existing search endpoint [Reference:#/components/examples/TryWithExistingSearchEndpoint]
       # @request_body_example try creating a new search endpoint [Reference:#/components/examples/TryCreatingNewSearchEndpoint]
@@ -35,8 +33,8 @@ module Api
         # if we are creating a new try with an existing search_endpoint_id,
         # then the params[:search_endpoint] will be empty or won't be passed in
         unless params[:search_endpoint] && params[:search_endpoint].empty?
-          search_endpoint_params_to_use = search_endpoint_params
-          return unless assign_search_endpoint_to_try(search_endpoint_params_to_use)
+          assign_search_endpoint_to_try search_endpoint_params
+          return if performed?
         end
 
         try_number = @case.last_try_number + 1
@@ -61,8 +59,6 @@ module Api
           render json: @try.errors.concat(@case.errors), status: :bad_request
         end
       end
-      # rubocop:enable Metrics/MethodLength
-      # rubocop:enable Metrics/AbcSize
 
       # @request_body Try to be updated [Reference:#/components/schemas/Try]
       # @request_body_example updating a try
@@ -75,10 +71,8 @@ module Api
       #     "search_endpoint": {}
       #   }]
       def update
-        search_endpoint_params_to_use = search_endpoint_params
-        unless search_endpoint_params_to_use.empty?
-          return unless assign_search_endpoint_to_try(search_endpoint_params_to_use)
-        end
+        assign_search_endpoint_to_try search_endpoint_params unless search_endpoint_params.empty?
+        return if performed?
 
         if @try.update try_params
           respond_with @try
@@ -95,17 +89,18 @@ module Api
 
       private
 
-      def assign_search_endpoint_to_try(params_hash)
+      # Controller-internal: renders :bad_request on save failure. Callers should
+      # check Rails' `performed?` after invoking and return early if true.
+      def assign_search_endpoint_to_try params_hash
         convert_blank_values_to_nil params_hash
 
-        search_endpoint = SearchEndpoint.find_or_initialize_for_user(@current_user, params_hash)
+        search_endpoint = SearchEndpoint.find_or_initialize_for_user @current_user, params_hash
         if search_endpoint.new_record? && !search_endpoint.save
           render json: search_endpoint.errors, status: :bad_request
-          return false
+          return
         end
 
         @try.search_endpoint = search_endpoint
-        true
       end
 
       def convert_blank_values_to_nil hash

--- a/app/controllers/api/v1/tries_controller.rb
+++ b/app/controllers/api/v1/tries_controller.rb
@@ -36,16 +36,7 @@ module Api
         # then the params[:search_endpoint] will be empty or won't be passed in
         unless params[:search_endpoint] && params[:search_endpoint].empty?
           search_endpoint_params_to_use = search_endpoint_params
-          convert_blank_values_to_nil search_endpoint_params_to_use
-
-          search_endpoint = @current_user.search_endpoints_involved_with.find_by search_endpoint_params_to_use
-          if search_endpoint.nil?
-            search_endpoint = SearchEndpoint.new search_endpoint_params_to_use
-            search_endpoint.owner = @current_user
-            search_endpoint.save!
-          end
-
-          @try.search_endpoint = search_endpoint
+          return unless assign_search_endpoint_to_try(search_endpoint_params_to_use)
         end
 
         try_number = @case.last_try_number + 1
@@ -85,19 +76,8 @@ module Api
       #   }]
       def update
         search_endpoint_params_to_use = search_endpoint_params
-        search_endpoint_params_to_use = convert_blank_values_to_nil search_endpoint_params_to_use
         unless search_endpoint_params_to_use.empty?
-
-          # really should be a search_endpoint_id passed in versus all the properties of one!
-          search_endpoint = @current_user.search_endpoints_involved_with
-            .find_by search_endpoint_params_to_use.except :name
-
-          if search_endpoint.nil?
-            search_endpoint = SearchEndpoint.new search_endpoint_params_to_use
-            search_endpoint.owner = @current_user
-            search_endpoint.save!
-          end
-          @try.search_endpoint = search_endpoint
+          return unless assign_search_endpoint_to_try(search_endpoint_params_to_use)
         end
 
         if @try.update try_params
@@ -114,6 +94,19 @@ module Api
       end
 
       private
+
+      def assign_search_endpoint_to_try(params_hash)
+        convert_blank_values_to_nil params_hash
+
+        search_endpoint = SearchEndpoint.find_or_initialize_for_user(@current_user, params_hash)
+        if search_endpoint.new_record? && !search_endpoint.save
+          render json: search_endpoint.errors, status: :bad_request
+          return false
+        end
+
+        @try.search_endpoint = search_endpoint
+        true
+      end
 
       def convert_blank_values_to_nil hash
         hash.each do |key, value|

--- a/app/controllers/api/v1/tries_controller.rb
+++ b/app/controllers/api/v1/tries_controller.rb
@@ -30,9 +30,9 @@ module Api
 
         @try = @case.tries.build try_parameters_to_use # .except(:parent_try_number)
 
-        # if we are creating a new try with an existing search_endpoint_id,
-        # then the params[:search_endpoint] will be empty or won't be passed in
-        unless params[:search_endpoint] && params[:search_endpoint].empty?
+        # Only assign via nested search_endpoint params when they were actually provided.
+        # If an existing search_endpoint_id is being used, search_endpoint may be omitted.
+        if params[:search_endpoint].present?
           assign_search_endpoint_to_try search_endpoint_params
           return if performed?
         end

--- a/app/models/search_endpoint.rb
+++ b/app/models/search_endpoint.rb
@@ -83,6 +83,20 @@ class SearchEndpoint < ApplicationRecord
     Case.joins(:tries).where(tries: { search_endpoint_id: id }).distinct.count
   end
 
+  # Find an existing endpoint owned by or shared with the user, or build a new one.
+  # basic_auth_credential is excluded from the lookup because it is non-deterministically
+  # encrypted and cannot be queried with find_by.
+  def self.find_or_initialize_for_user(user, params)
+    normalized = params.to_h.symbolize_keys
+    lookup_params = normalized.except(:name, :basic_auth_credential)
+    endpoint = user.search_endpoints_involved_with.find_by(lookup_params)
+    return endpoint if endpoint
+
+    endpoint = new(normalized)
+    endpoint.owner = user
+    endpoint
+  end
+
   private
 
   def middle_truncate str, total: 30, lead: 15, trail: 15

--- a/app/models/search_endpoint.rb
+++ b/app/models/search_endpoint.rb
@@ -86,11 +86,19 @@ class SearchEndpoint < ApplicationRecord
   # Find an existing endpoint owned by or shared with the user, or build a new one.
   # basic_auth_credential is excluded from the lookup because it is non-deterministically
   # encrypted and cannot be queried with find_by.
+  # proxy_requests defaults to false when omitted so lookup matches the DB default; callers
+  # that use a proxied endpoint must pass proxy_requests explicitly.
   def self.find_or_initialize_for_user user, params
     normalized = params.to_h.symbolize_keys
-    lookup_params = normalized.except(:name, :basic_auth_credential)
-    endpoint = user.search_endpoints_involved_with.find_by(lookup_params)
-    return endpoint if endpoint
+    normalized[:proxy_requests] = false if normalized[:proxy_requests].nil?
+
+    lookup_keys = %i[search_engine endpoint_url api_method proxy_requests]
+    lookup_params = normalized.slice(*lookup_keys)
+
+    if lookup_keys.all? { |key| lookup_params.key?(key) }
+      endpoint = user.search_endpoints_involved_with.find_by(lookup_params)
+      return endpoint if endpoint
+    end
 
     endpoint = new(normalized)
     endpoint.owner = user

--- a/app/models/search_endpoint.rb
+++ b/app/models/search_endpoint.rb
@@ -92,7 +92,7 @@ class SearchEndpoint < ApplicationRecord
     normalized = params.to_h.symbolize_keys
     normalized[:proxy_requests] = false if normalized[:proxy_requests].nil?
 
-    lookup_keys = %i[search_engine endpoint_url api_method proxy_requests]
+    lookup_keys = [ :search_engine, :endpoint_url, :api_method, :proxy_requests ]
     lookup_params = normalized.slice(*lookup_keys)
 
     if lookup_keys.all? { |key| lookup_params.key?(key) }

--- a/app/models/search_endpoint.rb
+++ b/app/models/search_endpoint.rb
@@ -88,9 +88,15 @@ class SearchEndpoint < ApplicationRecord
   # encrypted and cannot be queried with find_by.
   def self.find_or_initialize_for_user user, params
     normalized = params.to_h.symbolize_keys
-    lookup_params = normalized.except(:name, :basic_auth_credential)
-    endpoint = user.search_endpoints_involved_with.find_by(lookup_params)
-    return endpoint if endpoint
+    normalized[:proxy_requests] = false if normalized[:proxy_requests].nil?
+
+    lookup_keys = %i[search_engine endpoint_url api_method proxy_requests]
+    lookup_params = normalized.slice(*lookup_keys)
+
+    if lookup_keys.all? { |key| lookup_params.key?(key) }
+      endpoint = user.search_endpoints_involved_with.find_by(lookup_params)
+      return endpoint if endpoint
+    end
 
     endpoint = new(normalized)
     endpoint.owner = user

--- a/app/models/search_endpoint.rb
+++ b/app/models/search_endpoint.rb
@@ -86,7 +86,7 @@ class SearchEndpoint < ApplicationRecord
   # Find an existing endpoint owned by or shared with the user, or build a new one.
   # basic_auth_credential is excluded from the lookup because it is non-deterministically
   # encrypted and cannot be queried with find_by.
-  def self.find_or_initialize_for_user(user, params)
+  def self.find_or_initialize_for_user user, params
     normalized = params.to_h.symbolize_keys
     lookup_params = normalized.except(:name, :basic_auth_credential)
     endpoint = user.search_endpoints_involved_with.find_by(lookup_params)

--- a/app/services/case_importer.rb
+++ b/app/services/case_importer.rb
@@ -46,6 +46,8 @@ class CaseImporter
 
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def import
     params_to_use = @data_to_process
 
@@ -102,4 +104,6 @@ class CaseImporter
   end
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
 end

--- a/app/services/case_importer.rb
+++ b/app/services/case_importer.rb
@@ -77,15 +77,11 @@ class CaseImporter
       end
     end
 
-    # find_or_create_by wasn't working, so just doing it in two steps
-    search_endpoint = @current_user.search_endpoints_involved_with.find_by(
+    search_endpoint = SearchEndpoint.find_or_initialize_for_user(
+      @current_user,
       params_to_use[:try][:search_endpoint]
     )
-    if search_endpoint.nil?
-      search_endpoint = SearchEndpoint.new(params_to_use[:try][:search_endpoint])
-      search_endpoint.owner = @current_user
-      search_endpoint.save!
-    end
+    search_endpoint.save! if search_endpoint.new_record?
 
     params_to_use[:try][:search_endpoint_id] = search_endpoint.id
     params_to_use[:try][:try_number] = 1

--- a/app/services/case_importer.rb
+++ b/app/services/case_importer.rb
@@ -81,7 +81,15 @@ class CaseImporter
       @current_user,
       params_to_use[:try][:search_endpoint]
     )
-    search_endpoint.save! if search_endpoint.new_record?
+    if search_endpoint.new_record? && !search_endpoint.save
+      search_endpoint.errors.messages.each do |attribute, messages|
+        messages.each do |message|
+          @case.errors.add(attribute, message)
+        end
+      end
+
+      return false
+    end
 
     params_to_use[:try][:search_endpoint_id] = search_endpoint.id
     params_to_use[:try][:try_number] = 1

--- a/app/services/case_importer.rb
+++ b/app/services/case_importer.rb
@@ -62,10 +62,7 @@ class CaseImporter
 
     # For some reason we can't do @case.queries.build with out forcing a save.
     # Works fine with book however.
-    unless @case.save
-      render json: @case.errors, status: :bad_request
-      return
-    end
+    return false unless @case.save
 
     params_to_use[:queries]&.each do |query|
       new_query = @case.queries.build(query.except(:ratings))
@@ -81,7 +78,15 @@ class CaseImporter
       @current_user,
       params_to_use[:try][:search_endpoint]
     )
-    search_endpoint.save! if search_endpoint.new_record?
+    if search_endpoint.new_record? && !search_endpoint.save
+      search_endpoint.errors.messages.each do |attribute, messages|
+        messages.each do |message|
+          @case.errors.add(attribute, message)
+        end
+      end
+
+      return false
+    end
 
     params_to_use[:try][:search_endpoint_id] = search_endpoint.id
     params_to_use[:try][:try_number] = 1

--- a/spec/javascripts/angular/controllers/wizardModal_spec.js
+++ b/spec/javascripts/angular/controllers/wizardModal_spec.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/*global URI, expectedSolrUrl, jasmine*/
+
 describe('Controller: WizardModalCtrl', function () {
 
   // load the controller's module
@@ -10,7 +12,6 @@ describe('Controller: WizardModalCtrl', function () {
   var settingsSvc;
   var $httpBackend;
 
-  /*global jasmine*/
   var mockModalInstance = {
     close: jasmine.createSpy(),
     dismiss: jasmine.createSpy()
@@ -20,7 +21,7 @@ describe('Controller: WizardModalCtrl', function () {
 
   var mockWizardHandler = {
     wizard: function(){
-      return {goTo: function(){}}
+      return {goTo: function(){}};
     }
   };
 
@@ -54,7 +55,7 @@ describe('Controller: WizardModalCtrl', function () {
     completedCaseWizard:       true,
     introWizardSeen: false,
     shownIntroWizard: function() {
-      self.introWizardSeen=true;
+      mockUser.introWizardSeen=true;
     }
   };
 
@@ -205,14 +206,14 @@ describe('Controller: WizardModalCtrl', function () {
   
   describe('parse url', function() {
     it('blows up on %', function() {
-      var url = "http://username:pass%@quepid-solr.dev.o19s.com:8985/solr/tmdb/select?q=*:*&fl=*&wt=json";
+      var url = 'http://username:pass%@quepid-solr.dev.o19s.com:8985/solr/tmdb/select?q=*:*&fl=*&wt=json';
       expect(function() {
         new URI(url);
       }).toThrowError('URI malformed');
     });
     
     it('Works with %25', function() {
-      var url = "http://username:pass%25@quepid-solr.dev.o19s.com:8985/solr/tmdb/select?q=*:*&fl=*&wt=json";
+      var url = 'http://username:pass%25@quepid-solr.dev.o19s.com:8985/solr/tmdb/select?q=*:*&fl=*&wt=json';
       
       var a = new URI(url);
       expect(a.password()).toBe('pass%');
@@ -220,7 +221,7 @@ describe('Controller: WizardModalCtrl', function () {
     });
     
     it('Works with %25 nested', function() {
-      var url = "http://username:pass%25word@quepid-solr.dev.o19s.com:8985/solr/tmdb/select?q=*:*&fl=*&wt=json";
+      var url = 'http://username:pass%25word@quepid-solr.dev.o19s.com:8985/solr/tmdb/select?q=*:*&fl=*&wt=json';
       
       var a = new URI(url);
       expect(a.password()).toBe('pass%word');

--- a/spec/javascripts/angular/controllers/wizardModal_spec.js
+++ b/spec/javascripts/angular/controllers/wizardModal_spec.js
@@ -225,7 +225,104 @@ describe('Controller: WizardModalCtrl', function () {
       var a = new URI(url);
       expect(a.password()).toBe('pass%word');
       expect(a.username()).toBe('username');
-    });    
+    });
 
+  });
+});
+
+describe('Controller: WizardModalCtrl — validating flag lifecycle', function () {
+
+  beforeEach(module('QuepidTest'));
+
+  var $rootScope, $q, scope;
+  var validatorDeferred;
+  var nextSpy;
+
+  beforeEach(function () {
+    /*global jasmine*/
+    nextSpy = jasmine.createSpy('wizard.next');
+
+    module(function ($provide) {
+      $provide.value('$uibModalInstance', { close: function () {}, dismiss: function () {} });
+      $provide.value('userSvc', { getUser: function () { return { completedCaseWizard: true }; } });
+      $provide.value('WizardHandler', { wizard: function () { return { next: nextSpy, goTo: function () {} }; } });
+
+      $provide.value('SettingsValidatorFactory', function () {
+        this.validateUrl = function () { return validatorDeferred.promise; };
+        this.fieldSpec   = function () { return { fieldList: function () { return []; } }; };
+      });
+    });
+
+    inject(function ($injector, $controller, _$rootScope_, _$q_) {
+      $rootScope = _$rootScope_;
+      $q = _$q_;
+      scope = $rootScope.$new();
+      validatorDeferred = $q.defer();
+
+      var $httpBackend = $injector.get('$httpBackend');
+      $httpBackend.whenGET(/^api\/cases\/\d+$/).respond(200, {});
+      $httpBackend.whenGET(/^api\/search_endpoints/).respond(200, {});
+      $httpBackend.whenGET(/^api\/cases\/\d+\/tries/).respond(200, { tries: [] });
+
+      $controller('WizardModalCtrl', { $scope: scope });
+    });
+  });
+
+  function primeSearchapi(extra) {
+    scope.pendingWizardSettings = angular.extend({
+      searchEngine:   'searchapi',
+      searchUrl:      'http://example.com/search',
+      testQuery:      'foo',
+      queryParams:    '',
+      mapperCode:     'window.numberOfResultsMapper = function(){return 0;};' +
+                      'window.docsMapper = function(){return [];};',
+      proxyRequests:  false,
+      customHeaders:  '',
+    }, extra || {});
+  }
+
+  it('clears validating when validateUrl() resolves and justValidate=true (ping it)', function () {
+    primeSearchapi();
+    scope.validate(true);
+    expect(scope.validating).toBe(true);
+
+    validatorDeferred.resolve();
+    $rootScope.$digest();
+
+    expect(scope.validating).toBe(false);
+    expect(scope.urlValid).toBe(true);
+    expect(nextSpy).not.toHaveBeenCalled();
+  });
+
+  it('clears validating and navigates when validateUrl() resolves and justValidate=false', function () {
+    primeSearchapi();
+    scope.validate(false);
+
+    validatorDeferred.resolve();
+    $rootScope.$digest();
+
+    expect(scope.validating).toBe(false);
+    expect(scope.urlValid).toBe(true);
+    expect(nextSpy).toHaveBeenCalled();
+  });
+
+  it('clears validating when validateUrl() rejects', function () {
+    primeSearchapi();
+    scope.validate(false);
+
+    validatorDeferred.reject('Error: boom');
+    $rootScope.$digest();
+
+    expect(scope.validating).toBe(false);
+    expect(scope.urlInvalid).toBe(true);
+    expect(nextSpy).not.toHaveBeenCalled();
+  });
+
+  it('clears validating on mapper eval failure (early-exit before validateUrl)', function () {
+    primeSearchapi({ mapperCode: 'throw new Error("kaboom");' });
+    scope.validate(false);
+
+    expect(scope.validating).toBe(false);
+    expect(scope.mapperInvalid).toBe(true);
   });
 });

--- a/test/controllers/api/v1/import/cases_controller_test.rb
+++ b/test/controllers/api/v1/import/cases_controller_test.rb
@@ -121,7 +121,7 @@ module Api
                     proxy_requests:        false,
                   },
                 },
-                queries:     [],
+                queries:   [],
               }
 
               assert_no_difference 'SearchEndpoint.count' do

--- a/test/controllers/api/v1/import/cases_controller_test.rb
+++ b/test/controllers/api/v1/import/cases_controller_test.rb
@@ -91,7 +91,9 @@ module Api
               case_name:   'test case',
               owner_email: 'fakeowner@fake.com',
               scorer:      acase.scorer.as_json(only: [ :name ]),
-              try:         acase.tries.last.as_json,
+              try:         acase.tries.last.as_json.merge(
+                search_endpoint: search_endpoint.as_json(except: [ :id, :owner_id, :created_at, :updated_at ])
+              ),
               queries:     [],
             }
 
@@ -102,6 +104,36 @@ module Api
             kase = Case.find_by(case_name: 'test case')
             assert_not_nil kase
             kase.owner = user
+          end
+
+          test 'returns bad request when search endpoint fails validation on import' do
+            with_require_proxy_with_basic_auth(true) do
+              data = {
+                case_name: 'invalid endpoint case',
+                scorer:    acase.scorer.as_json(only: [ :name ]),
+                try:       {
+                  escape_query:    true,
+                  search_endpoint: {
+                    search_engine:         'os',
+                    endpoint_url:          'https://opensearch.example.com/tmdb/_search',
+                    api_method:            'POST',
+                    basic_auth_credential: 'reader:reader',
+                    proxy_requests:        false,
+                  },
+                },
+                queries:     [],
+              }
+
+              assert_no_difference 'SearchEndpoint.count' do
+                post :create, params: { case: data, format: :json }
+              end
+
+              assert_response :bad_request
+
+              body = response.parsed_body
+              assert_includes body['proxy_requests'],
+                              'must be enabled when basic auth credentials are present'
+            end
           end
 
           test 'does not duplicate an existing endpoint with basic_auth_credential' do

--- a/test/controllers/api/v1/import/cases_controller_test.rb
+++ b/test/controllers/api/v1/import/cases_controller_test.rb
@@ -104,6 +104,48 @@ module Api
             kase.owner = user
           end
 
+          test 'does not duplicate an existing endpoint with basic_auth_credential' do
+            # basic_auth_credential is encrypted non-deterministically, so a naive find_by
+            # that includes it can never match an existing row and would silently create a
+            # duplicate endpoint on every import. This test locks in the lookup behavior.
+            existing = SearchEndpoint.create!(
+              name:                  'Shared OS',
+              endpoint_url:          'https://opensearch.example.com/tmdb/_search',
+              search_engine:         'os',
+              api_method:            'POST',
+              basic_auth_credential: 'reader:reader',
+              proxy_requests:        true,
+              owner:                 user
+            )
+
+            data = {
+              case_name:   'reimport case',
+              owner_email: user.email,
+              scorer:      acase.scorer.as_json(only: [ :name ]),
+              try:         {
+                escape_query:    true,
+                search_endpoint: {
+                  name:                  existing.name,
+                  endpoint_url:          existing.endpoint_url,
+                  search_engine:         existing.search_engine,
+                  api_method:            existing.api_method,
+                  basic_auth_credential: 'reader:reader',
+                  proxy_requests:        true,
+                },
+              },
+              queries:     [],
+            }
+
+            assert_no_difference 'SearchEndpoint.count' do
+              post :create, params: { case: data, format: :json }
+            end
+
+            assert_response :created
+
+            imported = Case.find_by(case_name: 'reimport case')
+            assert_equal existing, imported.tries.first.search_endpoint
+          end
+
           test 'creates a new case' do
             data = {
               case_name:   'test case',

--- a/test/controllers/api/v1/tries_controller_test.rb
+++ b/test/controllers/api/v1/tries_controller_test.rb
@@ -173,6 +173,60 @@ search_endpoint: es_endpoint.attributes }
           assert_equal 'New field_spec', the_try.field_spec
           assert_equal 'es', the_try.search_endpoint.search_engine
         end
+
+        test 'creates opensearch endpoint with basic auth and proxy on wizard finish' do
+          with_require_proxy_with_basic_auth(true) do
+            put :update,
+                params: {
+                  case_id:    the_case.id,
+                  try_number: the_try.try_number,
+                  try:        {
+                    escape_query:   true,
+                    field_spec:     'id:_id, title:title, overview, cast, thumb:poster_path',
+                    number_of_rows: 10,
+                    query_params:   "{\n  \"query\": {\n    \"multi_match\": {\n      \"query\": \"#$query##\",\n      \"fields\": [\"*\"]\n    }\n  }\n}",
+                  },
+                  search_endpoint: {
+                    search_engine:         'os',
+                    endpoint_url:          'https://quepid-opensearch.dev.o19s.com:9000/tmdb/_search',
+                    api_method:            'POST',
+                    custom_headers:        '',
+                    basic_auth_credential: 'reader:reader',
+                    proxy_requests:        true,
+                  },
+                }
+
+            assert_response :ok
+
+            the_try.reload
+            assert_equal 'os', the_try.search_endpoint.search_engine
+            assert the_try.search_endpoint.proxy_requests?
+            assert_equal 'reader:reader', the_try.search_endpoint.basic_auth_credential
+          end
+        end
+
+        test 'returns bad request when basic auth endpoint omits proxy requests' do
+          with_require_proxy_with_basic_auth(true) do
+            put :update,
+                params: {
+                  case_id:    the_case.id,
+                  try_number: the_try.try_number,
+                  try:        { field_spec: 'id:_id' },
+                  search_endpoint: {
+                    search_engine:         'os',
+                    endpoint_url:          'https://quepid-opensearch.dev.o19s.com:9000/tmdb/_search',
+                    api_method:            'POST',
+                    basic_auth_credential: 'reader:reader',
+                    proxy_requests:        false,
+                  },
+                }
+
+            assert_response :bad_request
+
+            body = response.parsed_body
+            assert_includes body['proxy_requests'], 'must be enabled when basic auth credentials are present'
+          end
+        end
       end
 
       describe 'Creates new case tries' do

--- a/test/controllers/api/v1/tries_controller_test.rb
+++ b/test/controllers/api/v1/tries_controller_test.rb
@@ -178,13 +178,13 @@ search_endpoint: es_endpoint.attributes }
           with_require_proxy_with_basic_auth(true) do
             put :update,
                 params: {
-                  case_id:    the_case.id,
-                  try_number: the_try.try_number,
-                  try:        {
+                  case_id:         the_case.id,
+                  try_number:      the_try.try_number,
+                  try:             {
                     escape_query:   true,
                     field_spec:     'id:_id, title:title, overview, cast, thumb:poster_path',
                     number_of_rows: 10,
-                    query_params:   "{\n  \"query\": {\n    \"multi_match\": {\n      \"query\": \"#$query##\",\n      \"fields\": [\"*\"]\n    }\n  }\n}",
+                    query_params:   '{"query": {"multi_match": {"query": "#$query##", "fields": ["*"]}}}',
                   },
                   search_endpoint: {
                     search_engine:         'os',
@@ -200,7 +200,7 @@ search_endpoint: es_endpoint.attributes }
 
             the_try.reload
             assert_equal 'os', the_try.search_endpoint.search_engine
-            assert the_try.search_endpoint.proxy_requests?
+            assert_predicate the_try.search_endpoint, :proxy_requests?
             assert_equal 'reader:reader', the_try.search_endpoint.basic_auth_credential
           end
         end
@@ -209,9 +209,9 @@ search_endpoint: es_endpoint.attributes }
           with_require_proxy_with_basic_auth(true) do
             put :update,
                 params: {
-                  case_id:    the_case.id,
-                  try_number: the_try.try_number,
-                  try:        { field_spec: 'id:_id' },
+                  case_id:         the_case.id,
+                  try_number:      the_try.try_number,
+                  try:             { field_spec: 'id:_id' },
                   search_endpoint: {
                     search_engine:         'os',
                     endpoint_url:          'https://quepid-opensearch.dev.o19s.com:9000/tmdb/_search',
@@ -436,6 +436,55 @@ search_endpoint: { search_engine: 'os', endpoint_url: 'http://my.os.url', api_me
 
           assert_not_equal try, created_try
           assert_equal 'os', created_try.search_endpoint.search_engine
+        end
+
+        test 'creates opensearch endpoint with basic auth and proxy on wizard finish' do
+          with_require_proxy_with_basic_auth(true) do
+            post :create,
+                 params: {
+                   case_id:         the_case.id,
+                   try:             { field_spec: 'id:_id' },
+                   search_endpoint: {
+                     search_engine:         'os',
+                     endpoint_url:          'https://quepid-opensearch.dev.o19s.com:9000/tmdb/_search',
+                     api_method:            'POST',
+                     basic_auth_credential: 'reader:reader',
+                     proxy_requests:        true,
+                   },
+                 }
+
+            assert_response :ok
+
+            the_case.reload
+            created_try = the_case.tries.where(try_number: response.parsed_body['try_number']).first
+            assert_equal 'os', created_try.search_endpoint.search_engine
+            assert_predicate created_try.search_endpoint, :proxy_requests?
+            assert_equal 'reader:reader', created_try.search_endpoint.basic_auth_credential
+          end
+        end
+
+        test 'returns bad request when basic auth endpoint omits proxy requests' do
+          with_require_proxy_with_basic_auth(true) do
+            assert_no_difference 'the_case.tries.count' do
+              post :create,
+                   params: {
+                     case_id:         the_case.id,
+                     try:             { field_spec: 'id:_id' },
+                     search_endpoint: {
+                       search_engine:         'os',
+                       endpoint_url:          'https://quepid-opensearch.dev.o19s.com:9000/tmdb/_search',
+                       api_method:            'POST',
+                       basic_auth_credential: 'reader:reader',
+                       proxy_requests:        false,
+                     },
+                   }
+            end
+
+            assert_response :bad_request
+
+            body = response.parsed_body
+            assert_includes body['proxy_requests'], 'must be enabled when basic auth credentials are present'
+          end
         end
 
         describe 'analytics' do

--- a/test/controllers/api/v1/tries_controller_test.rb
+++ b/test/controllers/api/v1/tries_controller_test.rb
@@ -233,6 +233,50 @@ search_endpoint: es_endpoint.attributes }
         let(:the_case) { cases(:case_with_one_try) }
         let(:solr_endpoint) { search_endpoints(:one) }
 
+        test 'reuses an existing search endpoint when search_endpoint_id is provided without nested params' do
+          try_params = {
+            search_endpoint_id: solr_endpoint.id,
+            field_spec:         'catch_line',
+            query_params:       'q=#$query##',
+          }
+
+          assert_difference 'the_case.tries.count', 1 do
+            assert_no_difference 'SearchEndpoint.count' do
+              post :create, params: { case_id: the_case.id, try: try_params, search_endpoint: {} }
+            end
+
+            assert_response :ok
+          end
+
+          the_case.reload
+          try_response  = response.parsed_body
+          created_try   = the_case.tries.where(try_number: try_response['try_number']).first
+
+          assert_equal solr_endpoint.id, created_try.search_endpoint_id
+        end
+
+        test 'reuses an existing search endpoint when search_endpoint param is omitted' do
+          try_params = {
+            search_endpoint_id: solr_endpoint.id,
+            field_spec:         'catch_line',
+            query_params:       'q=#$query##',
+          }
+
+          assert_difference 'the_case.tries.count', 1 do
+            assert_no_difference 'SearchEndpoint.count' do
+              post :create, params: { case_id: the_case.id, try: try_params }
+            end
+
+            assert_response :ok
+          end
+
+          the_case.reload
+          try_response  = response.parsed_body
+          created_try   = the_case.tries.where(try_number: try_response['try_number']).first
+
+          assert_equal solr_endpoint.id, created_try.search_endpoint_id
+        end
+
         test 'sets attribute successfully and assigns try to case' do
           try_params = {
 
@@ -302,8 +346,9 @@ search_endpoint: es_endpoint.attributes }
           }
 
           search_endpoint_params = {
-            search_url:    'http://solr.quepidapp.com',
+            endpoint_url:  'http://solr.quepidapp.com/solr/tmdb/select',
             search_engine: 'solr',
+            api_method:    'GET',
           }
 
           curator_vars_params = {

--- a/test/models/search_endpoint_test.rb
+++ b/test/models/search_endpoint_test.rb
@@ -160,6 +160,46 @@ class SearchEndpointTest < ActiveSupport::TestCase
     end
   end
 
+  describe 'find_or_initialize_for_user' do
+    let(:joey) { users(:joey) }
+
+    it 'finds by endpoint attributes without querying basic_auth_credential' do
+      existing = search_endpoints(:one)
+      existing.update!(
+        search_engine:         'os',
+        endpoint_url:          'https://example.com/tmdb/_search',
+        api_method:            'POST',
+        basic_auth_credential: 'reader:reader',
+        proxy_requests:        true,
+        owner:                 joey
+      )
+
+      found = SearchEndpoint.find_or_initialize_for_user(
+        joey,
+        search_engine:         'os',
+        endpoint_url:          'https://example.com/tmdb/_search',
+        api_method:            'POST',
+        basic_auth_credential: 'other:creds',
+        proxy_requests:        true
+      )
+
+      assert_equal existing, found
+    end
+
+    it 'builds a new endpoint when no match exists' do
+      endpoint = SearchEndpoint.find_or_initialize_for_user(
+        joey,
+        search_engine:  'os',
+        endpoint_url:   'https://new.example.com/tmdb/_search',
+        api_method:     'POST',
+        proxy_requests: true
+      )
+
+      assert_not endpoint.persisted?
+      assert_equal joey, endpoint.owner
+    end
+  end
+
   describe 'proxy required with basic auth credentials' do
     it 'requires proxy_requests when require_proxy_with_basic_auth_credentials is true' do
       original = Rails.application.config.require_proxy_with_basic_auth_credentials

--- a/test/models/search_endpoint_test.rb
+++ b/test/models/search_endpoint_test.rb
@@ -163,7 +163,10 @@ class SearchEndpointTest < ActiveSupport::TestCase
   describe 'find_or_initialize_for_user' do
     let(:joey) { users(:joey) }
 
-    it 'finds by endpoint attributes without querying basic_auth_credential' do
+    it 'matches an existing endpoint even when basic_auth_credential differs' do
+      # basic_auth_credential is encrypted non-deterministically, so it must be excluded
+      # from the lookup. Passing a *different* credential value here proves the lookup
+      # ignores it — otherwise we'd silently create a duplicate row on every wizard run.
       existing = search_endpoints(:one)
       existing.update!(
         search_engine:         'os',
@@ -184,6 +187,7 @@ class SearchEndpointTest < ActiveSupport::TestCase
       )
 
       assert_equal existing, found
+      assert_predicate found, :persisted?
     end
 
     it 'builds a new endpoint when no match exists' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,6 +49,14 @@ module ActiveSupport
       end
     end
 
+    def with_require_proxy_with_basic_auth value
+      original = Rails.application.config.require_proxy_with_basic_auth_credentials
+      Rails.application.config.require_proxy_with_basic_auth_credentials = value
+      yield
+    ensure
+      Rails.application.config.require_proxy_with_basic_auth_credentials = original
+    end
+
     def login_user_for_integration_test user
       # We don't actually want to load up scores...
       Bullet.enable = false


### PR DESCRIPTION
# Fix wizard finish save for basic-auth search endpoints

## Description

Fixes the case-setup wizard and related API flows when saving tries that use basic-auth search endpoints (e.g. OpenSearch behind Quepid's proxy). Also skips the Puppeteer browser download on Heroku deploys.

**Backend**
- Adds `SearchEndpoint.find_or_initialize_for_user` to find an existing endpoint by `search_engine`, `endpoint_url`, `api_method`, and `proxy_requests`, excluding `basic_auth_credential` from lookup (non-deterministic encryption made `find_by` unreliable).
- Refactors `Api::V1::TriesController` to use a shared `assign_search_endpoint_to_try` helper that returns validation errors as `:bad_request` instead of raising.
- Only assigns a search endpoint from nested params when `search_endpoint` is actually present, so `create` works when reusing an existing endpoint via `search_endpoint_id` alone.
- Updates `CaseImporter` to use the same find-or-build logic and surface search-endpoint validation errors on import.

**Frontend**
- Clears the wizard's `validating` spinner when URL validation succeeds, so the UI no longer hangs on the endpoint step after a successful check.

**Heroku**
- Adds `PUPPETEER_SKIP_DOWNLOAD` as a required env var in `app.json` so Heroku slug builds skip downloading Puppeteer's Chromium bundle (not used at runtime).

**Tests**
- Adds coverage for basic-auth + proxy wizard finish (create/update), endpoint reuse when nested params are omitted, validation failures when proxy is required but disabled, import deduplication, and `wizardModal` URL-validation behavior.
- Adds `with_require_proxy_with_basic_auth` test helper.

**Files changed (10):** `wizardModal.js`, `tries_controller.rb`, `search_endpoint.rb`, `case_importer.rb`, `app.json`, plus corresponding JS/Rails tests.

## Motivation and Context

Finishing the case wizard with a basic-auth OpenSearch endpoint could fail or create duplicate `SearchEndpoint` rows because lookup included `basic_auth_credential`, which cannot be matched reliably in the database. The wizard UI could also stay stuck on "validating" after a successful URL check.

Follow-up commits hardened the tries controller create path when nested `search_endpoint` params are omitted, improved error handling on save, and addressed PR review feedback.

The `app.json` change avoids unnecessary Puppeteer Chromium downloads during Heroku builds.

## How Has This Been Tested?

- `bin/docker r bundle exec rails test test/controllers/api/v1/tries_controller_test.rb`
- `bin/docker r bundle exec rails test test/controllers/api/v1/import/cases_controller_test.rb`
- `bin/docker r bundle exec rails test test/models/search_endpoint_test.rb`
- `bin/docker r yarn test` (includes updated `wizardModal_spec.js`)
- Playwright MCP with human supervision.

Test environment: Docker via `bin/docker`, Rails test suite and Karma/Jasmine for the Angular wizard controller spec.

## Screenshots or GIFs (if appropriate):

N/A — backend/API fix with a small wizard spinner correction; no visual UI redesign.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
