### PR TITLE
Treat blank Active Record encryption env vars as unset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,11 @@ You are working on Quepid, a Rails application. Review the ClaudeOnRails context
 
 We run Quepid in Docker primarily, don't run Rails and other build tasks locally.
 
-Assume Quepid is already up and running. Check first (for example, `docker compose ps` or a request to http://localhost) and only start it if it isn't:
+Assume Quepid is already up and running. Check first (for example, a request to http://localhost:33000 or `docker compose ps`) and only start it if it isn't.
 
-`bin/setup_docker`.
+To start rails:
+
+`bin/docker s`.
 
 To set up the environment use:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,15 +2,15 @@
 
 You are working on Quepid, a Rails application. Review the ClaudeOnRails context file at @.claude-on-rails/context.md
 
-We run Quepid in Docker primarily, don't run Rails and other build tasks locally..
+We run Quepid in Docker primarily, don't run Rails and other build tasks locally.
 
-To set up the envirnoment use:
+Assume Quepid is already up and running. Check first (for example, `docker compose ps` or a request to http://localhost) and only start it if it isn't:
 
 `bin/setup_docker`.
 
-To start rails:
+To set up the environment use:
 
-`bin/docker s`
+`bin/setup_docker`.
 
 Most commands you want to run you can just prefix with `bin/docker r bundle exec` so `rails console --environment=test` becomes `bin/docker r bundle exec rails console --environment=test`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Use yarn instead of npm for package management.
 Run javascript tests via `bin/docker r yarn test`.
 
 
-Documentation goes in the `docs` directory, not a toplevel `doc` directory.
+Documentation goes in the `docs` directory, not a toplevel `doc` directory. When editing markdown, update only what changed -- avoid rewriting unrelated sections; we want minimal churn so the diff is clear.
 
 To understand the data model used by Quepid, consult `./docs/data_mapping.md`.
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,9 +50,12 @@ module Quepid
     # place before the active_record.encryption Railtie initializer copies them into
     # ActiveRecord::Encryption.config. We provide defaults, but you should set your
     # own keys via env vars in production and NOT lose them.
-    config.active_record.encryption.primary_key         = ENV.fetch('ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY',         'bnYX3NlvUJxHWXwNYBgP33yi8BKlN7Ml')
-    config.active_record.encryption.deterministic_key   = ENV.fetch('ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY',   'OItaH6HSftjoxkl9QDejPAmQ8EaFOlwk')
-    config.active_record.encryption.key_derivation_salt = ENV.fetch('ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT', 'BzPDVAl1jAUquD4p7rM9J40wAwf7CCFh')
+    config.active_record.encryption.primary_key =
+      ENV['ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY'].presence || 'bnYX3NlvUJxHWXwNYBgP33yi8BKlN7Ml'
+    config.active_record.encryption.deterministic_key =
+      ENV['ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY'].presence || 'OItaH6HSftjoxkl9QDejPAmQ8EaFOlwk'
+    config.active_record.encryption.key_derivation_salt =
+      ENV['ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT'].presence || 'BzPDVAl1jAUquD4p7rM9J40wAwf7CCFh'
 
     # == SSL Specific Settings
     # Note, if true then this will allow Quepid to ONLY talk to HTTPS based search engines.

--- a/docs/ENCRYPTION_SETUP.md
+++ b/docs/ENCRYPTION_SETUP.md
@@ -1,42 +1,53 @@
-# ActiveRecord Encryption Setup for LLM Keys
+# ActiveRecord Encryption Setup
 
-This document describes the encryption setup for User's `llm_key` field in Quepid.
+Quepid encrypts sensitive attributes at rest using [Active Record Encryption](https://guides.rubyonrails.org/active_record_encryption.html).
 
-## Overview
+## Encrypted fields
 
-The `llm_key` field in the User model is now encrypted using ActiveRecord encryption. This ensures that sensitive API keys are not stored in plaintext in the database.
+| Model | Attribute | Purpose |
+|-------|-----------|---------|
+| `User` | `llm_key` | AI judge API keys |
+| `SearchEndpoint` | `basic_auth_credential` | Search engine HTTP basic auth (`username:password`) |
+| `MapperWizardState` | `basic_auth_credential` | Mapper wizard draft basic auth (same format) |
 
 ## Configuration
 
 ### 1. Encryption Keys
 
-The encryption requires three keys to be configured. You can set these up in one of two ways:
+Encryption keys are set in `config/application.rb` via `ENV[...].presence` with committed defaults.
 
-Set the following environment variables:
+Generate values with `bin/rails db:encryption:init`, then set environment variables (see `.env.example`):
+
 ```bash
-export ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY="your-32-char-key"
-export ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT="your-32-char-salt"
-export ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY="your-32-char-primary-key"
+export ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY="your-primary-key"
+export ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY="your-deterministic-key"
+export ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT="your-salt"
 ```
+
+If a variable is unset, the default in `application.rb` is used. If it is set to an empty string, encryption will fail—remove the config entry or set a real value.
 
 ### 2. Development Environment
 
-For development and test environments, default keys are automatically used if no credentials or environment variables are set. These should NEVER be used in production.
+For development and test environments, default keys are automatically used if the environment variables are unset. These should NEVER be used in production.
+
+`config.active_record.encryption.support_unencrypted_data = true` in `application.rb` allows reading legacy plaintext rows during migration.
 
 ## Migration
 
-To encrypt existing `llm_key` values in your database:
+To encrypt existing values in your database:
 
 ```bash
 bundle exec rails db:migrate
 ```
 
-The migration `EncryptExistingUserLlmKeys` will:
-1. Find all users with non-null `llm_key` values
-2. Re-save each record to trigger encryption
-3. Process records in batches to handle large datasets efficiently
+- `EncryptExistingUserLlmKeys` — finds users with non-null `llm_key`, re-saves each record to trigger encryption, in batches
+- `EncryptExistingBasicAuthCredentials` — re-saves `SearchEndpoint` and `MapperWizardState` rows that have basic auth credentials
 
-## Usage
+Both require `support_unencrypted_data = true` (already set in `application.rb`).
+
+**Back up the database before migrating.** These migrations are not reversible; ciphertext cannot be turned back into plaintext via `db:rollback`.
+
+## Usage examples
 
 Once configured, encryption happens automatically:
 
@@ -59,8 +70,10 @@ user.llm_key  # => "sk-1234567890"
 ## Testing
 
 Run the encryption tests:
+
 ```bash
 bundle exec rails test test/models/user_llm_key_encryption_test.rb
+bundle exec rails test test/models/search_endpoint_test.rb
 ```
 
 ## Important Notes
@@ -75,7 +88,7 @@ bundle exec rails test test/models/user_llm_key_encryption_test.rb
 
 If you encounter issues:
 
-1. Ensure all three encryption keys are properly configured
-2. Check that the keys are exactly 32 characters long
-3. Verify Rails can access the credentials: `Rails.application.credentials.active_record_encryption`
+1. Ensure all three `ACTIVE_RECORD_ENCRYPTION_*` environment variables are unset or non-empty (blank values fall back to defaults)
+2. Keep the same key values across deploys; changing keys without re-encrypting makes existing data unreadable
+3. For `Missing Active Record encryption credential: active_record_encryption.primary_key` on case API loads, check keys in `application.rb` and basic auth on tries (`app/views/api/v1/tries/_try.json.jbuilder`)
 4. Check logs for any encryption-related errors during migration

--- a/docs/ENCRYPTION_SETUP.md
+++ b/docs/ENCRYPTION_SETUP.md
@@ -24,7 +24,7 @@ export ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY="your-deterministic-key"
 export ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT="your-salt"
 ```
 
-If a variable is unset, the default in `application.rb` is used. If it is set to an empty string, encryption will fail—remove the config entry or set a real value.
+If a variable is unset or set to an empty string, the default in `application.rb` is used. Set a non-empty value only when you intend to override the committed default.
 
 ### 2. Development Environment
 

--- a/docs/operating_documentation.md
+++ b/docs/operating_documentation.md
@@ -310,7 +310,7 @@ Once they see it, they won't see it again.
 
 ## ActiveRecord Encryption Setup
 
-Quepid uses ActiveRecord encryption to protect sensitive data like LLM API keys. For details on how to set up and configure encryption for your Quepid installation, see [ENCRYPTION_SETUP.md](./ENCRYPTION_SETUP.md).
+Quepid uses ActiveRecord encryption to protect sensitive data like LLM API keys and search endpoint basic auth (keys in `config/application.rb`). For details on how to set up and configure encryption for your Quepid installation, see [ENCRYPTION_SETUP.md](./ENCRYPTION_SETUP.md).
 
 ## Integrating External Eval Pipeline
 


### PR DESCRIPTION
## Description

This PR makes Active Record encryption configuration more robust when `ACTIVE_RECORD_ENCRYPTION_*` environment variables are present but empty, and updates encryption documentation.

**`config/application.rb`**

- Replaces `ENV.fetch(...)` with `ENV[...].presence || default` for all three encryption keys (`primary_key`, `deterministic_key`, `key_derivation_salt`).
- Empty strings now fall back to the committed defaults instead of being passed through as invalid keys, which could break decryption of existing encrypted data.

**`docs/ENCRYPTION_SETUP.md`**

- Broadens scope from LLM keys only to all encrypted attributes (`User#llm_key`, `SearchEndpoint#basic_auth_credential`, `MapperWizardState#basic_auth_credential`).
- Documents that keys are configured in `application.rb` via `ENV[...].presence` with committed defaults.
- Documents both encryption migrations (`EncryptExistingUserLlmKeys` and `EncryptExistingBasicAuthCredentials`).
- Adds notes on `support_unencrypted_data`, backup/rollback limitations, and troubleshooting (including basic auth on tries).

**`docs/operating_documentation.md`**

- Minor cross-reference update to mention basic auth and `config/application.rb` key configuration.

**`CLAUDE.md`**

- Add a line encouraging minimal doc churn when editing markdown (no unrelated rewrites).
- Encourage use of existing Docker before trying to start new instances.

## Motivation and Context

Deploy environments sometimes define `ACTIVE_RECORD_ENCRYPTION_*` variables with empty values (e.g. placeholder entries in `.env`, Docker compose, Heroku, or orchestration templates). With `ENV.fetch`, an empty string is treated as a real value and overrides the defaults in `application.rb`, causing decryption failures for data encrypted with the default keys.

Using `.presence` treats blank values the same as unset variables, so development and test setups continue to work while production operators who intentionally set real keys are unaffected.

## How Has This Been Tested?

- Reviewed the diff to confirm blank env vars resolve to the same defaults as unset vars.
- Verified documentation matches current `application.rb` configuration and existing migrations.
- Ran full test suite.

## Screenshots or GIFs (if appropriate):

N/A — configuration and documentation changes only.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
