### PR TITLE
Make search boxes case-insensitive

### DIFF
--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -7,8 +7,8 @@ module Admin
     def index
       query = Announcement.order(updated_at: :desc)
       if params[:q].present?
-        query = query.where('text LIKE ?',
-                            "%#{params[:q]}%")
+        query = query.where('LOWER(text) LIKE ?',
+                            "%#{params[:q].to_s.downcase}%")
       end
 
       @pagy, @announcements = pagy(query)

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -37,8 +37,8 @@ class BooksController < ApplicationController
     query = query.where(teams: { id: params[:team_id] }) if params[:team_id].present?
 
     if params[:q].present?
-      query = query.where('books.name LIKE ? OR teams.name LIKE ?',
-                          "%#{params[:q]}%", "%#{params[:q]}%")
+      q = "%#{params[:q].to_s.downcase}%"
+      query = query.where('LOWER(books.name) LIKE ? OR LOWER(teams.name) LIKE ?', q, q)
     end
 
     @pagy, @books = pagy(query)

--- a/app/controllers/bulk_judge_controller.rb
+++ b/app/controllers/bulk_judge_controller.rb
@@ -24,7 +24,7 @@ class BulkJudgeController < ApplicationController
     query = @book.query_doc_pairs.includes(:judgements)
 
     # Use LIKE search if query_text is provided to match partial queries
-    query = query.where('query_text LIKE ?', "%#{@query_text}%") if @query_text.present?
+    query = query.where('LOWER(query_text) LIKE ?', "%#{@query_text.to_s.downcase}%") if @query_text.present?
 
     # Filter by rank depth if specified
     query = query.where(position: ..@rank_depth) if @rank_depth.present?

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -18,8 +18,8 @@ class CasesController < ApplicationController
 
     # Apply search filter
     if @filter_q.present?
-      query = query.where('case_name LIKE ? OR cases.id = ?',
-                          "%#{@filter_q}%", @filter_q.to_i)
+      query = query.where('LOWER(case_name) LIKE ? OR cases.id = ?',
+                          "%#{@filter_q.to_s.downcase}%", @filter_q.to_i)
     end
 
     # Apply archived filter

--- a/app/controllers/judgements_controller.rb
+++ b/app/controllers/judgements_controller.rb
@@ -167,9 +167,11 @@ class JudgementsController < ApplicationController
 
     # Apply generic LIKE search for remaining text
     if remaining_text.present?
+      q = "%#{remaining_text.to_s.downcase}%"
       query = query.where(
-        'query_doc_pair_id = ? OR doc_id LIKE ? OR query_text LIKE ? OR information_need LIKE ? OR judgements.explanation LIKE ?',
-        remaining_text.to_i, "%#{remaining_text}%", "%#{remaining_text}%", "%#{remaining_text}%", "%#{remaining_text}%"
+        'query_doc_pair_id = ? OR LOWER(doc_id) LIKE ? OR LOWER(query_text) LIKE ? OR ' \
+        'LOWER(information_need) LIKE ? OR LOWER(judgements.explanation) LIKE ?',
+        remaining_text.to_i, q, q, q, q
       )
     end
 

--- a/app/controllers/query_doc_pairs_controller.rb
+++ b/app/controllers/query_doc_pairs_controller.rb
@@ -13,9 +13,10 @@ class QueryDocPairsController < ApplicationController
     query = @book.query_doc_pairs
 
     if params[:q].present?
+      q = "%#{params[:q].to_s.downcase}%"
       query = query.where(
-        'query_text LIKE ? OR query_doc_pairs.id = ? OR doc_id LIKE ? OR document_fields LIKE ?',
-        "%#{params[:q]}%", params[:q].to_i, "%#{params[:q]}%", "%#{params[:q]}%"
+        'LOWER(query_text) LIKE ? OR query_doc_pairs.id = ? OR LOWER(doc_id) LIKE ? OR LOWER(document_fields) LIKE ?',
+        q, params[:q].to_i, q, q
       )
     end
 

--- a/app/controllers/ratings_controller.rb
+++ b/app/controllers/ratings_controller.rb
@@ -10,8 +10,9 @@ class RatingsController < ApplicationController
     query = @case.ratings.includes([ :query, :user ])
 
     if params[:q].present?
-      query = query.where('query_text LIKE ? OR doc_id LIKE ? OR rating = ?',
-                          "%#{params[:q]}%", "%#{params[:q]}%", params[:q].to_f)
+      q = "%#{params[:q].to_s.downcase}%"
+      query = query.where('LOWER(query_text) LIKE ? OR LOWER(doc_id) LIKE ? OR rating = ?',
+                          q, q, params[:q].to_f)
     end
 
     @pagy, @ratings = pagy(query.order(:updated_at))

--- a/app/controllers/scorers_controller.rb
+++ b/app/controllers/scorers_controller.rb
@@ -21,7 +21,7 @@ class ScorersController < ApplicationController
         combined_query = combined_query.where(communal: false)
       end
     end
-    combined_query = combined_query.where('scorers.name LIKE ?', "%#{@q}%") if @q.present?
+    combined_query = combined_query.where('LOWER(scorers.name) LIKE ?', "%#{@q.to_s.downcase}%") if @q.present?
     # Order so that communal (true) comes after custom (false)
     combined_query = combined_query.order(Arel.sql('communal ASC, name'))
 

--- a/app/controllers/search_endpoints_controller.rb
+++ b/app/controllers/search_endpoints_controller.rb
@@ -18,8 +18,8 @@ class SearchEndpointsController < ApplicationController
     query = query.where(teams: { id: params[:team_id] }) if params[:team_id].present?
 
     if params[:q].present?
