### PR TITLE
Require end date for annoucements

### DIFF
--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -17,6 +17,8 @@ module Admin
     def new
       @announcement = Announcement.new
       @announcement.text = ''
+      @announcement.publish_date = 1.day.from_now.to_date
+      @announcement.expiration_date = 30.days.from_now.to_date
     end
 
     def edit
@@ -48,21 +50,10 @@ module Admin
       redirect_to admin_announcements_path
     end
 
-    def publish
-      @announcement = Announcement.find(params.expect(:id))
-      if @announcement.live?
-        @announcement.update(live: false)
-        redirect_to admin_announcements_path, notice: "Announcement id #{@announcement.id} is hidden."
-      else
-        @announcement.make_live!
-        redirect_to admin_announcements_path, notice: "Announcement id #{@announcement.id} is now live."
-      end
-    end
-
     private
 
     def announcement_params
-      params.expect(announcement: [ :text, :author_id ])
+      params.expect(announcement: [ :text, :author_id, :publish_date, :expiration_date ])
     end
   end
 end

--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -32,16 +32,18 @@ module Admin
       if @announcement.save
         redirect_to edit_admin_announcement_path(@announcement)
       else
-        render 'new'
+        render 'new', status: :unprocessable_content
       end
     end
 
     def update
       @announcement = Announcement.find(params.expect(:id))
 
-      @announcement.update(announcement_params)
-
-      render 'edit' # we stay on the edit page because that is where you can preview the rendered changes
+      if @announcement.update(announcement_params)
+        render 'edit' # we stay on the edit page because that is where you can preview the rendered changes
+      else
+        render 'edit', status: :unprocessable_content
+      end
     end
 
     def destroy

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -128,7 +128,9 @@ class HomeController < ApplicationController
   private
 
   def check_for_announcement
-    @announcement = Announcement.where(live: true).latest_unseen_for_user(@current_user).first if @current_user
+    return unless @current_user
+
+    @announcement = Announcement.active.order(publish_date: :desc).latest_unseen_for_user(@current_user).first
     AnnouncementViewed.create(user: @current_user, announcement: @announcement) if @announcement
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -130,7 +130,7 @@ class HomeController < ApplicationController
   def check_for_announcement
     return unless @current_user
 
-    @announcement = Announcement.active.order(publish_date: :desc).latest_unseen_for_user(@current_user).first
+    @announcement = Announcement.active.latest_unseen_for_user(@current_user).first
     AnnouncementViewed.create(user: @current_user, announcement: @announcement) if @announcement
   end
 end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -26,11 +26,11 @@ class Announcement < ApplicationRecord
   validates :expiration_date, presence: true
   validate :publish_date_not_after_expiration_date
 
