### PR TITLE
Improve wizard finish save and search endpoint credential handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ To start rails:
 
 `bin/docker s`
 
+Do not stop (you may restart) the dev server unless the user explicitly asks. Leave it running across tasks.
+
 Most commands you want to run you can just prefix with `bin/docker r bundle exec` so `rails console --environment=test` becomes `bin/docker r bundle exec rails console --environment=test`
 
 Use yarn instead of npm for package management.
@@ -37,3 +39,13 @@ Likewise urls generated should never start with / as we need relative links.
 In Ruby we say `credentials?` versus `has_credentials?` for predicates.
 
 In JavaScript, use `const` or `let` instead of `var`. When writing multiline ternary expressions, keep `?` and `:` at the end of the line, not the start of the next line, to avoid JSHint "misleading line break" errors.
+
+## UI changes — screenshots via Playwright MCP (`playwright` server)
+
+For any user-visible change, prove the behavior with Playwright MCP screenshots — never substitute prose or memory. App: `http://localhost:33000`; sign in with `quepid+realisticactivity@o19s.com` / `password`.
+
+- **Before & after**: capture the affected flow before editing, then repeat the identical steps after. Capture every relevant state (modal open/closed, accordion expanded, error vs success, etc.). `browser_snapshot` is only for driving clicks; `browser_take_screenshot` is the proof.
+- **Frame big** (my screenshots have come out too small): shoot the **full viewport**, not element crops. Quepid modals scroll *internally*, so `fullPage:true` does NOT reach below their fold — instead `browser_resize` the viewport to roughly match the modal so it fills the frame, then screenshot the viewport. Size to the content: a tall step (e.g. the wizard endpoint step) needs ~`820x2200`; a short step (e.g. wizard Finish) needs ~`900x760` — a tall viewport dwarfs a short modal. Narrower width = modal fills more of the frame.
+- **Force hard-to-reach states** (e.g. a failed save) by intercepting the API with `browser_run_code_unsafe` + `page.route('**/api/...', ...)`.
+    - Gotcha: `setTimeout` is undefined in that context — use `await page.waitForTimeout(ms)` for delays.
+- **Save** under `.playwright-mcp/` (gitignored) with clear `-before`/`-after` (+ state) names, e.g. `behavior-wizard-proxy-after-error.png`.

--- a/app/assets/javascripts/controllers/wizardModal.js
+++ b/app/assets/javascripts/controllers/wizardModal.js
@@ -264,6 +264,14 @@ angular.module('QuepidApp')
       $scope.validateHeaders = validateHeaders;
       $scope.validateProxyApiMethod = validateProxyApiMethod;
       $scope.changeProxySetting = changeProxySetting;
+
+      // Toggle via a function so the write lands on the controller scope.
+      // An inline `ng-click="x = !x"` would shadow the primitive on the
+      // ng-if child scope, breaking programmatic opens (showProxyHelpIfNeeded).
+      $scope.toggleHeaderConfig = function () {
+        $scope.isHeaderConfigCollapsed = !$scope.isHeaderConfigCollapsed;
+      };
+
       $scope.searchFields   = [];
       $scope.createSnapshot = createSnapshot;
 
@@ -473,9 +481,20 @@ angular.module('QuepidApp')
           }
           else {
             $scope.urlInvalid = true;
+            showProxyHelpIfNeeded();
           }              
           $scope.validating = false;
         });
+      }
+
+      function showProxyHelpIfNeeded () {
+        if (
+          $scope.urlInvalid &&
+          !$scope.pendingWizardSettings.proxyRequests &&
+          $scope.pendingWizardSettings.searchEngine !== 'static'
+        ) {
+          $scope.isHeaderConfigCollapsed = true;
+        }
       }
 
       function validateHeaders () {
@@ -704,6 +723,10 @@ angular.module('QuepidApp')
 
         // pass pending settings on to be saved
         $scope.pendingWizardSettings.submit = function() {
+          if ($scope.savingFinish) {
+            return;
+          }
+
           $log.debug('Submitting settings (from wizard modal)');
 
           // if we aren't using a demo, then lets finalize our queryParams with our best guess
@@ -717,7 +740,9 @@ angular.module('QuepidApp')
            }
          }
 
