### PR TITLE
Match email case-insensitively in SQL instead of relying on the colla…

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -17,8 +17,8 @@ module Admin
       query = User.order(created_at: :desc)
 
       if params[:q].present?
-        query = query.where('users.name LIKE ? OR users.email LIKE ?',
-                            "%#{params[:q]}%", "%#{params[:q]}%")
+        q = "%#{params[:q].to_s.downcase}%"
+        query = query.where('LOWER(users.name) LIKE ? OR LOWER(users.email) LIKE ?', q, q)
       end
 
       respond_to do |format|

--- a/app/controllers/api/v1/signups_controller.rb
+++ b/app/controllers/api/v1/signups_controller.rb
@@ -15,7 +15,7 @@ module Api
         if user_params_to_save[:email].blank?
           @user = User.new user_params_to_save
         else
-          @user = User.where(email: user_params_to_save[:email]).where.not(invitation_token: nil).first
+          @user = User.by_email(user_params_to_save[:email]).where.not(invitation_token: nil).first
           if @user
             @user.assign_attributes(user_params_to_save)
           else

--- a/app/controllers/api/v1/team_members_controller.rb
+++ b/app/controllers/api/v1/team_members_controller.rb
@@ -15,7 +15,8 @@ module Api
       # @summary Add user to team
       # @parameter id(query) [!Integer] The id of the user to be added to the team.
       def create
-        @member = User.where('email = ? OR id = ?', params[:id].to_s.downcase, params[:id] ).first
+        @member = User.where('LOWER(users.email) = ? OR users.id = ?',
+                             params[:id].to_s.strip.downcase, params[:id].to_i).first
 
         unless @member
           render json: { error: 'User Not Found!' }, status: :not_found
@@ -69,7 +70,8 @@ module Api
       # @summary Remove user from team
       # @parameter id(query) [!Integer] The id of the user to be removed from the team.
       def destroy
-        member = @team.members.where('email = ? OR id = ?', params[:id].to_s.downcase, params[:id])
+        member = @team.members.where('LOWER(users.email) = ? OR users.id = ?',
+                                     params[:id].to_s.strip.downcase, params[:id].to_i)
 
         @team.members.delete(member) if member
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -11,8 +11,8 @@ module Api
         @users = []
         if params[:prefix]
           prefix = params.expect(:prefix).downcase
-          @users = User.where('email LIKE :prefix',
-                              prefix: "#{prefix}%").or(User.where('name LIKE :prefix', prefix: "#{prefix}%")).limit(8)
+          @users = User.where('LOWER(email) LIKE :prefix', prefix: "#{prefix}%")
+            .or(User.where('LOWER(name) LIKE :prefix', prefix: "#{prefix}%")).limit(8)
         end
         respond_with @users
       end
@@ -36,7 +36,8 @@ module Api
       private
 
       def set_user
-        @user = User.where('email = ? OR id = ?', params[:id].to_s.downcase, params[:id] ).first
+        @user = User.where('LOWER(users.email) = ? OR users.id = ?',
+                           params[:id].to_s.strip.downcase, params[:id].to_i).first
         render json: { message: 'User not found!' }, status: :not_found unless @user
       end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -47,7 +47,7 @@ class SessionsController < ApplicationController
   private
 
   def login email, password
-    user = User.where(email: email.downcase).first
+    user = User.by_email(email).first
 
     return nil unless user
 

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -301,7 +301,7 @@ class TeamsController < ApplicationController
   # rubocop:disable Metrics/MethodLength
   def add_member
     email = params[:email].to_s.strip.downcase
-    user = User.where(email: email).first
+    user = User.by_email(email).first
 
     if user
       if @team.members.exists?(user.id)
@@ -395,7 +395,7 @@ class TeamsController < ApplicationController
     query1_start = Time.current
     exact_email_matches = User
       .where.not(id: @team.members.pluck(:id))
-      .where('LOWER(email) = ?', query)
+      .by_email(query)
       .limit(10)
     exact_count = exact_email_matches.to_a.count
     query1_time = ((Time.current - query1_start) * 1000).round(2)
@@ -404,7 +404,7 @@ class TeamsController < ApplicationController
     # Used for prefix and name matching (more restricted)
     scope_start = Time.current
     base_scope = User.where.not(id: @team.members.pluck(:id))
-      .where('id IN (?) OR email LIKE ?', team_member_ids, "%@#{current_domain}")
+      .where('id IN (?) OR LOWER(email) LIKE ?', team_member_ids, "%@#{current_domain.to_s.downcase}")
     scope_time = ((Time.current - scope_start) * 1000).round(2)
 
     # Query 2: Prefix email match (exclude exact matches)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -55,12 +55,16 @@ module Users
     private
 
     def create_user_from_omniauth auth