-  # Currently-visible announcements: today falls within [publish_date, expiration_date].
-  # Ordered by publish_date desc so the most recently scheduled one wins when windows
-  # overlap - no separate "only one at a time" flag to keep in sync.
+  # Ordered by publish_date desc, id desc so the most recently scheduled announcement
+  # wins when windows overlap (id as a tiebreaker keeps same-day picks deterministic) -
+  # avoids needing a separate "only one active" flag to keep in sync.
   scope :active, -> {
-    where(publish_date: ..Date.current).where(expiration_date: Date.current..).order(publish_date: :desc)
+    where(publish_date: ..Date.current).where(expiration_date: Date.current..).order(publish_date: :desc, id: :desc)
   }
 
   scope :latest_unseen_for_user, ->(user) {

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -29,7 +29,9 @@ class Announcement < ApplicationRecord
   # Currently-visible announcements: today falls within [publish_date, expiration_date].
   # Ordered by publish_date desc so the most recently scheduled one wins when windows
   # overlap - no separate "only one at a time" flag to keep in sync.
-  scope :active, -> { where(publish_date: ..Date.current).where(expiration_date: Date.current..) }
+  scope :active, -> {
+    where(publish_date: ..Date.current).where(expiration_date: Date.current..).order(publish_date: :desc)
+  }
 
   scope :latest_unseen_for_user, ->(user) {
     join_condition = "

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -4,25 +4,32 @@
 #
 # Table name: announcements
 #
-#  id         :bigint           not null, primary key
-#  live       :boolean          default(FALSE)
-#  text       :text(65535)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  author_id  :integer
+#  id              :bigint           not null, primary key
+#  expiration_date :date             not null
+#  publish_date    :date             not null
+#  text            :text(65535)
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  author_id       :integer
 #
 # Indexes
 #
 #  index_announcements_author_id  (author_id)
-#  index_announcements_on_live    (live)
 #
 class Announcement < ApplicationRecord
   belongs_to :author, class_name: 'User'
   has_many :announcement_viewed, dependent: :destroy
   has_many :viewers, through: :announcement_viewed, source: :user
 
-  validates :live, uniqueness: { if: :live? }
   validates :text, presence: true, length: { maximum: 1024 }
+  validates :publish_date, presence: true
+  validates :expiration_date, presence: true
+  validate :publish_date_not_after_expiration_date
+
+  # Currently-visible announcements: today falls within [publish_date, expiration_date].
+  # Ordered by publish_date desc so the most recently scheduled one wins when windows
+  # overlap - no separate "only one at a time" flag to keep in sync.
+  scope :active, -> { where(publish_date: ..Date.current).where(expiration_date: Date.current..) }
 
   scope :latest_unseen_for_user, ->(user) {
     join_condition = "
@@ -34,13 +41,24 @@ class Announcement < ApplicationRecord
       .where('`announcement_viewed`.`user_id` IS NULL')
   }
 
-  def live?
-    live
+  def published?
+    publish_date <= Date.current
   end
 
-  def make_live!
-    Announcement.update_all(live: false) # Set all announcements to not live
-    update(live: true) # Set the current announcement as live
+  def expired?
+    expiration_date < Date.current
   end
-  # rubocop:enable Rails/SkipsModelValidations
+
+  def active?
+    published? && !expired?
+  end
+
+  private
+
+  def publish_date_not_after_expiration_date
+    return if publish_date.blank? || expiration_date.blank?
+    return if publish_date <= expiration_date
+
+    errors.add(:publish_date, 'must be on or before the expiration date')
+  end
 end

--- a/app/views/admin/announcements/edit.html.erb
+++ b/app/views/admin/announcements/edit.html.erb
@@ -16,7 +16,19 @@
         <%= form.text_area :text, required: true, rows: 5, class: 'form-control' %>
         <div class="form-text">The announcement.  You can use HTML and emojis.</div>
       </div>
-    
+
+      <div class="mb-3">
+        <%= form.label :publish_date, class: 'form-label' %>
+        <%= form.date_field :publish_date, required: true, class: 'form-control' %>
+        <div class="form-text">The announcement won't be shown to users before this date. Use today's date to publish immediately.</div>
+      </div>
+
+      <div class="mb-3">
+        <%= form.label :expiration_date, class: 'form-label' %>
+        <%= form.date_field :expiration_date, required: true, class: 'form-control' %>
+        <div class="form-text">After this date the announcement will no longer be shown to users.</div>
+      </div>
+
       <br>
     
       <div class="actions">

--- a/app/views/admin/announcements/edit.html.erb
+++ b/app/views/admin/announcements/edit.html.erb
@@ -9,6 +9,18 @@
 </div>
 
 <%= form_for [:admin, @announcement] do |form| %>
+  <% if @announcement.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@announcement.errors.count, "error") %> prohibited this announcement from being saved:</h2>
+
+      <ul>
+      <% @announcement.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
   <div class="card">
     <div class="card-body">
       <div class="mb-3">

--- a/app/views/admin/announcements/index.html.erb
+++ b/app/views/admin/announcements/index.html.erb
@@ -43,25 +43,34 @@
           <th>Text</th>
           <th>Author</th>
           <th>Created</th>
+          <th>Publishes</th>
+          <th>Expires</th>
           <th>Views</th>
           <th></th>
         </tr>
       </thead>
-  
-      <tbody>      
+
+      <tbody>
         <% @announcements.each do |announcement| %>
-          <tr class="<%= announcement.live? ? 'table-success' : '' %>">
+          <tr class="<%= announcement.active? ? 'table-success' : (announcement.expired? ? 'table-secondary' : '') %>">
             <td><%= announcement.text.html_safe %></td>
             <td><%= announcement.author.name %> </td>
             <td><%= announcement.created_at.strftime("%B %d %Y, %l:%M%P") %> </td>
+            <td>
+              <%= announcement.publish_date.strftime("%B %d %Y") %>
+              <% unless announcement.published? %>
+                <span class="badge bg-info text-dark">Scheduled</span>
+              <% end %>
+            </td>
+            <td>
+              <%= announcement.expiration_date.strftime("%B %d %Y") %>
+              <% if announcement.expired? %>
+                <span class="badge bg-secondary">Expired</span>
+              <% end %>
+            </td>
             <td><%= announcement.announcement_viewed.size %> </td>
-            <td class="d-flex gap-2">
-              <%= link_to 'Edit', edit_admin_announcement_path(announcement) %>              
-              <% if announcement.live? %>
-                <%= button_to 'Turn Off', publish_admin_announcement_path(announcement), method: :post, class: 'btn btn-sm btn-primary' %>
-              <% else %>
-                <%= button_to 'Make Live', publish_admin_announcement_path(announcement), method: :post, class: 'btn btn-sm btn-outline-primary' %>
-              <% end %>              
+            <td>
+              <%= link_to 'Edit', edit_admin_announcement_path(announcement) %>
             </td>
           </tr>
         <% end %>

--- a/app/views/admin/announcements/new.html.erb
+++ b/app/views/admin/announcements/new.html.erb
@@ -16,7 +16,19 @@
         <%= form.text_area :text, required: true, rows: 5, class: 'form-control' %>
         <div class="form-text">The announcement.  You can use HTML and emojis.</div>
       </div>
-    
+
+      <div class="mb-3">
+        <%= form.label :publish_date, class: 'form-label' %>
+        <%= form.date_field :publish_date, required: true, class: 'form-control' %>
+        <div class="form-text">The announcement won't be shown to users before this date. Use today's date to publish immediately.</div>
+      </div>
+
+      <div class="mb-3">
+        <%= form.label :expiration_date, class: 'form-label' %>
+        <%= form.date_field :expiration_date, required: true, class: 'form-control' %>
+        <div class="form-text">After this date the announcement will no longer be shown to users.</div>
+      </div>
+
       <br>
     
       <div class="actions">

--- a/app/views/admin/announcements/new.html.erb
+++ b/app/views/admin/announcements/new.html.erb
@@ -9,6 +9,18 @@
 
 
 <%= form_for [:admin, @announcement] do |form| %>
+  <% if @announcement.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@announcement.errors.count, "error") %> prohibited this announcement from being saved:</h2>
+
+      <ul>
+      <% @announcement.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
   <div class="card">
     <div class="card-body">
       <div class="mb-3">

