### PR TITLE
Compare numeric columns with = instead of LIKE in search filters

### DIFF
--- a/app/controllers/judgements_controller.rb
+++ b/app/controllers/judgements_controller.rb
@@ -168,8 +168,8 @@ class JudgementsController < ApplicationController
     # Apply generic LIKE search for remaining text
     if remaining_text.present?
       query = query.where(
-        'query_doc_pair_id LIKE ? OR doc_id LIKE ? OR query_text LIKE ? OR information_need LIKE ? OR judgements.explanation LIKE ?',
-        "%#{remaining_text}%", "%#{remaining_text}%", "%#{remaining_text}%", "%#{remaining_text}%", "%#{remaining_text}%"
+        'query_doc_pair_id = ? OR doc_id LIKE ? OR query_text LIKE ? OR information_need LIKE ? OR judgements.explanation LIKE ?',
+        remaining_text.to_i, "%#{remaining_text}%", "%#{remaining_text}%", "%#{remaining_text}%", "%#{remaining_text}%"
       )
     end
 

--- a/app/controllers/query_doc_pairs_controller.rb
+++ b/app/controllers/query_doc_pairs_controller.rb
@@ -13,8 +13,10 @@ class QueryDocPairsController < ApplicationController
     query = @book.query_doc_pairs
 
     if params[:q].present?
-      query = query.where('query_text LIKE ? OR query_doc_pairs.id LIKE ? OR doc_id LIKE ? OR document_fields LIKE ?',
-                          "%#{params[:q]}%", "%#{params[:q]}%", "%#{params[:q]}%", "%#{params[:q]}%")
+      query = query.where(
+        'query_text LIKE ? OR query_doc_pairs.id = ? OR doc_id LIKE ? OR document_fields LIKE ?',
+        "%#{params[:q]}%", params[:q].to_i, "%#{params[:q]}%", "%#{params[:q]}%"
+      )
     end
 
     # Eager load judgements count to avoid N+1 queries when showing the count

--- a/app/controllers/ratings_controller.rb
+++ b/app/controllers/ratings_controller.rb
@@ -10,8 +10,8 @@ class RatingsController < ApplicationController
     query = @case.ratings.includes([ :query, :user ])
 
     if params[:q].present?
-      query = query.where('query_text LIKE ? OR doc_id LIKE ? OR rating LIKE ?',
-                          "%#{params[:q]}%", "%#{params[:q]}%", "%#{params[:q]}%")
+      query = query.where('query_text LIKE ? OR doc_id LIKE ? OR rating = ?',
+                          "%#{params[:q]}%", "%#{params[:q]}%", params[:q].to_f)
     end
 
     @pagy, @ratings = pagy(query.order(:updated_at))

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -241,8 +241,8 @@ class TeamsController < ApplicationController
     # Cases filtering
     cases_query = @team.cases
     if @cases_q.present?
-      cases_query = cases_query.where('case_name LIKE ? OR id LIKE ? ',
-                                      "%#{@cases_q}%", "%#{@cases_q}%")
+      cases_query = cases_query.where('case_name LIKE ? OR id = ?',
+                                      "%#{@cases_q}%", @cases_q.to_i)
     end
     cases_query = @cases_archived ? cases_query.archived : cases_query.active
     @pagy_cases, @cases = pagy(cases_query.order(:id).includes(:owner, :teams))

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -9,6 +9,41 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
     login_user_for_integration_test @user
   end
 