+      # The identity provider decides how it cases the address, so match on the
+      # folded value rather than relying on the database collation to do it.
+      email = auth['info']['email'].to_s.strip.downcase
+
       if Rails.application.config.signup_enabled
-        user = User.find_or_initialize_by(email: auth['info']['email'])
+        user = User.by_email(email).first || User.new(email: email)
       else
-        user = User.find_by(email: auth['info']['email'])
+        user = User.by_email(email).first
         if user.nil? # we looked for a existing user account and didn't find it
-          user = User.new(email: auth['info']['email'])
+          user = User.new(email: email)
           user.errors.add(:base, 'You can only sign in with already created users.' )
         end
       end

--- a/app/controllers/users/signups_controller.rb
+++ b/app/controllers/users/signups_controller.rb
@@ -11,7 +11,7 @@ module Users
       if user_params_to_save[:email].blank?
         @user = User.new user_params_to_save
       else
-        @user = User.where(email: user_params_to_save[:email]).where.not(invitation_token: nil).first
+        @user = User.by_email(user_params_to_save[:email]).where.not(invitation_token: nil).first
         if @user
           @user.assign_attributes(user_params_to_save)
         else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -118,7 +118,7 @@ class User < ApplicationRecord
   # https://davidcel.is/posts/stop-validating-email-addresses-with-regex/
   validates :email,
             presence:   true,
-            uniqueness: true,
+            uniqueness: { case_sensitive: false },
             format:     { with: URI::MailTo::EMAIL_REGEXP },
             length:     { maximum: 80 },
             unless:     :ai_judge?
@@ -211,6 +211,12 @@ class User < ApplicationRecord
   # Scopes
   # default_scope -> { includes(:permissions) }
   scope :only_ai_judges, -> { where.not(llm_key: nil) }
+
+  # Email matching is case insensitive on MySQL only because the users table
+  # inherits latin1_swedish_ci; PostgreSQL and SQLite compare byte for byte.
+  # Fold both sides in SQL so lookups behave the same on every adapter and
+  # don't depend on every stored address already being lowercase.
+  scope :by_email, ->(email) { where('LOWER(users.email) = ?', email.to_s.strip.downcase) }
 
   # Lets get STI in and have actual AiJudge and User objects!
   # Reads the raw column to avoid triggering Active Record encryption, which

--- a/app/services/book_importer.rb
+++ b/app/services/book_importer.rb
@@ -39,7 +39,7 @@ class BookImporter
       end
       list_of_emails_of_users.uniq!
       list_of_emails_of_users.each do |email|
-        unless User.exists?(email: email)
+        unless User.by_email(email).exists?
           if true == options[:force_create_users]
             User.invite!({ email: email, password: '', skip_invitation: true }, @current_user)
           else
@@ -96,7 +96,7 @@ class BookImporter
         next unless query_doc_pair[:judgements]
 
         query_doc_pair[:judgements].each do |judgement|
-          judgement[:user] = User.find_by(email: judgement[:user_email])
+          judgement[:user] = User.by_email(judgement[:user_email]).first
           qdp.judgements.create(judgement.except(:user_email))
         end
       end

--- a/app/services/case_importer.rb
+++ b/app/services/case_importer.rb
@@ -34,7 +34,7 @@ class CaseImporter
     end
 
     list_of_emails_of_users.uniq.each do |email|
-      unless User.exists?(email: email)
+      unless User.by_email(email).exists?
         if options[:force_create_users]
           User.invite!({ email: email, password: '', skip_invitation: true }, @current_user)
         else
@@ -83,7 +83,7 @@ class CaseImporter
       next unless query[:ratings]
 
       query[:ratings].each do |rating|
-        rating[:user] = User.find_by(email: rating[:user_email]) if rating[:user_email].present?
+        rating[:user] = User.by_email(rating[:user_email]).first if rating[:user_email].present?
         new_query.ratings.build(rating.except(:user_email))
       end
     end

--- a/lib/tasks/case.thor
+++ b/lib/tasks/case.thor
@@ -26,7 +26,7 @@ class Case < Thor
       puts "Could not find scorer with name: #{scorer_name}".red
       return
     end
-    owner = ::User.find_by! email: owner_email
+    owner = ::User.by_email(owner_email).first
     unless owner
       puts "Could not find owner with email: #{owner_email}".red
       return

