### PR TITLE
Only regenerate model annotations when running against MySQL

### DIFF
--- a/lib/tasks/annotate_rb.rake
+++ b/lib/tasks/annotate_rb.rake
@@ -2,8 +2,19 @@
 
 # This rake task was added by annotate_rb gem.
 
+# Annotations are generated from the live connection, and db/schema.rb is
+# authored against MySQL, so annotating from another adapter rewrites every
+# model's schema comment to that adapter's idea of the types - PostgreSQL
+# reports a varchar with no limit, so `:string(255)` becomes `:string` across
+# 46 files. Same rule as dump_schema_after_migration in config/application.rb:
+# only MySQL gets to regenerate what was authored against MySQL.
+db_adapter = ENV.fetch('DB_ADAPTER', nil)
+database_url = ENV.fetch('DATABASE_URL', '')
+annotating_adapter = db_adapter.nil? || 'mysql2' == db_adapter
+annotating_adapter &&= !database_url.start_with?('sqlite3:', 'postgres')
+
 # Can set `ANNOTATERB_SKIP_ON_DB_TASKS` to be anything to skip this
-if Rails.env.development? && ENV['ANNOTATERB_SKIP_ON_DB_TASKS'].nil?
+if Rails.env.development? && ENV['ANNOTATERB_SKIP_ON_DB_TASKS'].nil? && annotating_adapter
   require 'annotate_rb'
 
   AnnotateRb::Core.load_rake_tasks

--- a/lib/tasks/annotate_rb.rake
+++ b/lib/tasks/annotate_rb.rake
@@ -4,9 +4,9 @@
 
 # Annotations are generated from the live connection, and db/schema.rb is
 # authored against MySQL, so annotating from another adapter rewrites every
-# model's schema comment to that adapter's idea of the types - PostgreSQL
-# reports a varchar with no limit, so `:string(255)` becomes `:string` across
-# 46 files. Same rule as dump_schema_after_migration in config/application.rb:
+# model's schema comment to that adapter's idea of the types (e.g. adapters that
+# don't report varchar limits will rewrite `:string(255)` as `:string` across many
+# files). Same rule as dump_schema_after_migration in config/application.rb:
 # only MySQL gets to regenerate what was authored against MySQL.
 db_adapter = ENV.fetch('DB_ADAPTER', nil)
 database_url = ENV.fetch('DATABASE_URL', '')


### PR DESCRIPTION
lib/tasks/annotate_rb.rake hooks the annotate_rb gem onto the db: rake tasks, so `rails db:migrate` rewrites the schema comment at the top of every model, test and fixture. Those comments are generated by asking the *live connection* what the columns look like.

db/schema.rb is authored against MySQL. Every other adapter describes the same columns differently, so migrating against one of them rewrites all of those comments into that adapter's vocabulary. Neither SQLite nor PostgreSQL report a length for a varchar, so `:string(255)` becomes `:string` throughout:

    -#  company                     :string(255)
    +#  company                     :string
    -#  invitation_token            :string(255)
    +#  invitation_token            :string

This is not hypothetical and it is not about PostgreSQL. SQLite has been a supported adapter since #1763, and running

    DB_ADAPTER=sqlite3 bin/docker r bundle exec rails db:migrate

on main today modifies 60 files. Nothing warns you. The annotations are comments, so nothing fails, no test breaks, and the working tree just quietly fills with changes that are wrong for everyone using MySQL - which is the default, and what the schema was written against.

It has gone unnoticed because DEVELOPER_GUIDE.md says not to run db:migrate under SQLite. That is a convention, not a guard, and `bin/setup_docker` runs db:migrate unconditionally as part of normal setup - so following the documented setup path with DB_ADAPTER set is enough to trigger it.

The same hazard was already recognised for db/schema.rb itself: config/application.rb turns off dump_schema_after_migration for non-MySQL adapters, precisely so a foreign connection cannot regenerate what was authored against MySQL. Annotations are a second instance of that rule that nobody spotted. This applies the same condition to them.

After the change, `db:migrate` annotates on MySQL exactly as before and leaves the tree untouched on SQLite and PostgreSQL:

    MySQL       annotate runs,  0 files modified
    SQLite      annotate skipped
    PostgreSQL  annotate skipped

ANNOTATERB_SKIP_ON_DB_TASKS still works as it always did, for anyone who wants to skip annotation on MySQL too.

Verification

Full suite, MySQL:  1256 tests, 4258 assertions, 0 failures, 0 errors.
Full suite, SQLite: 1256 tests, 4256 assertions, 0 failures, 0 errors.
RuboCop: no offenses.


Claude-Session: https://claude.ai/code/session_01UAEu5HNhDxXkebPy1DQ6rb

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