+  describe 'cases search' do
+    # `id` is an integer column. Matching it with LIKE made a search for "5"
+    # return cases 15, 25 and 51 as well, and is a type error on PostgreSQL.
+    it 'matches a numeric term against the case id exactly, not as a substring' do
+      owner = users(:doug)
+      wanted = nil
+      [ 5, 15, 25 ].each do |id|
+        Case.where(id: id).delete_all
+        kase = Case.new(id: id, case_name: "Team search case #{('A'.ord + (id % 26)).chr}", owner: owner)
+        kase.save!(validate: false)
+        @team.cases << kase
+        wanted = kase if 5 == id
+      end
+
+      Bullet.enable = false # narrowing to one case makes the view's eager load look unused
+      get team_path(@team), params: { cases_q: '5' }
+      Bullet.enable = true
+
+      assert_response :success
+      found = assigns(:cases).map(&:id)
+      assert_includes found, wanted.id
+      assert_not_includes found, 15
+      assert_not_includes found, 25
+    end
+
+    it 'still matches on the case name and survives a non numeric term' do
+      Bullet.enable = false
+      get team_path(@team), params: { cases_q: 'definitely-no-such-case' }
+      Bullet.enable = true
+
+      assert_response :success
+      assert_empty assigns(:cases)
+    end
+  end
+
   describe 'suggest_members' do
     it 'returns users with matching email from same teams' do
       # random user is already in the 'shared' team with random_1


### PR DESCRIPTION
Four search filters apply SQL's LIKE operator to numeric columns. LIKE is a string pattern-matching operator, so asking it about an integer or a float is asking the database to do something it was never meant to do. The three adapters Quepid cares about disagree about what that means, and two of them disagree quietly.

    app/controllers/teams_controller.rb:244        id                 integer
    app/controllers/ratings_controller.rb:13       rating             float
    app/controllers/query_doc_pairs_controller.rb  query_doc_pairs.id bigint
    app/controllers/judgements_controller.rb:171   query_doc_pair_id  bigint

MySQL and SQLite silently coerce the number to text and run the pattern match anyway. It works, in the sense that no error is raised - but the results are wrong, because a substring match on a number is not a meaningful question. Searching a team's cases for "5" returns every case whose id merely contains a 5:

    searching cases for: "5"   (no case name contains a digit)
    OLD  id LIKE '%5%'  => ids [5, 15, 25, 51]
    NEW  id = 5         => ids [5]

That is a real defect in the search results today, on the adapters we already ship, and it is the reason to fix this now rather than as part of any migration work.

PostgreSQL does not coerce. It rejects the comparison outright with `operator does not exist: integer ~~ unknown`, which is an unhandled 500 on four user-facing search endpoints. So the same defect that is merely wrong on MySQL and SQLite is fatal on PostgreSQL, and it has to be resolved before that adapter can be evaluated at all.

The fix is the pattern already used correctly elsewhere in this codebase, at cases_controller.rb:21 - which searches cases by name or id and gets it right:

    query.where('case_name LIKE ? OR cases.id = ?', "%#{@filter_q}%", @filter_q.to_i)

An exact `=` against a parsed number. A non-numeric search term becomes 0 (or 0.0), so `id = 0` simply matches nothing, which is the correct outcome when somebody typed a word rather than an id. Each of the four sites ORs together several genuine string columns as well - case_name, query_text, doc_id, document_fields, information_need, explanation - and those keep their LIKE untouched. Only the numeric term in each chain changes.

ratings_controller.rb is worth a second look in review: `rating` is a float, so the fix is exact float equality via .to_f. Searching ratings by an exact floating point value is an odd feature to offer, and dropping that term from the search entirely may be better than fixing it. That is a product decision, so this change preserves the existing intent rather than making it.

Why this went unnoticed

There was no test coverage of these search filters at all. Three of the four controllers have test files that never exercise the search parameter, and query_doc_pairs_controller has no test file at all. Nothing was watching.

A regression test is added for the teams cases search, and it was verified to actually catch the defect rather than merely pass: reverting the fix and re-running produces

    Expected [5, 15, 25, 440887456, 729759591] to not include 15.

That check matters here, because a test written against MySQL will happily pass on the buggy code - the coercion hides it. The other three sites are fixed but remain uncovered; query_doc_pairs would need a new test file.

Verification

Full suite, MySQL:  1252 tests, 4244 assertions, 0 failures, 0 errors.
Full suite, SQLite: 1252 tests, 4242 assertions, 0 failures, 0 errors.
RuboCop: 161 files, no offenses.


Claude-Session: https://claude.ai/code/session_01UAEu5HNhDxXkebPy1DQ6rb

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
