### PR TITLE
Pick the oldest match when a search endpoint lookup is ambiguous

### DIFF
--- a/app/models/search_endpoint.rb
+++ b/app/models/search_endpoint.rb
@@ -96,7 +96,12 @@ class SearchEndpoint < ApplicationRecord
     lookup_params = normalized.slice(*lookup_keys)
 
     if lookup_keys.all? { |key| lookup_params.key?(key) }
-      endpoint = user.search_endpoints_involved_with.find_by(lookup_params)
+      # These four fields do not identify an endpoint uniquely - the same URL
+      # can be registered more than once with different options or credentials.
+      # find_by would take whichever row the database happened to return first,
+      # which is not defined and does differ between adapters. Take the oldest
+      # match instead, so the same import always attaches the same endpoint.
+      endpoint = user.search_endpoints_involved_with.where(lookup_params).order(:id).first
       return endpoint if endpoint
     end
 

--- a/app/models/search_endpoint.rb
+++ b/app/models/search_endpoint.rb
@@ -99,7 +99,7 @@ class SearchEndpoint < ApplicationRecord
       # These four fields do not identify an endpoint uniquely - the same URL
       # can be registered more than once with different options or credentials.
       # find_by would take whichever row the database happened to return first,
-      # which is not defined and does differ between adapters. Take the oldest
+      # which is not defined and does differ between adapters. Take the lowest-id
       # match instead, so the same import always attaches the same endpoint.
       endpoint = user.search_endpoints_involved_with.where(lookup_params).order(:id).first
       return endpoint if endpoint

--- a/test/models/search_endpoint_test.rb
+++ b/test/models/search_endpoint_test.rb
@@ -190,6 +190,28 @@ class SearchEndpointTest < ActiveSupport::TestCase
       assert_predicate found, :persisted?
     end
 
+    # The lookup fields do not identify an endpoint uniquely, so more than one
+    # row can match. Which one a database returns without an ORDER BY is not
+    # defined and does differ between adapters, so the oldest is chosen.
+    it 'returns the oldest match when several endpoints share the lookup fields' do
+      shared = {
+        search_engine:  'solr',
+        endpoint_url:   'https://duplicated.example.com/solr/select',
+        api_method:     'GET',
+        proxy_requests: false,
+      }
+
+      older = SearchEndpoint.create!(shared.merge(owner: joey, options: { 'corpusId' => 1 }))
+      newer = SearchEndpoint.create!(shared.merge(owner: joey, options: nil))
+
+      assert_operator older.id, :<, newer.id, 'fixture ids should be ordered for this to mean anything'
+
+      found = SearchEndpoint.find_or_initialize_for_user(joey, **shared)
+
+      assert_equal older, found
+      assert_equal({ 'corpusId' => 1 }, found.options)
+    end
+
     it 'builds a new endpoint when no match exists' do
       endpoint = SearchEndpoint.find_or_initialize_for_user(
         joey,

--- a/test/models/search_endpoint_test.rb
+++ b/test/models/search_endpoint_test.rb
@@ -204,7 +204,7 @@ class SearchEndpointTest < ActiveSupport::TestCase
       older = SearchEndpoint.create!(shared.merge(owner: joey, options: { 'corpusId' => 1 }))
       newer = SearchEndpoint.create!(shared.merge(owner: joey, options: nil))
 
-      assert_operator older.id, :<, newer.id, 'fixture ids should be ordered for this to mean anything'
+      assert_operator older.id, :<, newer.id, 'created ids should be ordered for this to mean anything'
 
       found = SearchEndpoint.find_or_initialize_for_user(joey, **shared)
 


### PR DESCRIPTION
SearchEndpoint.find_or_initialize_for_user looks an endpoint up by four fields - search_engine, endpoint_url, api_method and proxy_requests - and those do not identify a row uniquely. The same URL can be registered more than once with different options or credentials, and the fixtures already contain such a pair:

    matches: 2
      id=247532087  opts={"corpusId" => 12345}
      id=732477833  opts=nil

`find_by` takes whichever of them the database returns first. No query said which that should be, so the answer is undefined - and it genuinely differs: MySQL returns the first, PostgreSQL the second.

The consequence is not cosmetic. Importing a case calls this to decide which search endpoint the imported case gets attached to, so an import could silently pick up an endpoint with different options or different credentials than the one it was exported from. Nothing was making that choice stable, on any adapter - MySQL just happened to be consistent enough that nobody noticed.

Taking the oldest match makes the choice deterministic, and is the row MySQL was already returning, so behaviour is unchanged there.

This surfaced as ExportImportCaseFlowTest failing on PostgreSQL with `NoMethodError: undefined method 'transform_values' for nil` - the endpoint it picked had no options. JSON handling was ruled out first: a hash round-trips through a json column identically on both adapters.

The new test was checked to be a real guard rather than one that passes either way - making the lookup take the newest match instead makes it fail.

Verification

Full suite, MySQL:  1251 tests, 4238 assertions, 0 failures, 0 errors.
Full suite, SQLite: 1251 tests, 4236 assertions, 0 failures, 0 errors.
RuboCop: 435 files, no offenses.


Claude-Session: https://claude.ai/code/session_01UAEu5HNhDxXkebPy1DQ6rb

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