--- a/bin/pre-commit-rubocop
+++ b/bin/pre-commit-rubocop
@@ -11,7 +11,7 @@ if [[ $# -eq 0 ]]; then
 fi
 
 if docker info >/dev/null 2>&1; then
-  exec bin/docker r bundle exec rubocop "$@"
+  exec bin/docker r bundle exec rubocop --force-exclusion "$@"
 fi
 
-exec bin/rubocop "$@"
+exec bin/rubocop --force-exclusion "$@"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,11 +191,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :announcements, except: [ :show ] do
-      member do
-        post :publish
-      end
-    end
+    resources :announcements, except: [ :show ]
     resources :websocket_tester, only: [ :index ] do
       post 'test_background_job', on: :collection
     end

--- a/db/migrate/20260901203020_add_expiration_date_to_announcements.rb
+++ b/db/migrate/20260901203020_add_expiration_date_to_announcements.rb
@@ -5,9 +5,10 @@ class AddExpirationDateToAnnouncements < ActiveRecord::Migration[8.1]
     add_column :announcements, :expiration_date, :date
 
     # Backfill existing announcements so the NOT NULL constraint below doesn't
-    # orphan them - today's date means they read as already-expired until an
-    # admin explicitly extends them, which is the safe default.
-    Announcement.where(expiration_date: nil).update_all(expiration_date: Date.current)
+    # orphan them - yesterday's date means they read as already-expired (expired?
+    # is a strict '<') until an admin explicitly extends them, which is the safe
+    # default. Date.current itself would NOT count as expired yet.
+    Announcement.where(expiration_date: nil).update_all(expiration_date: Date.current - 1.day)
 
     change_column_null :announcements, :expiration_date, false
   end

--- a/db/migrate/20260901203020_add_expiration_date_to_announcements.rb
+++ b/db/migrate/20260901203020_add_expiration_date_to_announcements.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddExpirationDateToAnnouncements < ActiveRecord::Migration[8.1]
+  def up
+    add_column :announcements, :expiration_date, :date
+
+    # Backfill existing announcements so the NOT NULL constraint below doesn't
+    # orphan them - today's date means they read as already-expired until an
+    # admin explicitly extends them, which is the safe default.
+    Announcement.where(expiration_date: nil).update_all(expiration_date: Date.current)
+
+    change_column_null :announcements, :expiration_date, false
+  end
+
+  def down
+    remove_column :announcements, :expiration_date
+  end
+end

--- a/db/migrate/20260901203020_add_expiration_date_to_announcements.rb
+++ b/db/migrate/20260901203020_add_expiration_date_to_announcements.rb
@@ -6,9 +6,13 @@ class AddExpirationDateToAnnouncements < ActiveRecord::Migration[8.1]
 
     # Backfill existing announcements so the NOT NULL constraint below doesn't
     # orphan them - yesterday's date means they read as already-expired (expired?
-    # is a strict '<') until an admin explicitly extends them, which is the safe
-    # default. Date.current itself would NOT count as expired yet.
-    Announcement.where(expiration_date: nil).update_all(expiration_date: Date.current - 1.day)
+    # uses a strict '<', so today's date would not count yet) until an admin
+    # explicitly extends them, which is the safe default. A later migration
+    # backfills publish_date to DATE(created_at); using GREATEST here keeps
+    # expiration_date >= that value for announcements created earlier today,
+    # so the publish_date <= expiration_date invariant always holds.
+    Announcement.where(expiration_date: nil)
+      .update_all('expiration_date = GREATEST(DATE(created_at), DATE_SUB(CURDATE(), INTERVAL 1 DAY))')
 
     change_column_null :announcements, :expiration_date, false
   end

--- a/db/migrate/20260901211506_add_publish_date_to_announcements_remove_live.rb
+++ b/db/migrate/20260901211506_add_publish_date_to_announcements_remove_live.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class AddPublishDateToAnnouncementsRemoveLive < ActiveRecord::Migration[8.1]
+  def up
+    add_column :announcements, :publish_date, :date
+
+    # Existing announcements read as "already published" as of when they were created -
+    # expiration_date (added separately) is what actually governs whether they still show.
+    Announcement.update_all('publish_date = DATE(created_at)')
+
+    change_column_null :announcements, :publish_date, false
+
+    remove_column :announcements, :live, :boolean, default: false
+  end
+
+  def down
+    add_column :announcements, :live, :boolean, default: false
+    add_index :announcements, :live, name: 'index_announcements_on_live'
+
+    remove_column :announcements, :publish_date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_15_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_01_211506) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -108,11 +108,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_15_000000) do
   create_table "announcements", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "author_id"
     t.datetime "created_at", null: false