-          settingsSvc.update($scope.pendingWizardSettings)
+          $scope.finishSaveError = null;
+          $scope.savingFinish = true;
+          return settingsSvc.update($scope.pendingWizardSettings)
           .then(function() {
             var latestSettings = settingsSvc.editableSettings();
             docCacheSvc.invalidate();
@@ -746,8 +771,43 @@ angular.module('QuepidApp')
             $rootScope.currentUser.shownIntroWizard();
 
             $uibModalInstance.close();
+          })
+          .catch(function(response) {
+            $log.error('Wizard finish save failed', response);
+            $scope.finishSaveError = formatFinishSaveError(response);
+          })
+          .finally(function() {
+            $scope.savingFinish = false;
           });
         };
+
+        function formatFinishSaveError(response) {
+          var data = response && response.data;
+          var detail = '';
+
+          if (angular.isString(data)) {
+            detail = data;
+          } else if (angular.isObject(data)) {
+            if (data.error) {
+              detail = data.error;
+            } else {
+              var messages = [];
+              angular.forEach(data, function(value, key) {
+                if (angular.isArray(value)) {
+                  messages.push(key + ' ' + value.join(', '));
+                } else if (angular.isString(value)) {
+                  messages.push(value);
+                }
+              });
+              detail = messages.join('. ');
+            }
+          }
+
+          if (detail) {
+            return 'Could not save your case settings: ' + detail + '. Please click Finish to try again.';
+          }
+          return 'Could not save your case settings. Please click Finish to try again.';
+        }
       });
 
       $scope.close = function() {

--- a/app/assets/templates/views/wizardModal.html
+++ b/app/assets/templates/views/wizardModal.html
@@ -81,7 +81,7 @@
             <div ng-show="showTLSChangeWarning" class="alert alert-warning">
               <span>
               You have specified a search endpoint url that is on a different protocol ( <code>{{protocolToSwitchTo}}</code> ) than Quepid is running,
-              and this triggers your browser to prevent communciation with the search endpoint.
+              and this triggers your browser to prevent communication with the search endpoint.
               <br/>Option 1: Reload Quepid to run on the correct protocol.
               <br/>Option 2: Proxy the requests THROUGH the Quepid server.
               </span>

--- a/app/assets/templates/views/wizardModal.html
+++ b/app/assets/templates/views/wizardModal.html
@@ -81,7 +81,8 @@
             <div ng-show="showTLSChangeWarning" class="alert alert-warning">
               <span>
               You have specified a search endpoint url that is on a different protocol ( <code>{{protocolToSwitchTo}}</code> ) than Quepid is running,
-              and this triggers your browser to prevent communciation with the search endpoint.  <br/>Option 1: Reload Quepid to run on the correct protocol
+              and this triggers your browser to prevent communciation with the search endpoint.
+              <br/>Option 1: Reload Quepid to run on the correct protocol.
               <br/>Option 2: Proxy the requests THROUGH the Quepid server.
               </span>
             </div>
@@ -94,32 +95,36 @@
               Sorry, we're not getting any search results from your {{ pendingWizardSettings.searchEngine | searchEngineName }}.
 
               <ul ng-if="pendingWizardSettings.searchEngine === 'searchapi'">
-                <li>Is your Search API behind a firewall or proxy? Try accessing the <a target="_blank" ng-href="{{linkToSearchEndpointUrl()}}">URL directly</a> and see if you get a response</li>
-                <li>Do you need an API Key?  If so, set one up under Advanced pane --> Custom Headers.</li>
+                <li ng-if="!pendingWizardSettings.proxyRequests"><strong>Quick fix:</strong> check <strong>Proxy Requests</strong> below so Quepid's server talks to your Search API instead of your browser.</li>
+                <li ng-if="!pendingWizardSettings.proxyRequests"><strong>Or configure CORS</strong> on your Search API if your team prefers direct browser access.</li>
+                <li>Can you open the <a target="_blank" ng-href="{{linkToSearchEndpointUrl()}}">URL directly</a> in a new tab? If yes but Quepid still fails, check the browser console for CORS errors.</li>
+                <li>Do you need an API Key?  If so, set one up in <strong>Custom Headers</strong> below.</li>
                 <li>Use the browser <i>Network Inspector</i> to see the actual request.</li>
                 <li>See the <a target="_blank" href="https://github.com/o19s/quepid/wiki/Troubleshooting-SearchAPI-and-Quepid/">Troubleshooting Search API and Quepid</a> wiki page for more help!</li>
               </ul>
 
               <ul ng-if="pendingWizardSettings.searchEngine === 'es'">
-                <li>Is your Elasticsearch behind a firewall or proxy? Try accessing the <a target="_blank" ng-href="{{linkToSearchEndpointUrl()}}">URL directly</a> and see if you get a response</li>
+                <li ng-if="!pendingWizardSettings.proxyRequests"><strong>Quick fix:</strong> check <strong>Proxy Requests</strong> below so Quepid's server talks to Elasticsearch instead of your browser. No cluster changes required.</li>
+                <li ng-if="!pendingWizardSettings.proxyRequests"><strong>Or configure CORS</strong> on Elasticsearch to allow Quepid's domain if your team prefers direct browser access.</li>
+                <li>Can you open the <a target="_blank" ng-href="{{linkToSearchEndpointUrl()}}">URL directly</a> in a new tab? If yes but Quepid still fails, check the browser console for CORS errors.</li>
                 <li>Does your Elasticsearch accept HTTP POST requests?</li>
-                <li>Is your Elasticsearch setup for CORS to talk to Quepid's web app (http://go.quepidapp.com)?</li>
-                <li>Do you need an API Key?  If so, set one up under Advanced pane --> Custom Headers.</li>
+                <li>Do you need an API Key?  If so, set one up in <strong>Custom Headers</strong> below.</li>
                 <li>Use the browser <i>Network Inspector</i> to see the actual request.</li>
                 <li>See the <a target="_blank" href="https://github.com/o19s/quepid/wiki/Troubleshooting-Elasticsearch-and-Quepid/">Troubleshooting Elasticsearch and Quepid</a> wiki page for more help!</li>
               </ul>
 
               <ul ng-if="pendingWizardSettings.searchEngine === 'os'">
-                <li>Is your OpenSearch behind a firewall or proxy? Try accessing the <a target="_blank" ng-href="{{linkToSearchEndpointUrl()}}">URL directly</a> and see if you get a response</li>
+                <li ng-if="!pendingWizardSettings.proxyRequests"><strong>Quick fix:</strong> check <strong>Proxy Requests</strong> below so Quepid's server talks to OpenSearch instead of your browser. No cluster changes required.</li>
+                <li ng-if="!pendingWizardSettings.proxyRequests"><strong>Or configure CORS</strong> on OpenSearch to allow Quepid's domain if your team prefers direct browser access.</li>
+                <li>Can you open the <a target="_blank" ng-href="{{linkToSearchEndpointUrl()}}">URL directly</a> in a new tab? If yes but Quepid still fails, check the browser console for CORS errors.</li>
                 <li>Does your OpenSearch accept HTTP POST requests?</li>
-                <li>Is your OpenSearch setup for CORS to talk to Quepid's web app (http://go.quepidapp.com)?</li>
                 <li>Use the browser <i>Network Inspector</i> to see the actual request.</li>
                 <li>See the <a target="_blank" href="https://github.com/o19s/quepid/wiki/Troubleshooting-OpenSearch-and-Quepid/">Troubleshooting OpenSearch and Quepid</a> wiki page for more help!</li>
               </ul>
 
               <ul ng-if="pendingWizardSettings.searchEngine === 'solr'">
-                <li>Do you see any errors when you visit your <a target="_blank" ng-href="{{linkToSearchEndpointUrl()}}">Solr URL directly?</a></li>
-                <li>Use the Proxy option under <i>Advanced</i>!</li>
+                <li ng-if="!pendingWizardSettings.proxyRequests"><strong>Quick fix:</strong> check <strong>Proxy Requests</strong> below so Quepid's server talks to Solr instead of your browser. No Solr configuration changes required.</li>
+                <li>Do you see any errors when you visit your <a target="_blank" ng-href="{{linkToSearchEndpointUrl()}}">Solr URL directly?</a> If Solr responds but Quepid still fails, check the browser console for CORS or mixed-content errors.</li>
                 <li>
                   You may need to configure the JSON <code>wt=json</code> to be <code>application/javascript</code> to work with Quepid.
                   You can do this via the below curl command:
@@ -270,7 +275,7 @@ star wars,1921,3, Star Wars: Return of the Jedi
 
             <span ng-if="pendingWizardSettings.searchEngine !== 'static'">
             <p>
-              <button type="button" class="btn btn-sm btn-default" ng-click="isHeaderConfigCollapsed = !isHeaderConfigCollapsed">Advanced</button>
+              <button type="button" class="btn btn-sm btn-default" ng-click="toggleHeaderConfig()">Advanced</button>
             </p>
             <div uib-collapse="!isHeaderConfigCollapsed">
               <div class="well well-sm">
@@ -279,7 +284,7 @@ star wars,1921,3, Star Wars: Return of the Jedi
                   <div class="col-sm-9">
                     <div class="checkbox">
                       <label>
-                        <p class="help-block"><input id="proxy-requests" type="checkbox" ng-model="pendingWizardSettings.proxyRequests" ng-change="changeProxySetting()">Fighting with CORS issues?  Proxy your search requests through Quepid server.</p>
+                        <p class="help-block"><input id="proxy-requests" type="checkbox" ng-model="pendingWizardSettings.proxyRequests" ng-change="changeProxySetting()">Route search requests through the Quepid server instead of the browser. Useful when CORS, mixed-content, or firewall rules block direct access; check with your operations team if unsure.</p>
                       </label>
                     </div>
                   </div>
@@ -510,8 +515,11 @@ star wars,1921,3, Star Wars: Return of the Jedi
     <wz-step title="Finish" id="step-six">
       <h1>That's It!</h1>
       <p class="help-block">Go to "Tune Relevance" to iterate on your relevance and manipulate searches</p>
+      <div ng-show="finishSaveError" class="alert alert-danger">
+        {{ finishSaveError }}
+      </div>
       
-      <button class="btn-lg btn-success pull-right finish" wz-next>Finish</button>
+      <button class="btn-lg btn-success pull-right finish" wz-next ng-disabled="savingFinish">Finish</button>
       <br><br><br><br><br>
     </wz-step>
   </wizard>

--- a/app/controllers/api/v1/tries_controller.rb
+++ b/app/controllers/api/v1/tries_controller.rb
@@ -93,14 +93,39 @@ module Api
       # check Rails' `performed?` after invoking and return early if true.
       def assign_search_endpoint_to_try params_hash
         convert_blank_values_to_nil params_hash
+        return if params_hash.blank?
 
         search_endpoint = SearchEndpoint.find_or_initialize_for_user @current_user, params_hash
-        if search_endpoint.new_record? && !search_endpoint.save
-          render json: search_endpoint.errors, status: :bad_request
-          return
+
+        if search_endpoint.new_record?
+          save_search_endpoint_or_render_errors search_endpoint
+          return if performed?
+        elsif search_endpoint.owner_id == @current_user.id
+          merge_search_endpoint_updates! search_endpoint, params_hash
+          if search_endpoint.changed?
+            save_search_endpoint_or_render_errors search_endpoint
+            return if performed?
+          end
         end
 
         @try.search_endpoint = search_endpoint
+      end
+
+      def merge_search_endpoint_updates! search_endpoint, params_hash
+        credential = params_hash.to_h.symbolize_keys[:basic_auth_credential]
+        return if credential.blank?
+        return if credential == search_endpoint.masked_basic_auth_credential
+
+        search_endpoint.basic_auth_credential = credential
+      end
+
+      def save_search_endpoint_or_render_errors search_endpoint
+        render json: search_endpoint.errors, status: :bad_request unless search_endpoint.save
+      rescue ActiveRecord::Encryption::Errors::Base => e
+        Rails.logger.error("Search endpoint encryption error: #{e.message}")
+        render json: {
+          error: 'Unable to save search endpoint credentials. Check server encryption configuration.',
+        }, status: :internal_server_error
       end
 
       def convert_blank_values_to_nil hash
@@ -135,7 +160,7 @@ module Api
 
       def search_endpoint_params
         # we do not REQUIRE a search_endpoint on a try
-        return {} if params[:search_endpoint].nil?
+        return {} if params[:search_endpoint].blank?
 
         params.expect(
           search_endpoint: [ :name,

--- a/docs/endpoints_opensearch.md
+++ b/docs/endpoints_opensearch.md
@@ -2,16 +2,22 @@
 
 This document explains what endpoints Quepid hits on OpenSearch.
 
-Quepid connects to OpenSearch using standard RESTful calls.   
-You need to have CORS set up to allow Quepid on one domain talk to OpenSearch on another domain.
+Quepid connects to OpenSearch in one of two ways:
+
+1. **Direct browser requests** (default) — OpenSearch must allow CORS from Quepid's domain. Many teams prefer this in production because traffic goes directly from the browser to the cluster.
+
+2. **Proxy Requests** — the Quepid server makes the request instead of the browser. This is often the fastest way to get unblocked during Case Setup, but it routes search traffic through Quepid and may need approval from your operations team.
+
 One interesting thing is that if OpenSearch is running on HTTPS, then Quepid needs to run on HTTPS as well, so you may be prompted to reload Quepid using the right security protocol.
 
 
 ## Ping OpenSearch During Case Setup
 
 Quepid checks that that OpenSearch is available and responding during the Case Setup Wizard, and if not
-then Quepid attempts to provide you some workarounds.  You can bypass this check as well, and then
-fix your connectivity setup yourself in the Case Settings window ;-).
+then Quepid opens the **Advanced** section and suggests workarounds.  The quickest unblock is usually
+**Proxy Requests** (no OpenSearch configuration changes).  If your team prefers direct browser access,
+configure CORS on OpenSearch instead.  You can bypass this check as well, and then fix your connectivity
+setup yourself in the Case Settings window ;-).
 
 Request
 ```

--- a/spec/javascripts/angular/controllers/wizardModal_spec.js
+++ b/spec/javascripts/angular/controllers/wizardModal_spec.js
@@ -202,6 +202,34 @@ describe('Controller: WizardModalCtrl', function () {
       scope.pendingWizardSettings.submit();
       $httpBackend.flush();
     });
+
+    it('shows an error when finish save fails', function() {
+      mockModalInstance.close.calls.reset();
+      $httpBackend.expectPUT('api/cases/0/tries/0').respond(500, { status: 500, error: 'Internal Server Error' });
+
+      scope.pendingWizardSettings.submit();
+      $httpBackend.flush();
+
+      expect(scope.finishSaveError).toBe('Could not save your case settings: Internal Server Error. Please click Finish to try again.');
+      expect(scope.savingFinish).toBe(false);
+      expect(mockModalInstance.close).not.toHaveBeenCalled();
+    });
+
+    it('shows validation errors when finish save fails with bad request', function() {
+      mockModalInstance.close.calls.reset();
+      $httpBackend.expectPUT('api/cases/0/tries/0').respond(400, {
+        proxy_requests: [ 'must be enabled when basic auth credentials are present' ],
+      });
+
+      scope.pendingWizardSettings.submit();
+      $httpBackend.flush();
+
+      expect(scope.finishSaveError).toBe(
+        'Could not save your case settings: proxy_requests must be enabled when basic auth credentials are present. Please click Finish to try again.'
+      );
+      expect(scope.savingFinish).toBe(false);
+      expect(mockModalInstance.close).not.toHaveBeenCalled();
+    });
   });
   
   describe('parse url', function() {
@@ -316,6 +344,7 @@ describe('Controller: WizardModalCtrl — validating flag lifecycle', function (
 
     expect(scope.validating).toBe(false);
     expect(scope.urlInvalid).toBe(true);
+    expect(scope.isHeaderConfigCollapsed).toBe(true);
     expect(nextSpy).not.toHaveBeenCalled();
   });
 
@@ -325,5 +354,40 @@ describe('Controller: WizardModalCtrl — validating flag lifecycle', function (
 
     expect(scope.validating).toBe(false);
     expect(scope.mapperInvalid).toBe(true);
+  });
+
+  it('toggleHeaderConfig flips the flag on the controller scope', function () {
+    scope.isHeaderConfigCollapsed = false;
+
+    scope.toggleHeaderConfig();
+    expect(scope.isHeaderConfigCollapsed).toBe(true);
+
+    scope.toggleHeaderConfig();
+    expect(scope.isHeaderConfigCollapsed).toBe(false);
+  });
+
+  // Regression: the Advanced section lives inside an ng-if, which creates a child
+  // scope. An inline `ng-click="x = !x"` would shadow the primitive on that child,
+  // disconnecting it from the controller so later programmatic opens never reach
+  // uib-collapse. Toggling through the controller function must avoid that.
+  it('reopens the Advanced panel on validation failure even after a manual toggle', function () {
+    primeSearchapi();
+    scope.isHeaderConfigCollapsed = true;
+
+    // The Advanced button toggles on the ng-if child scope, not the controller.
+    var childScope = scope.$new();
+    childScope.toggleHeaderConfig();
+
+    expect(scope.isHeaderConfigCollapsed).toBe(false);
+    expect(childScope.hasOwnProperty('isHeaderConfigCollapsed')).toBe(false); // no shadow created
+
+    // A failed validation reopens the panel programmatically on the controller scope.
+    scope.validate(false);
+    validatorDeferred.reject('Error: boom');
+    $rootScope.$digest();
+
+    // uib-collapse binds against the child scope, so it must see the reopened value.
+    expect(scope.isHeaderConfigCollapsed).toBe(true);
+    expect(childScope.isHeaderConfigCollapsed).toBe(true);
   });
 });

--- a/test/controllers/api/v1/tries_controller_test.rb
+++ b/test/controllers/api/v1/tries_controller_test.rb
@@ -205,6 +205,106 @@ search_endpoint: es_endpoint.attributes }
           end
         end
 
+        test 'updates basic auth credentials when reusing an existing search endpoint on wizard finish' do
+          with_require_proxy_with_basic_auth(true) do
+            existing = SearchEndpoint.create!(
+              search_engine:  'os',
+              endpoint_url:   'https://quepid-opensearch.dev.o19s.com:9000/tmdb/_search',
+              api_method:     'POST',
+              proxy_requests: true,
+              owner:          joey
+            )
+
+            put :update,
+                params: {
+                  case_id:         the_case.id,
+                  try_number:      the_try.try_number,
+                  try:             { field_spec: 'id:_id' },
+                  search_endpoint: {
+                    search_engine:         'os',
+                    endpoint_url:          'https://quepid-opensearch.dev.o19s.com:9000/tmdb/_search',
+                    api_method:            'POST',
+                    basic_auth_credential: 'reader:reader',
+                    proxy_requests:        true,
+                  },
+                }
+
+            assert_response :ok
+
+            the_try.reload
+            existing.reload
+            assert_equal existing.id, the_try.search_endpoint_id
+            assert_equal 'reader:reader', the_try.search_endpoint.basic_auth_credential
+          end
+        end
+
+        test 'does not overwrite basic auth when masked credential is submitted on wizard finish' do
+          with_require_proxy_with_basic_auth(false) do
+            existing = SearchEndpoint.create!(
+              search_engine:         'os',
+              endpoint_url:          'https://quepid-opensearch.dev.o19s.com:9000/tmdb/_search',
+              api_method:            'POST',
+              basic_auth_credential: 'reader:secret',
+              proxy_requests:        true,
+              owner:                 joey
+            )
+
+            put :update,
+                params: {
+                  case_id:         the_case.id,
+                  try_number:      the_try.try_number,
+                  try:             { field_spec: 'id:_id' },
+                  search_endpoint: {
+                    search_engine:         'os',
+                    endpoint_url:          'https://quepid-opensearch.dev.o19s.com:9000/tmdb/_search',
+                    api_method:            'POST',
+                    basic_auth_credential: existing.masked_basic_auth_credential,
+                    proxy_requests:        true,
+                  },
+                }
+
+            assert_response :ok
+
+            existing.reload
+            assert_equal 'reader:secret', existing.basic_auth_credential
+          end
+        end
+
+        test 'does not mutate a team-shared search endpoint owned by another user on wizard finish' do
+          with_require_proxy_with_basic_auth(true) do
+            doug = users(:doug)
+            existing = SearchEndpoint.create!(
+              search_engine:  'os',
+              endpoint_url:   'https://shared-opensearch.dev.o19s.com:9000/tmdb/_search',
+              api_method:     'POST',
+              proxy_requests: true,
+              owner:          doug
+            )
+            teams(:case_finder_shared_team).search_endpoints << existing
+
+            put :update,
+                params: {
+                  case_id:         the_case.id,
+                  try_number:      the_try.try_number,
+                  try:             { field_spec: 'id:_id' },
+                  search_endpoint: {
+                    search_engine:         'os',
+                    endpoint_url:          'https://shared-opensearch.dev.o19s.com:9000/tmdb/_search',
+                    api_method:            'POST',
+                    basic_auth_credential: 'reader:reader',
+                    proxy_requests:        true,
+                  },
+                }
+
+            assert_response :ok
+
+            the_try.reload
+            existing.reload
+            assert_equal existing.id, the_try.search_endpoint_id
+            assert_nil existing.basic_auth_credential
+          end
+        end
+
         test 'returns bad request when basic auth endpoint omits proxy requests' do
           with_require_proxy_with_basic_auth(true) do
             put :update,


### PR DESCRIPTION
## Description

This PR improves the create-case wizard finish flow and how search endpoint credentials are persisted when reusing an existing endpoint.

**Wizard finish UX**
- When Finish fails, the wizard stays open on the last step and shows an alert with API validation or server error details instead of closing silently.
- The Finish button is disabled while the save is in progress (`savingFinish`) to prevent duplicate submissions.
- Added `formatFinishSaveError()` to surface string errors, `error` fields, and ActiveModel validation messages from failed saves.

**Advanced panel / validation**
- Replaced inline `ng-click="isHeaderConfigCollapsed = !isHeaderConfigCollapsed"` with `toggleHeaderConfig()` to avoid AngularJS `ng-if` child-scope shadowing that broke programmatic panel opens.
- After URL validation fails, `showProxyHelpIfNeeded()` auto-expands the Advanced panel when proxy is not enabled (for non-static engines).

**Search endpoint credential handling (`TriesController`)**
- When reusing an existing search endpoint owned by the current user, merge submitted basic auth credentials without overwriting masked placeholder values.
- Leave team-shared endpoints owned by another user unchanged.
- Extracted `merge_search_endpoint_updates!` and `save_search_endpoint_or_render_errors` (including encryption error handling).
- Treat blank `search_endpoint` params as absent.

**Troubleshooting copy**
- Refreshed proxy and CORS guidance on the wizard URL step for Elasticsearch, OpenSearch, Solr, and Search API.
- Clarified the Proxy Requests checkbox help text.

## Motivation and Context

Users completing the wizard could hit save failures—validation errors, encryption issues, or endpoint constraint violations—and get no feedback because the modal closed on success only. That made it hard to recover without repeating the whole flow.

Separately, re-saving a case with a reused search endpoint could either fail to update credentials the user intended to change, or overwrite stored credentials when the UI sent back masked placeholders. Team-shared endpoints also needed to stay immutable when another team member finishes the wizard against a shared endpoint.

The Advanced panel toggle had a classic AngularJS primitive shadowing bug: manual toggles worked, but programmatic opens after validation failure did not reliably expand the panel.

## How Has This Been Tested?

**Automated**
- `bin/docker r bundle exec rails test test/controllers/api/v1/tries_controller_test.rb` — new/updated cases for:
  - Creating OpenSearch endpoints with basic auth and proxy on wizard finish
  - Updating basic auth when reusing an owned endpoint
  - Skipping credential overwrite when masked placeholder is submitted
  - Not mutating team-shared endpoints owned by another user
  - Validation when proxy is required for basic auth
- `bin/docker r yarn test spec/javascripts/angular/controllers/wizardModal_spec.js` — new/updated cases for:
  - Finish save error display (generic and validation responses)
  - `toggleHeaderConfig()` scope behavior
  - Advanced panel reopening after validation failure

**Manual**
- Confirm Finish is disabled during save.
- Trigger URL validation failure without proxy enabled and confirm Advanced expands with updated troubleshooting copy.

## Screenshots or GIFs (if appropriate):
<img width="820" height="2200" alt="behavior-1-proxy-help-autoexpand" src="https://github.com/user-attachments/assets/ab49fe33-1877-42c2-a8be-ae31011d5d32" />
<img width="900" height="760" alt="behavior-2-finish-disabled-during-save" src="https://github.com/user-attachments/assets/5baf2bb8-cb0a-49eb-988c-a60af6193c72" />
<img width="900" height="760" alt="behavior-3-finish-save-error" src="https://github.com/user-attachments/assets/cbab71ce-ac50-4264-bcd4-6b6cf24a946b" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.