--- a/lib/tasks/sample_data.thor
+++ b/lib/tasks/sample_data.thor
@@ -586,7 +586,7 @@ class SampleData < Thor
     data = JSON.parse(contents)
     case_params = data.to_h.deep_symbolize_keys
 
-    realistic_activity_user = ::User.find_by(email: 'quepid+realisticActivity@o19s.com')
+    realistic_activity_user = ::User.by_email('quepid+realisticActivity@o19s.com').first
 
     @case = ::Case.find_by(id: 6789)
     @case&.destroy
@@ -682,8 +682,8 @@ class SampleData < Thor
   private
 
   def seed_user hash
-    if hash[:email] && ::User.exists?(email: hash[:email].downcase)
-      ::User.where(email: hash[:email].downcase).first
+    if hash[:email] && ::User.by_email(hash[:email]).exists?
+      ::User.by_email(hash[:email]).first
     elsif hash[:name] && ::User.exists?(name: hash[:name])
       ::User.where(name: hash[:name]).first
     else

--- a/lib/tasks/user.thor
+++ b/lib/tasks/user.thor
@@ -59,7 +59,7 @@ class User < Thor
 
     load_environment
 
-    user = ::User.where(email: email).first
+    user = ::User.by_email(email).first
 
     unless user
       puts "Could not find user with email: #{email}".red
@@ -89,7 +89,7 @@ class User < Thor
 
     load_environment
 
-    user = ::User.where(email: email).first
+    user = ::User.by_email(email).first
 
     unless user
       puts "Could not find user with email: #{email}".red
@@ -119,7 +119,7 @@ class User < Thor
 
     load_environment
 
-    user = ::User.where(email: email).first
+    user = ::User.by_email(email).first
 
     unless user
       puts "Could not find user with email: #{email}".red

--- a/test/controllers/users/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/users/omniauth_callbacks_controller_test.rb
@@ -37,6 +37,24 @@ module Users
         assert_nil flash[:alert]
       end
 
+      # The identity provider chooses how it cases the address it sends us. On
+      # MySQL the collation hid any mismatch; everywhere else it would miss the
+      # existing account and fail to save over the unique index.
+      test 'logs in an existing user when the provider sends a different case' do
+        user = users(:random)
+
+        OmniAuth.config.add_mock(:openid_connect, { info: { 'email' => user.email.upcase } })
+        @request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]
+
+        assert_no_difference 'User.count' do
+          post :openid_connect
+        end
+
+        assert_equal user, @controller.ahoy.user
+        assert_redirected_to root_path
+        assert_nil flash[:alert]
+      end
+
       test 'prevents logging in an existing locked user' do
         OmniAuth.config.add_mock(:openid_connect, { info: { 'email' => locked_user.email } })
         @request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:openid_connect]

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -238,7 +238,8 @@ autocomplete_different_domain:
   name: Different Domain User
   administrator: false
 
-# Autocomplete test user - uppercase email for case sensitivity test
+# Stored with mixed case on purpose: fixtures skip validations, so this row
+# exercises User.by_email folding the column and not just the input.
 autocomplete_uppercase:
   <<: *default
   email: UpperCase@example.com

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -185,6 +185,32 @@ class UserTest < ActiveSupport::TestCase
       new_user = User.create(email: 'DeFaultS@emaiL.COM', password: 'password')
       assert_includes new_user.errors.messages[:email], 'has already been taken'
     end
+
+    describe 'by_email' do
+      test 'folds the case of the value being looked up' do
+        user = users(:random)
+
+        assert_equal user, User.by_email(user.email.upcase).first
+        assert_equal user, User.by_email(" #{user.email.upcase} ").first
+      end
+
+      # Fixtures skip validations, so this row keeps the casing it was written
+      # with - the same way a row inserted by insert_all or raw SQL would.
+      # Folding only the input would never find it once the database compares
+      # byte for byte, which is what PostgreSQL and SQLite do.
+      test 'finds a stored address that is not itself lowercase' do
+        stored = users(:autocomplete_uppercase)
+
+        assert_equal 'UpperCase@example.com', stored.email
+        assert_equal stored, User.by_email('uppercase@example.com').first
+      end
+
+      test 'returns nothing for a blank or unknown address' do
+        assert_nil User.by_email('').first
+        assert_nil User.by_email(nil).first
+        assert_nil User.by_email('nobody@example.com').first
+      end
+    end
   end
 
   describe 'Name' do


### PR DESCRIPTION
Quepid looks users up by email in about twenty places, and not one of them asks for case-insensitive matching. They get it for free from MySQL, because db/schema.rb declares the users table as:

    create_table "users", id: :integer, charset: "latin1", force: :cascade do |t|
      t.string "email", limit: 80