-    t.boolean "live", default: false
+    t.date "expiration_date", null: false
+    t.date "publish_date", null: false
     t.text "text", collation: "utf8mb4_unicode_ci"
     t.datetime "updated_at", null: false
     t.index ["author_id"], name: "index_announcements_author_id"
-    t.index ["live"], name: "index_announcements_on_live"
   end
 
   create_table "api_keys", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "build:angular-vendor": "esbuild app/javascript/angular_app.js --bundle --sourcemap --format=iife --outdir=app/assets/builds --public-path=/assets --loader:.css=css --loader:.png=dataurl --loader:.svg=dataurl --loader:.woff=dataurl --loader:.woff2=dataurl --loader:.ttf=dataurl --loader:.eot=dataurl --external:jquery",
     "build:angular-app": "node build_angular_app.js",
     "build:angular-app:watch": "node build_angular_app.js --watch",
-    "build:angular": "npm run build:angular-vendor && npm run build:angular-app",
+    "build:angular": "yarn build:angular-vendor && yarn build:angular-app",
     "build:angular-templates": "node build_templates.js",
     "build:angular-templates:watch": "node build_templates.js --watch",
     "build:analytics": "esbuild app/javascript/analytics.js --bundle --sourcemap --format=iife --outdir=app/assets/builds --public-path=/assets",

