### PR TITLE
Move to fork of omniauth-keycloak that is maintained.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ claude-swarm.log
 
 /node_modules
 *.patch
+/.playwright-mcp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Big upgrade of the core application stack, moving Ruby from 3.4.8 to 4.0.1, Rails from 8.1.1 to 8.1.2, and the Debian base image from Bookworm to Trixie, along with Bundler and numerous gem/Node package updates.
 
 * **splainer-search 3.0.0:** The `splainer-search` npm package is now a vanilla JavaScript (ESM) library rather than an AngularJS module. The Angular app still depends on the `o19s.splainer-search` module name; `app/javascript/splainer_search_adapter.js` wires the new `createWiredServices` API from the package to that module so existing injectors and services keep working.
+* **omniauth-keycloak switched to the `ifad` fork:** The original `ccrockett/omniauth-keycloak` gem was unmaintained and pinned `omniauth-oauth2` below 1.9, blocking that upgrade. We've moved to the actively-maintained [ifad/omniauth-keycloak](https://github.com/ifad/omniauth-keycloak) fork (via a git source in the Gemfile, since it isn't published to RubyGems), which lets `omniauth-oauth2` move to 1.9.0. This fork also renames the strategy from `KeycloakOpenId`/`keycloak_openid` to `Keycloak`/`keycloak`, so the Keycloak sign-in route changed from `/users/auth/keycloakopenid` to `/users/auth/keycloak` — no action needed for users, but worth knowing if you have anything hardcoded against the old path.
 
 ## 8.5.0 -- 2026-01-14
 

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,10 @@ gem 'mission_control-jobs' # git: 'https://github.com/rails/mission_control-jobs
 gem 'mysql2'
 gem 'oas_rails'
 gem 'omniauth'
-gem 'omniauth-keycloak'
+# Using the ifad fork instead of the unmaintained ccrockett original: it drops the
+# omniauth-oauth2 < 1.9 ceiling that was blocking that gem's update, and renames the
+# strategy from KeycloakOpenId/keycloak_openid to Keycloak/keycloak.
+gem 'omniauth-keycloak', github: 'ifad/omniauth-keycloak', ref: '75978274fe9299b033c74894837a340b6ce333f0'
 gem 'omniauth-google-oauth2'
 gem 'omniauth_openid_connect'
 gem 'omniauth-rails_csrf_protection'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/ifad/omniauth-keycloak.git
+  revision: 75978274fe9299b033c74894837a340b6ce333f0
+  ref: 75978274fe9299b033c74894837a340b6ce333f0
+  specs:
+    omniauth-keycloak (2.0.0)
+      faraday
+      json-jwt
+      omniauth-oauth2 (>= 1.8)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -95,8 +105,8 @@ GEM
     annotaterb (4.22.0)
       activerecord (>= 6.0.0)
       activesupport (>= 6.0.0)
-    anonymous_loader (0.1.2)
-      version_gem (~> 1.1, >= 1.1.13)
+    anonymous_loader (0.1.3)
+      version_gem (~> 1.1, >= 1.1.14)
     ansi (1.6.0)
     ast (2.4.3)
     async (2.39.0)
@@ -106,8 +116,8 @@ GEM
       metrics (~> 0.12)
       traces (~> 0.18)
     attr_required (1.0.2)
-    auth-sanitizer (0.2.2)
-      version_gem (~> 1.1, >= 1.1.10)
+    auth-sanitizer (0.2.3)
+      version_gem (~> 1.1, >= 1.1.14)
     base64 (0.3.0)
     bcrypt (3.1.22)
     benchmark (0.5.0)
@@ -309,7 +319,7 @@ GEM
       activesupport (>= 7.0.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.20.0)
+    json (2.21.2)
     json-jwt (1.17.1)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -415,16 +425,16 @@ GEM
     oas_rails (1.4.0)
       easy_talk_two (~> 1.1.3)
       oas_core (>= 1.1.0)
-    oauth2 (2.0.24)
-      anonymous_loader (~> 0.1, >= 0.1.1)
-      auth-sanitizer (~> 0.2, >= 0.2.2)
+    oauth2 (2.0.25)
+      anonymous_loader (~> 0.1, >= 0.1.3)
+      auth-sanitizer (~> 0.2, >= 0.2.3)
       faraday (>= 0.17.3, < 4.0)
       jwt (>= 1.0, < 4.0)
       logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0, >= 2.0.6)
-      version_gem (~> 1.1, >= 1.1.12)
+      snaky_hash (~> 2.0, >= 2.0.7)
+      version_gem (~> 1.1, >= 1.1.14)
     omniauth (2.1.4)
       hashie (>= 3.4.6)
       logger
@@ -435,13 +445,8 @@ GEM
       oauth2 (~> 2.0)
       omniauth (~> 2.0)
       omniauth-oauth2 (~> 1.8)