No collation is specified, so MySQL applies the latin1 default, latin1_swedish_ci. The _ci suffix is the entire reason `WHERE email = 'foo@bar.com'` matches a stored `Foo@Bar.com`.

That behaviour is not in the application, is not written down in schema.rb, and is not covered by any test. It is an inherited MySQL default. On any adapter that compares byte for byte it simply disappears, and it does so without raising anything.

This is not hypothetical. SQLite became a supported adapter in 383fef60 and compares `=` byte for byte, so the bug is already live there:

    stored value:         "Proof@Example.com"
    MySQL   find_by(email: 'proof@example.com')  => "Proof@Example.com"
    SQLite  find_by(email: 'proof@example.com')  => nil

PostgreSQL, which is being evaluated next, behaves as SQLite does here.

What breaks, and why it is hard to notice

The failures are silent, and the worst of them are where the casing comes from outside Quepid:

  * SSO / OmniAuth. The identity provider decides how it cases the address. When Keycloak, Google or OIDC returns Foo@Bar.com for a user stored as foo@bar.com, the lookup misses, the code falls through to User.new, and save! then fails the uniqueness validation - a 500 on the callback. With signups disabled it is quieter but more confusing: "You can only sign in with already created users", for a user who plainly exists.

  * Book and case importers. Addresses come from an uploaded file. find_by returns nil and judgements and ratings are imported with an orphaned owner - data corruption rather than an error.

  * Team invitations and invitation acceptance. An existing member is not found, so a duplicate invite is created instead.

  * Admin user search and the member typeahead. These use LIKE, which folds case on MySQL and also on SQLite (whose LIKE folds ASCII by default even though its = does not), but not on PostgreSQL.

  * sample_data.thor creates the demo user as quepid+realisticActivity@o19s.com and then looks it up with that same mixed-case literal. The stored value is lowercased on write, so only the collation ever bridged the two. Off MySQL the lookup returns nil and the sample-data bootstrap fails.

Seven call sites had already worked around this individually with an ad hoc .downcase or LOWER(...), which is a reasonable signal that the root cause was overdue for a fix.

The fix

Fold both sides in SQL, in one place:

    scope :by_email, ->(email) { where('LOWER(users.email) = ?', email.to_s.strip.downcase) }

Folding only the input would not be enough. That is correct only while every stored address is already lowercase, and that invariant holds today purely as a side effect of Devise's downcase_keys - from a module Quepid does not otherwise use, with no test pinning it, and bypassed by any fixture, insert_all or raw SQL write. Folding the column as well makes the lookup correct regardless of what is stored.

LOWER() is identical on MySQL, PostgreSQL and SQLite, so this needs no adapter-specific code, no schema change, no migration and no backfill. The write path is untouched.

Uniqueness needed the same treatment. Rails' uniqueness validator defaults to case-sensitive, so on MySQL the unique index was the only thing stopping foo@x.com and FOO@x.com from coexisting. That enforcement vanishes on a byte-exact adapter, so the validation is now case_sensitive: false.

Incidental fixes

  * api/v1/users_controller.rb and api/v1/team_members_controller.rb passed params[:id] straight into an integer column via `email = ? OR id = ?`. MySQL coerces that to 0; PostgreSQL raises `invalid input syntax for type integer`. Now .to_i.

  * lib/tasks/case.thor used find_by!, whose exception made the `unless owner` guard on the following line unreachable. It is live again.

  * test/fixtures/users.yml carried an orphaned autocomplete_uppercase fixture whose test had been deleted. It now backs a real test.

Verification

Full suite on MySQL: 1254 tests, 4248 assertions, 0 failures, 0 errors. Changed-area tests pass on both MySQL and SQLite. RuboCop clean.

Green tests alone prove little here, since MySQL's collation makes the old code pass too. Verified directly with a mixed-case row written via save!(validate: false):

    --- SQLITE ---                      --- MYSQL ---
    OLD  find_by(email:)  nil           OLD  find_by(email:)  "Proof@Example.com"
    NEW  by_email    "Proof@Example.com" NEW  by_email    "Proof@Example.com"

Known limitation: the scope makes the right thing easy and greppable, but nothing enforces it - a future User.find_by(email: params[:email]) reintroduces the bug silently. A column-level fix (citext on PostgreSQL, COLLATE NOCASE on SQLite) is the version that cannot be forgotten, at the cost of per-adapter schema handling. Worth deciding if PostgreSQL is adopted.


Claude-Session: https://claude.ai/code/session_01UAEu5HNhDxXkebPy1DQ6rb

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
