### PR TITLE
Prevent duplicate book syncs

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -28,7 +28,8 @@ ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
     BUNDLE_WITHOUT="development test" \
-    LD_PRELOAD="/usr/local/lib/libjemalloc.so"
+    LD_PRELOAD="/usr/local/lib/libjemalloc.so" \
+    PUPPETEER_SKIP_DOWNLOAD="true"
 
 # Throw-away build stage to reduce size of final image
 FROM base AS build

--- a/app/controllers/api/v1/books/populate_controller.rb
+++ b/app/controllers/api/v1/books/populate_controller.rb
@@ -20,6 +20,17 @@ module Api
         # With 5000 queries in large case, this takes 108 seconds...
         #
         def update
+          # A sync for this book is already queued or running (PopulateBookJob
+          # itself also guards against duplicates via limits_concurrency, but
+          # checking here avoids uploading a throwaway blob for a job that
+          # would just get discarded). Respond with a conflict, rather than
+          # silently succeeding, so the client's syncedPairsCache retries
+          # these pairs on its next sync instead of assuming they landed.
+          if @book.populate_job.present?
+            head :conflict
+            return
+          end
+
           serialized_data = Marshal.dump(query_doc_pairs_params)
 
           compressed_data = Zlib::Deflate.deflate(serialized_data)

--- a/app/jobs/populate_book_job.rb
+++ b/app/jobs/populate_book_job.rb
@@ -6,6 +6,16 @@ class PopulateBookJob < ApplicationJob
   # NOTE: Duplicate prevention is handled on the client side in queriesSvc.syncToBook
   # which maintains a cache of already-synced query-doc pairs and only sends new ones.
   # Queries are batched in groups of 100 for efficiency.
+  #
+  # The client-side cache is reset on page reload though, so a case reloaded
+  # mid-sync (or opened in multiple tabs) can still queue several full syncs
+  # for the same book. Guard against that here: only one sync per book may be
+  # queued/running at a time, and duration must comfortably exceed the
+  # longest observed sync (large books can take 10+ minutes).
+  limits_concurrency to:          1,
+                     key:         ->(book, _kase, _blob) { "book_#{book.id}" },
+                     duration:    30.minutes,
+                     on_conflict: :discard
 
   # rubocop:disable Security/MarshalLoad
   # rubocop:disable Metrics/MethodLength

--- a/test/controllers/api/v1/books/populate_controller_test.rb
+++ b/test/controllers/api/v1/books/populate_controller_test.rb
@@ -62,6 +62,34 @@ module Api
           end
         end
 
+        describe 'a sync is already queued or running for the book' do
+          test 'rejects the request without enqueuing another job' do
+            book.update(populate_job: "queued at #{Time.zone.now}")
+
+            data = {
+              book_id:         book.id,
+              case_id:         acase.id,
+              query_doc_pairs: [
+                {
+                  query_text:      'star wars',
+                  doc_id:          'https://www.themoviedb.org/movie/11-star-wars',
+                  position:        0,
+                  document_fields: {
+                    title: 'Star Wars',
+                    year:  '1977',
+                  },
+                }
+              ],
+            }
+
+            assert_no_enqueued_jobs do
+              put :update, params: data
+            end
+
+            assert_response :conflict
+          end
+        end
+
         describe 'refresh a existing book' do
           test 'updates the position and doc fields' do
             data = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We had duplicate 1000 query case being sync to book...  piling up a big job backgorund, and then maxxing out the database!

Now we check if the book is being updated, and if so, then we don't queue up another one, no matter how many times the case opens up.
