### PR TITLE
Make the sample data seeder re-runnable

### DIFF
--- a/lib/tasks/sample_data.thor
+++ b/lib/tasks/sample_data.thor
@@ -262,7 +262,7 @@ class SampleData < Thor
     searchapi_try.search_endpoint = search_api_endpoint
     searchapi_try.update searchapi_params
 
-    searchapi_case.queries.create(query_text: 'student accomodation')
+    searchapi_case.queries.find_or_create_by(query_text: 'student accomodation')
     print_case_info searchapi_case
 
     ######################################
@@ -419,10 +419,10 @@ class SampleData < Thor
     book.scale = Scorer.system_default_scorer.scale
     book.scale_with_labels = Scorer.system_default_scorer.scale_with_labels
 
-    book.teams << osc
-    book.ai_judges << osc_ai_judge
-    book.ai_judges << azure_openai_judge
-    book.ai_judges << azure_anthropic_judge
+    book.teams << osc unless book.teams.include?(osc)
+    book.ai_judges << osc_ai_judge unless book.ai_judges.include?(osc_ai_judge)
+    book.ai_judges << azure_openai_judge unless book.ai_judges.include?(azure_openai_judge)
+    book.ai_judges << azure_anthropic_judge unless book.ai_judges.include?(azure_anthropic_judge)
     book.save
 
     # this code copied from populate_controller.rb and should be in a service...
@@ -561,10 +561,10 @@ class SampleData < Thor
     print_user_info user_params
 
     osc = ::Team.where(name: 'OSC').first_or_create
-    osc.members << hundreds_of_queries_user
-    osc.members << thousands_of_queries_user
+    osc.members << hundreds_of_queries_user unless osc.members.include?(hundreds_of_queries_user)
+    osc.members << thousands_of_queries_user unless osc.members.include?(thousands_of_queries_user)
 
-    osc.search_endpoints << statedecoded_solr_endpoint
+    osc.search_endpoints << statedecoded_solr_endpoint unless osc.search_endpoints.include?(statedecoded_solr_endpoint)
     osc.save!
 
     hundreds_of_queries_case = hundreds_of_queries_user.cases.create case_name: '100s of Queries'


### PR DESCRIPTION
`thor sample_data:sample_data` died on any run after the first with

    PG::UniqueViolation: duplicate key value violates unique constraint
    "index_books_ai_judges_on_book_id_and_user_id"

Adding the two Azure judges dropped the `unless ... include?` guard that was already there for the Ollama judge, so the book seeding appended to `books_ai_judges` unconditionally and hit the unique index. Restore the guard on all three, matching the idiom the team seeding above already uses.

Three more spots had the same defect and are fixed alongside it:

- `book.teams << osc` never raised because `teams_books` carries no unique index -- it just accumulated a duplicate row per run.
- `searchapi_case.queries.create` added another 'student accomodation' query every run; `find_or_create_by` matches the static and vespa cases seeded just below.
- `large_data`'s `osc.members <<` would have raised the same way, since `teams_members` has a composite primary key.

Not adapter specific -- the unique index is in the MySQL-dumped schema, so MySQL fails identically. Verified with four consecutive runs against PostgreSQL: all exit 0, and `queries`, `query_doc_pairs` and the join tables hold steady across them.


Claude-Session: https://claude.ai/code/session_01G4qA9VQ7QgMhnzQGirbYfi

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIFs (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] Improvement (non-breaking change which improves existing functionality)
- [] New feature (non-breaking change which adds new functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