--- a/test/controllers/admin/announcements_controller_test.rb
+++ b/test/controllers/admin/announcements_controller_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Admin
+  class AnnouncementsControllerTest < ActionController::TestCase
+    let(:admin) { users(:doug) }
+    let(:announcement) { announcements(:active_announcement) }
+
+    setup do
+      @controller = Admin::AnnouncementsController.new
+      login_user admin
+    end
+
+    test 'update with an invalid date range does not save and shows the errors' do
+      patch :update, params: {
+        id:           announcement,
+        announcement: { publish_date: Date.current, expiration_date: 1.day.ago.to_date },
+      }
+
+      assert_response :unprocessable_content
+      assert_template :edit
+      assert_includes assigns(:announcement).errors[:publish_date], 'must be on or before the expiration date'
+
+      announcement.reload
+      assert_not_equal 1.day.ago.to_date, announcement.expiration_date
+    end
+
+    test 'update with a valid date range saves and re-renders edit' do
+      patch :update, params: {
+        id:           announcement,
+        announcement: { publish_date: Date.current, expiration_date: 2.days.from_now.to_date },
+      }
+
+      assert_response :success
+      assert_template :edit
+
+      announcement.reload
+      assert_equal 2.days.from_now.to_date, announcement.expiration_date
+    end
+
+    test 'create with an invalid date range does not save and shows the errors' do
+      assert_no_difference 'Announcement.count' do
+        post :create, params: {
+          announcement: { text: 'x', publish_date: Date.current, expiration_date: 1.day.ago.to_date },
+        }
+      end
+
+      assert_response :unprocessable_content
+      assert_template :new
+      assert_includes assigns(:announcement).errors[:publish_date], 'must be on or before the expiration date'
+    end
+  end
+end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -8,6 +8,43 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
   end
 
+  describe 'announcements' do
+    let(:user) { users(:random) }
+
+    test 'shows a currently active announcement' do
+      login_user_for_integration_test user
+
+      get root_url
+
+      assert_response :success
+      assert_includes response.body, announcements(:active_announcement).text
+    end
+
+    test 'does not show an announcement that has expired' do
+      # Only the expired announcement is unseen for this user in this test, so if
+      # filtering failed we'd see it here.
+      announcements(:active_announcement).announcement_viewed.create!(user: user)
+
+      login_user_for_integration_test user
+
+      get root_url
+
+      assert_response :success
+      assert_not_includes response.body, announcements(:expired_announcement).text
+    end
+
+    test 'does not show an announcement scheduled for the future' do
+      announcements(:active_announcement).announcement_viewed.create!(user: user)
+
+      login_user_for_integration_test user
+
+      get root_url
+
+      assert_response :success
+      assert_not_includes response.body, announcements(:scheduled_announcement).text
+    end
+  end
+
   test 'can I group things' do
     case_names = [ 'Typeahead: Dairy', 'Typeahead: Meats', 'Typeahead: Dessert', 'Typeahead: Fruit & Veg',
                    'Global Search', 'Nested:Search:IsFun' ]

--- a/test/fixtures/announcements.yml
+++ b/test/fixtures/announcements.yml
@@ -2,20 +2,33 @@
 #
 # Table name: announcements
 #
-#  id         :bigint           not null, primary key
-#  live       :boolean          default(FALSE)
-#  text       :text(65535)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  author_id  :integer
+#  id              :bigint           not null, primary key
+#  expiration_date :date             not null
+#  publish_date    :date             not null
+#  text            :text(65535)
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  author_id       :integer
 #
 # Indexes
 #
 #  index_announcements_author_id  (author_id)
-#  index_announcements_on_live    (live)
 #
 
-live_announcement:
+active_announcement:
   text:  We have a new Scorer! 🥳
   author:     :random
-  live: true
+  publish_date: <%= 2.days.ago.to_date.iso8601 %>
+  expiration_date: <%= 30.days.from_now.to_date.iso8601 %>
+
+expired_announcement:
+  text:  This one already expired 🕰️
+  author:     :random
+  publish_date: <%= 10.days.ago.to_date.iso8601 %>
+  expiration_date: <%= 2.days.ago.to_date.iso8601 %>
+
+scheduled_announcement:
+  text:  Coming soon! 🔜
+  author:     :random
+  publish_date: <%= 5.days.from_now.to_date.iso8601 %>
+  expiration_date: <%= 30.days.from_now.to_date.iso8601 %>

--- a/test/models/announcement_test.rb
+++ b/test/models/announcement_test.rb
@@ -4,42 +4,85 @@
 #
 # Table name: announcements
 #
-#  id         :bigint           not null, primary key
-#  live       :boolean          default(FALSE)
-#  text       :text(65535)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  author_id  :integer
+#  id              :bigint           not null, primary key
+#  expiration_date :date             not null
+#  publish_date    :date             not null
+#  text            :text(65535)
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  author_id       :integer
 #
 # Indexes
 #
 #  index_announcements_author_id  (author_id)
