### PR TITLE
Match for_user by id instead of SELECT DISTINCT over every column

### DIFF
--- a/app/models/concerns/for_user_scope.rb
+++ b/app/models/concerns/for_user_scope.rb
@@ -7,7 +7,12 @@ module ForUserScope
     scope :for_user, ->(user) do
       direct = where(owner: user)
       by_team = left_joins(teams: :members).where(teams_members: { member_id: user.id })
-      by_team.or(direct).distinct
+
+      # Match on ids rather than SELECT DISTINCT over every column. The join can
+      # return a row per team member, so the duplicates are real, but `IN` folds
+      # them without asking the database to compare whole rows - which it cannot
+      # do here anyway once a json column is in the table.
+      where(id: by_team.or(direct).select(:id))
     end
   end
 end


### PR DESCRIPTION
ForUserScope#for_user builds a relation that left-joins through teams and members, so a record can come back once per team member. The duplicates are real and have to be removed. It did that with `.distinct`:

    by_team.or(direct).distinct

which emits `SELECT DISTINCT "cases".*` - asking the database to compare whole rows, every column, to decide which are the same.

That is more than the query needs. Deduplication here is by primary key: two rows are the same record when their ids match. Selecting ids and matching on them says exactly that, and lets `IN` fold the duplicates:

    where(id: by_team.or(direct).select(:id))

The outer query then has no join, so it cannot produce duplicates in the first place, and it never has to compare a row of arbitrary width. On a table like `cases`, whose columns include a `json` options blob and a pile of text, that is a meaningful saving on every call - and this scope is called constantly. It backs User#cases_involved_with, #books_involved_with and #search_endpoints_involved_with, and runs 575 times over a single pass of the test suite.

Comparing whole rows is also not universally possible. PostgreSQL's `json` type has no equality operator, so `SELECT DISTINCT` over a table carrying a `json` column fails outright:

    PG::UndefinedFunction: ERROR:  could not identify an equality operator
    for type json
    LINE 1: SELECT DISTINCT "cases".* FROM "cases" LEFT OUTER JOIN "team...

All three models including this concern - Case, Book and SearchEndpoint - have a `t.json "options"` column, which makes the scope unusable there. That is not the reason to make this change, but it is a clear signal that asking for row-wide equality was doing more work than the question required.

Behaviour is unchanged, and that is already covered: test/models/concerns/for_user_scope_test.rb asserts owned records are included, team records are included, others are excluded, and results are deduplicated. The deduplication assertion was verified to be a real guard rather than one that passes either way - removing the dedup entirely makes it fail, and the id-subquery form makes it pass. No new test is added because no new behaviour is introduced.

Note that Scorer.for_user is a different scope (app/models/scorer.rb:51) with its own distinct handling. It does not use this concern and is untouched.

Verification

Full suite, MySQL:  1250 tests, 4234 assertions, 0 failures, 0 errors.
Full suite, SQLite: 1250 tests, 4232 assertions, 0 failures, 0 errors.
RuboCop: 33 files, no offenses.


Claude-Session: https://claude.ai/code/session_01UAEu5HNhDxXkebPy1DQ6rb

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
