### PR TITLE
Ensure every sample-data case has at least one query

### DIFF
--- a/lib/tasks/sample_data.thor
+++ b/lib/tasks/sample_data.thor
@@ -233,6 +233,7 @@ class SampleData < Thor
     }
     solr_try.search_endpoint = tmdb_solr_endpoint
     solr_try.update solr_params
+    solr_case.queries.find_or_create_by(query_text: 'star wars')
     print_case_info solr_case
 
     ######################################
@@ -247,6 +248,7 @@ class SampleData < Thor
     }
     es_try.search_endpoint = tmdb_es_endpoint
     es_try.update es_params
+    es_case.queries.find_or_create_by(query_text: 'love')
     print_case_info es_case
 
     ######################################


### PR DESCRIPTION
## Summary
- `SOLR CASE` and `ES CASE` in `lib/tasks/sample_data.thor` only configured their try's search endpoint and query params, but never added a `Query` record — so both cases rendered empty (no queries to run) after seeding.
- Added one query to each, matching the TMDB movie dataset both endpoints already point at (`tmdb_solr_endpoint` / `tmdb_es_endpoint`), consistent with the neighboring `VESPA CASE` which queries the same dataset.
- Audited every other case created by `sample_data`/`large_data`: `SEARCHAPI CASE`, `STATIC CASE`, `VESPA CASE`, the Typeahead cases, and the `RatingsGenerator`/`RatingsImporter`-backed cases (`10s of Queries`, `100s of Queries`, `1000s of Queries`) all already get queries — only these two were missing them.

## Test plan
- [x] `rubocop lib/tasks/sample_data.thor` — clean
- [x] Ran `thor sample_data:sample_data` end-to-end against a real dev database and confirmed every seeded case now has `queries.count >= 1`, including `SOLR CASE` (1 query) and `ES CASE` (had a pre-existing manual query too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PF4dmszyeRsTDbiCWfKHVq