-#  index_announcements_on_live    (live)
 #
 require 'test_helper'
 
 class AnnouncementTest < ActiveSupport::TestCase
-  describe 'Creating a Announcement' do
+  describe 'validations' do
     let(:user) { users(:random) }
-    let(:existing_announcement) { announcements(:live_announcement) }
-    test 'sets live flag to false by default' do
-      announcement = Announcement.create(text: 'Hooray! 🥳 is ready to use.')
 
-      assert_not announcement.live
+    test 'requires publish_date' do
+      announcement = Announcement.new(text: 'x', author: user, expiration_date: Date.current)
+
+      assert_not announcement.valid?
+      assert_includes announcement.errors[:publish_date], "can't be blank"
     end
 
-    test 'can be set to true, forcing others to false' do
-      assert_predicate existing_announcement, :live?
+    test 'requires expiration_date' do
+      announcement = Announcement.new(text: 'x', author: user, publish_date: Date.current)
 
-      announcement = Announcement.create(text: 'Hooray! 🥳 is ready to use.')
+      assert_not announcement.valid?
+      assert_includes announcement.errors[:expiration_date], "can't be blank"
+    end
 
-      assert_not announcement.live
-      existing_announcement.reload
-      assert existing_announcement.live
+    test 'publish_date must be on or before expiration_date' do
+      announcement = Announcement.new(text: 'x', author: user, publish_date: Date.current,
+                                      expiration_date: 1.day.ago.to_date)
 
-      announcement.make_live!
-      existing_announcement.reload
-      assert_not existing_announcement.live
+      assert_not announcement.valid?
+      assert_includes announcement.errors[:publish_date], 'must be on or before the expiration date'
+    end
+
+    test 'publish_date equal to expiration_date is valid' do
+      announcement = Announcement.new(text: 'x', author: user, publish_date: Date.current,
+                                      expiration_date: Date.current)
+
+      assert_predicate announcement, :valid?
+    end
+  end
+
+  describe 'published?, expired?, and active?' do
+    test 'a currently active announcement is published, not expired, and active' do
+      announcement = announcements(:active_announcement)
+
+      assert_predicate announcement, :published?
+      assert_not announcement.expired?
+      assert_predicate announcement, :active?
+    end
+
+    test 'an expired announcement is published but not active' do
+      announcement = announcements(:expired_announcement)
+
+      assert_predicate announcement, :published?
+      assert_predicate announcement, :expired?
+      assert_not announcement.active?
+    end
+
+    test 'an announcement scheduled for the future is not published and not active' do
+      announcement = announcements(:scheduled_announcement)
+
+      assert_not announcement.published?
+      assert_not announcement.expired?
+      assert_not announcement.active?
+    end
+  end
+
+  describe '.active scope' do
+    test 'only includes announcements currently between publish_date and expiration_date' do
+      assert_includes Announcement.active, announcements(:active_announcement)
+      assert_not_includes Announcement.active, announcements(:expired_announcement)
+      assert_not_includes Announcement.active, announcements(:scheduled_announcement)
     end
   end
 end

--- a/test/models/announcement_test.rb
+++ b/test/models/announcement_test.rb
@@ -84,5 +84,21 @@ class AnnouncementTest < ActiveSupport::TestCase
       assert_not_includes Announcement.active, announcements(:expired_announcement)
       assert_not_includes Announcement.active, announcements(:scheduled_announcement)
     end
+
+    test 'agrees with the active? predicate for every announcement' do
+      # The scope re-implements published?/expired? in SQL so it can be queried -
+      # this keeps the two definitions from drifting apart unnoticed.
+      assert_equal Announcement.all.select(&:active?).to_set, Announcement.active.to_set
+    end
+
+    test 'breaks a publish_date tie by preferring the most recently created announcement' do
+      user = users(:random)
+      older = Announcement.create!(text: 'older', author: user, publish_date: Date.current,
+                                   expiration_date: 1.day.from_now.to_date)
+      newer = Announcement.create!(text: 'newer', author: user, publish_date: Date.current,
+                                   expiration_date: 1.day.from_now.to_date)
+
+      assert_equal newer, Announcement.active.where(id: [ older.id, newer.id ]).first
+    end
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
now you have multiple annoucnmetns queued up with a publish and expiration date.

## Motivation and Context
add expiratoin date because I forget to disable them.

add publish date because I want to queue up a bunch an dhave them autostart.

## How Has This Been Tested?
manual, ai, and unit