-      query = query.where('search_endpoints.name LIKE ? OR endpoint_url LIKE ?',
-                          "%#{params[:q]}%", "%#{params[:q]}%")
+      q = "%#{params[:q].to_s.downcase}%"
+      query = query.where('LOWER(search_endpoints.name) LIKE ? OR LOWER(endpoint_url) LIKE ?', q, q)
     end
 
     @pagy, @search_endpoints = pagy(query)

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -220,7 +220,7 @@ class TeamsController < ApplicationController
 
     query = query.joins(:members).where(users: { id: current_user.id }).distinct if params[:member].present?
 
-    query = query.where('teams.name LIKE ?', "%#{params[:q]}%") if params[:q].present?
+    query = query.where('LOWER(teams.name) LIKE ?', "%#{params[:q].to_s.downcase}%") if params[:q].present?
 
     @pagy, @teams = pagy(query.order(:name))
   end
@@ -241,8 +241,8 @@ class TeamsController < ApplicationController
     # Cases filtering
     cases_query = @team.cases
     if @cases_q.present?
-      cases_query = cases_query.where('case_name LIKE ? OR id = ?',
-                                      "%#{@cases_q}%", @cases_q.to_i)
+      cases_query = cases_query.where('LOWER(case_name) LIKE ? OR id = ?',
+                                      "%#{@cases_q.to_s.downcase}%", @cases_q.to_i)
     end
     cases_query = @cases_archived ? cases_query.archived : cases_query.active
     @pagy_cases, @cases = pagy(cases_query.order(:id).includes(:owner, :teams))
@@ -254,14 +254,14 @@ class TeamsController < ApplicationController
     books_query = @team.books
     books_query = @books_archived ? books_query.archived : books_query.active
     books_query = books_query.with_counts if books_query.respond_to?(:with_counts)
-    books_query = books_query.where('name LIKE ?', "%#{@books_q}%") if @books_q.present?
+    books_query = books_query.where('LOWER(name) LIKE ?', "%#{@books_q.to_s.downcase}%") if @books_q.present?
 
     @pagy_books, @books = pagy(books_query.order(:id))
 
     # Scorers filtering
     @scorers_q = params[:scorers_q].to_s.strip
     scorers_query = @team.scorers
-    scorers_query = scorers_query.where('name LIKE ?', "%#{@scorers_q}%") if @scorers_q.present?
+    scorers_query = scorers_query.where('LOWER(name) LIKE ?', "%#{@scorers_q.to_s.downcase}%") if @scorers_q.present?
     @pagy_scorers, @scorers = pagy(scorers_query.order(:name), page_param: :scorers_page)
 
     # Search Endpoints filtering
@@ -271,9 +271,10 @@ class TeamsController < ApplicationController
     search_endpoints_query = @team.search_endpoints.includes(:teams)
     search_endpoints_query = @search_endpoints_archived ? search_endpoints_query.where(archived: true) : search_endpoints_query.not_archived
     if @search_endpoints_q.present?
-      search_endpoints_query = search_endpoints_query.where('name LIKE ? OR endpoint_url LIKE ?',
-                                                            "%#{@search_endpoints_q}%",
-                                                            "%#{@search_endpoints_q}%")
+      search_endpoints_q = "%#{@search_endpoints_q.to_s.downcase}%"
+      search_endpoints_query = search_endpoints_query.where('LOWER(name) LIKE ? OR LOWER(endpoint_url) LIKE ?',
+                                                            search_endpoints_q,
+                                                            search_endpoints_q)
     end
     @pagy_search_endpoints, @search_endpoints = pagy(search_endpoints_query.order(:id), page_param: :search_endpoints_page)
   end

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -44,6 +44,25 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  describe 'index' do
+    it 'filters teams by name using the q param' do
+      get teams_path, params: { q: 'valid' }
+
+      assert_response :success
+      assert_includes assigns(:teams), @team
+    end
+
+    it 'filters teams by name case insensitively' do
+      acme = Team.create!(name: 'Acme')
+      acme.members << @user
+
+      get teams_path, params: { q: 'ACME' }
+
+      assert_response :success
+      assert_includes assigns(:teams), acme
+    end
+  end
+
   describe 'suggest_members' do
     it 'returns users with matching email from same teams' do
       # random user is already in the 'shared' team with random_1


### PR DESCRIPTION
## Summary
- The teams listing page search box (and several others across the app) did case-sensitive matching because Quepid's MySQL DB uses a case-sensitive `utf8mb4_bin` collation.
- Wrapped both the column and the search input in `LOWER()` for teams, cases, books, scorers, search endpoints, ratings, judgements, query/doc pairs, bulk judge, and admin announcements — matching the existing pattern already used in `admin/users_controller.rb`.
- Also fixed the team-detail sub-tab searches (cases/books/scorers/search-endpoints within a team).

## Test plan
- [x] `rubocop` clean on all changed files
- [x] Added new tests in `test/controllers/teams_controller_test.rb` covering the `q` filter, including a case-insensitivity test
- [x] Existing controller test suites (cases, books, scorers, search endpoints, ratings, judgements, bulk judge, admin announcements, teams) pass: 93 tests, 296 assertions, 0 failures
- [x] Manually verified the `query_doc_pairs` search query executes correctly via `rails runner` (no dedicated test file exists for that controller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PF4dmszyeRsTDbiCWfKHVq