-    omniauth-keycloak (1.5.3)
-      faraday
-      json-jwt (> 1.13.0)
-      omniauth (>= 2.0)
-      omniauth-oauth2 (>= 1.7, < 1.9)
-    omniauth-oauth2 (1.8.0)
-      oauth2 (>= 1.4, < 3)
+    omniauth-oauth2 (1.9.0)
+      oauth2 (>= 2.0.2, < 3)
       omniauth (~> 2.0)
     omniauth-rails_csrf_protection (2.0.1)
       actionpack (>= 4.2)
@@ -645,9 +650,9 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    snaky_hash (2.0.6)
+    snaky_hash (2.0.7)
       hashie (>= 0.1.0, < 6)
-      version_gem (>= 1.1.8, < 3)
+      version_gem (~> 1.1, >= 1.1.14)
     solid_cable (4.0.0)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -688,7 +693,7 @@ GEM
       activemodel (>= 3.0.0)
       public_suffix
     vega (0.6.0)
-    version_gem (1.1.13)
+    version_gem (1.1.14)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.3.0)
@@ -759,7 +764,7 @@ DEPENDENCIES
   oas_rails
   omniauth
   omniauth-google-oauth2
-  omniauth-keycloak
+  omniauth-keycloak!
   omniauth-rails_csrf_protection
   omniauth_openid_connect
   pagy

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -2,9 +2,9 @@
 
 module Users
   class OmniauthCallbacksController < Devise::OmniauthCallbacksController
-    skip_before_action :require_login, only: [ :keycloakopenid, :google_oauth2, :failure, :openid_connect ]
+    skip_before_action :require_login, only: [ :keycloak, :google_oauth2, :failure, :openid_connect ]
 
-    def keycloakopenid
+    def keycloak
       @user = create_user_from_omniauth(request.env['omniauth.auth'])
 
       @user.errors.add(:base, "Can't log in a locked user." ) if @user.locked
@@ -13,7 +13,7 @@ module Users
 
         redirect_to root_path
       else
-        session['devise.keycloakopenid_data'] = request.env['omniauth.auth']
+        session['devise.keycloak_data'] = request.env['omniauth.auth']
         redirect_to new_session
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -183,8 +183,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   # devise :invitable, :database_authenticatable, :registerable,
   # :recoverable, :rememberable, :trackable, :validatable
-  devise :invitable, :recoverable, :omniauthable, omniauth_providers: [ :keycloakopenid, :google_oauth2, :openid_connect ]
-  # devise :omniauthable, omniauth_providers: %i[keycloakopenid]
+  devise :invitable, :recoverable, :omniauthable, omniauth_providers: [ :keycloak, :google_oauth2, :openid_connect ]
+  # devise :omniauthable, omniauth_providers: %i[keycloak]
   # devise :invitable, :recoverable, :omniauthable
 
   # Devise hacks since we only use the recoverable module

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -16,11 +16,11 @@
         </p>
         <% end %>
 
-        <% if Rails.application.config.devise.omniauth_providers.include?(:keycloak_openid) %>
+        <% if Rails.application.config.devise.omniauth_providers.include?(:keycloak) %>
         <% email_login_only = false %>
         <!-- <a href="https://www.flaticon.com/free-icons/digital" title="digital icons">Digital icons created by Freepik - Flaticon</a> -->
         <p>
-          <%= button_to user_keycloakopenid_omniauth_authorize_path, data: { turbo: "false" }, :class=> "btn btn-social btn-openid" do %>
+          <%= button_to user_keycloak_omniauth_authorize_path, data: { turbo: "false" }, :class=> "btn btn-social btn-openid" do %>
             <%= image_tag "openid-logo.png", :class => "black-to-white" %> Sign in with Keycloak
 
           <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -321,15 +321,15 @@ Devise.setup do |config|
   # config.omniauth_path_prefix = '/my_engine/users/auth'
   # config.omniauth :github, "APP_ID", "APP_SECRET"
   # ==> OmniAuth
-  # config.omniauth_providers: %i[keycloakopenid google_oauth2]
+  # config.omniauth_providers: %i[keycloak google_oauth2]
   if Rails.application.config.keycloak_realm.present?
-    config.omniauth :keycloak_openid, 'quepid', 'example-secret-if-configured',
+    config.omniauth :keycloak, 'quepid', 'example-secret-if-configured',
                     client_options: {
                       site:     Rails.application.config.keycloak_site,
                       realm:    Rails.application.config.keycloak_realm,
                       base_url: '',
                     },
-                    strategy_class: OmniAuth::Strategies::KeycloakOpenId
+                    strategy_class: OmniAuth::Strategies::Keycloak
   end
 
   if Rails.application.config.google_client_id.present?


### PR DESCRIPTION
We need a maintained version so we can not be blocked on upgrades.